### PR TITLE
Removing tests from language detection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 *.sol linguist-language=Solidity
-
+test/* linguist-detectable=false
+tests/* linguist-detectable=false

--- a/publish/index.js
+++ b/publish/index.js
@@ -245,8 +245,13 @@ program
 				}
 				const { address } = deployedContract.options;
 
-				// in case we've already been verified, keep info from then
-				const { timestamp, txn } = deployment[name] || {};
+				let timestamp = new Date();
+				let txn = '';
+				if (!config[name].deploy) {
+					// deploy is false, so we reused a deployment, thus lets grab the details that already exist
+					timestamp = deployment[name].timestamp;
+					txn = deployment[name].txn;
+				}
 
 				// now update the deployed contract information
 				deployment[name] = {
@@ -256,8 +261,8 @@ program
 					link: `https://${network !== 'mainnet' ? network + '.' : ''}etherscan.io/address/${
 						deployer.deployedContracts[name].options.address
 					}`,
-					timestamp: timestamp || new Date(),
-					txn: txn || '',
+					timestamp,
+					txn,
 					network,
 					bytecode: compiled[name].evm.bytecode.object,
 					abi: compiled[name].abi,


### PR DESCRIPTION
This should remove tests from showing up as language detection, and highlight Solidity as the majority language not JavaScript.