### PR TITLE
Optimize FeePool struct size and usage

### DIFF
--- a/contracts/FeePool.sol
+++ b/contracts/FeePool.sol
@@ -343,7 +343,7 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
             .add(secondLastFeePeriod.rewardsToDistribute);
 
         // Shift the previous fee periods across to make room for the new one.
-        _currentFeePeriod = (_currentFeePeriod - 1 + FEE_PERIOD_LENGTH) % FEE_PERIOD_LENGTH;
+        _currentFeePeriod = _currentFeePeriod.add(FEE_PERIOD_LENGTH).sub(1).mod(FEE_PERIOD_LENGTH);
 
         // Clear the first element of the array to make sure we don't have any stale values.
         delete _recentFeePeriods[_currentFeePeriod];
@@ -428,7 +428,7 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         optionalProxy_onlyOwner
         onlyDuringSetup
     {
-        _recentFeePeriods[(_currentFeePeriod + feePeriodIndex) % FEE_PERIOD_LENGTH] = FeePeriod({
+        _recentFeePeriods[_currentFeePeriod.add(feePeriodIndex).mod(FEE_PERIOD_LENGTH)] = FeePeriod({
             feePeriodId: uint64(feePeriodId),
             startingDebtIndex: uint64(startingDebtIndex),
             startTime: uint64(startTime),

--- a/contracts/FeePool.sol
+++ b/contracts/FeePool.sol
@@ -321,13 +321,7 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         // for overflow after subtracting one from zero.
         for (uint i = FEE_PERIOD_LENGTH - 2; i < FEE_PERIOD_LENGTH; i--) {
             uint next = i + 1;
-            recentFeePeriods[next].feePeriodId = recentFeePeriods[i].feePeriodId;
-            recentFeePeriods[next].startingDebtIndex = recentFeePeriods[i].startingDebtIndex;
-            recentFeePeriods[next].startTime = recentFeePeriods[i].startTime;
-            recentFeePeriods[next].feesToDistribute = recentFeePeriods[i].feesToDistribute;
-            recentFeePeriods[next].feesClaimed = recentFeePeriods[i].feesClaimed;
-            recentFeePeriods[next].rewardsToDistribute = recentFeePeriods[i].rewardsToDistribute;
-            recentFeePeriods[next].rewardsClaimed = recentFeePeriods[i].rewardsClaimed;
+            recentFeePeriods[next] = recentFeePeriods[i];
         }
 
         // Clear the first element of the array to make sure we don't have any stale values.

--- a/contracts/FeePool.sol
+++ b/contracts/FeePool.sol
@@ -86,9 +86,9 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
 
     // This struct represents the issuance activity that's happened in a fee period.
     struct FeePeriod {
-        uint feePeriodId;
-        uint startingDebtIndex;
-        uint startTime;
+        uint64 feePeriodId;
+        uint64 startingDebtIndex;
+        uint64 startTime;
         uint feesToDistribute;
         uint feesClaimed;
         uint rewardsToDistribute;
@@ -152,7 +152,7 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
 
         // Set our initial fee period
         recentFeePeriods[0].feePeriodId = 1;
-        recentFeePeriods[0].startTime = now;
+        recentFeePeriods[0].startTime = uint64(now);
     }
 
     /**
@@ -335,9 +335,9 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
 
         // Open up the new fee period. Take a snapshot of the total value of the system.
         // Increment periodId from the recent closed period feePeriodId
-        recentFeePeriods[0].feePeriodId = recentFeePeriods[1].feePeriodId.add(1);
-        recentFeePeriods[0].startingDebtIndex = synthetixState.debtLedgerLength();
-        recentFeePeriods[0].startTime = now;
+        recentFeePeriods[0].feePeriodId = uint64(uint256(recentFeePeriods[1].feePeriodId).add(1));
+        recentFeePeriods[0].startingDebtIndex = uint64(synthetixState.debtLedgerLength());
+        recentFeePeriods[0].startTime = uint64(now);
 
         emitFeePeriodClosed(recentFeePeriods[1].feePeriodId);
     }
@@ -413,9 +413,9 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         optionalProxy_onlyOwner
         onlyDuringSetup
     {
-        recentFeePeriods[feePeriodIndex].feePeriodId = feePeriodId;
-        recentFeePeriods[feePeriodIndex].startingDebtIndex = startingDebtIndex;
-        recentFeePeriods[feePeriodIndex].startTime = startTime;
+        recentFeePeriods[feePeriodIndex].feePeriodId = uint64(feePeriodId);
+        recentFeePeriods[feePeriodIndex].startingDebtIndex = uint64(startingDebtIndex);
+        recentFeePeriods[feePeriodIndex].startTime = uint64(startTime);
         recentFeePeriods[feePeriodIndex].feesToDistribute = feesToDistribute;
         recentFeePeriods[feePeriodIndex].feesClaimed = feesClaimed;
         recentFeePeriods[feePeriodIndex].rewardsToDistribute = rewardsToDistribute;
@@ -826,7 +826,7 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
                 // We calculate a feePeriod's closingDebtIndex by looking at the next feePeriod's startingDebtIndex
                 // we can use the most recent issuanceData[0] for the current feePeriod
                 // else find the applicableIssuanceData for the feePeriod based on the StartingDebtIndex of the period
-                uint closingDebtIndex = nextPeriod.startingDebtIndex.sub(1);
+                uint closingDebtIndex = uint256(nextPeriod.startingDebtIndex).sub(1);
 
                 // Gas optimisation - to reuse debtEntryIndex if found new applicable one
                 // if applicable is 0,0 (none found) we keep most recent one from issuanceData[0]
@@ -858,7 +858,7 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
 
         // If period has closed we want to calculate debtPercentage for the period
         if (period > 0) {
-            uint closingDebtIndex = recentFeePeriods[period - 1].startingDebtIndex.sub(1);
+            uint closingDebtIndex = uint256(recentFeePeriods[period - 1].startingDebtIndex).sub(1);
             debtOwnershipForPeriod = _effectiveDebtRatioForPeriod(closingDebtIndex, ownershipPercentage, debtEntryIndex);
         }
 
@@ -904,7 +904,7 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         // No debt minted during period as next period starts at 0
         if (recentFeePeriods[period - 1].startingDebtIndex == 0) return;
 
-        uint closingDebtIndex = recentFeePeriods[period - 1].startingDebtIndex.sub(1);
+        uint closingDebtIndex = uint256(recentFeePeriods[period - 1].startingDebtIndex).sub(1);
 
         uint ownershipPercentage;
         uint debtEntryIndex;

--- a/contracts/FeePool.sol
+++ b/contracts/FeePool.sol
@@ -103,7 +103,8 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
     // [2] is the oldest fee period that users can claim for.
     uint8 constant public FEE_PERIOD_LENGTH = 3;
 
-    FeePeriod[FEE_PERIOD_LENGTH] public recentFeePeriods;
+    FeePeriod[FEE_PERIOD_LENGTH] private _recentFeePeriods;
+    uint256 private _currentFeePeriod;
 
     // How long a fee period lasts at a minimum. It is required for the
     // fee authority to roll over the periods, so they are not guaranteed
@@ -151,8 +152,35 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         exchangeFeeRate = _exchangeFeeRate;
 
         // Set our initial fee period
-        recentFeePeriods[0].feePeriodId = 1;
-        recentFeePeriods[0].startTime = uint64(now);
+        _recentFeePeriodsStorage(0).feePeriodId = 1;
+        _recentFeePeriodsStorage(0).startTime = uint64(now);
+    }
+
+    function recentFeePeriods(uint index) external view
+        returns(
+            uint64 feePeriodId,
+            uint64 startingDebtIndex,
+            uint64 startTime,
+            uint feesToDistribute,
+            uint feesClaimed,
+            uint rewardsToDistribute,
+            uint rewardsClaimed
+        )
+    {
+        FeePeriod storage feePeriod = _recentFeePeriodsStorage(index);
+        return (
+            feePeriod.feePeriodId,
+            feePeriod.startingDebtIndex,
+            feePeriod.startTime,
+            feePeriod.feesToDistribute,
+            feePeriod.feesClaimed,
+            feePeriod.rewardsToDistribute,
+            feePeriod.rewardsClaimed
+        );
+    }
+
+    function _recentFeePeriodsStorage(uint index) internal view returns(FeePeriod storage) {
+        return _recentFeePeriods[(_currentFeePeriod + index) % FEE_PERIOD_LENGTH];
     }
 
     /**
@@ -167,9 +195,9 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         external
         onlySynthetix
     {
-        feePoolState.appendAccountIssuanceRecord(account, debtRatio, debtEntryIndex, recentFeePeriods[0].startingDebtIndex);
+        feePoolState.appendAccountIssuanceRecord(account, debtRatio, debtEntryIndex, _recentFeePeriodsStorage(0).startingDebtIndex);
 
-        emitIssuanceDebtRatioEntry(account, debtRatio, debtEntryIndex, recentFeePeriods[0].startingDebtIndex);
+        emitIssuanceDebtRatioEntry(account, debtRatio, debtEntryIndex, _recentFeePeriodsStorage(0).startingDebtIndex);
     }
 
     /**
@@ -277,7 +305,7 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         }
 
         // Keep track of in XDRs in our fee pool.
-        recentFeePeriods[0].feesToDistribute = recentFeePeriods[0].feesToDistribute.add(xdrAmount);
+        _recentFeePeriodsStorage(0).feesToDistribute = _recentFeePeriodsStorage(0).feesToDistribute.add(xdrAmount);
     }
 
     /**
@@ -288,7 +316,7 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
     {
         require(messageSender == rewardsAuthority || msg.sender == rewardsAuthority, "Caller is not rewardsAuthority");
         // Add the amount of SNX rewards to distribute on top of any rolling unclaimed amount
-        recentFeePeriods[0].rewardsToDistribute = recentFeePeriods[0].rewardsToDistribute.add(amount);
+        _recentFeePeriodsStorage(0).rewardsToDistribute = _recentFeePeriodsStorage(0).rewardsToDistribute.add(amount);
     }
 
     /**
@@ -297,43 +325,36 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
     function closeCurrentFeePeriod()
         external
     {
-        require(recentFeePeriods[0].startTime <= (now - feePeriodDuration), "Too early to close fee period");
+        require(_recentFeePeriodsStorage(0).startTime <= (now - feePeriodDuration), "Too early to close fee period");
 
-        FeePeriod memory secondLastFeePeriod = recentFeePeriods[FEE_PERIOD_LENGTH - 2];
-        FeePeriod memory lastFeePeriod = recentFeePeriods[FEE_PERIOD_LENGTH - 1];
+        FeePeriod storage secondLastFeePeriod = _recentFeePeriodsStorage(FEE_PERIOD_LENGTH - 2);
+        FeePeriod storage lastFeePeriod = _recentFeePeriodsStorage(FEE_PERIOD_LENGTH - 1);
 
         // Any unclaimed fees from the last period in the array roll back one period.
         // Because of the subtraction here, they're effectively proportionally redistributed to those who
         // have already claimed from the old period, available in the new period.
         // The subtraction is important so we don't create a ticking time bomb of an ever growing
         // number of fees that can never decrease and will eventually overflow at the end of the fee pool.
-        recentFeePeriods[FEE_PERIOD_LENGTH - 2].feesToDistribute = lastFeePeriod.feesToDistribute
+        _recentFeePeriodsStorage(FEE_PERIOD_LENGTH - 2).feesToDistribute = lastFeePeriod.feesToDistribute
             .sub(lastFeePeriod.feesClaimed)
             .add(secondLastFeePeriod.feesToDistribute);
-        recentFeePeriods[FEE_PERIOD_LENGTH - 2].rewardsToDistribute = lastFeePeriod.rewardsToDistribute
+        _recentFeePeriodsStorage(FEE_PERIOD_LENGTH - 2).rewardsToDistribute = lastFeePeriod.rewardsToDistribute
             .sub(lastFeePeriod.rewardsClaimed)
             .add(secondLastFeePeriod.rewardsToDistribute);
 
         // Shift the previous fee periods across to make room for the new one.
-        // Condition checks for overflow when uint subtracts one from zero
-        // Could be written with int instead of uint, but then we have to convert everywhere
-        // so it felt better from a gas perspective to just change the condition to check
-        // for overflow after subtracting one from zero.
-        for (uint i = FEE_PERIOD_LENGTH - 2; i < FEE_PERIOD_LENGTH; i--) {
-            uint next = i + 1;
-            recentFeePeriods[next] = recentFeePeriods[i];
-        }
+        _currentFeePeriod = (_currentFeePeriod - 1 + FEE_PERIOD_LENGTH) % FEE_PERIOD_LENGTH;
 
         // Clear the first element of the array to make sure we don't have any stale values.
-        delete recentFeePeriods[0];
+        delete _recentFeePeriods[_currentFeePeriod];
 
         // Open up the new fee period. Take a snapshot of the total value of the system.
         // Increment periodId from the recent closed period feePeriodId
-        recentFeePeriods[0].feePeriodId = uint64(uint256(recentFeePeriods[1].feePeriodId).add(1));
-        recentFeePeriods[0].startingDebtIndex = uint64(synthetixState.debtLedgerLength());
-        recentFeePeriods[0].startTime = uint64(now);
+        _recentFeePeriodsStorage(0).feePeriodId = uint64(uint256(_recentFeePeriodsStorage(1).feePeriodId).add(1));
+        _recentFeePeriodsStorage(0).startingDebtIndex = uint64(synthetixState.debtLedgerLength());
+        _recentFeePeriodsStorage(0).startTime = uint64(now);
 
-        emitFeePeriodClosed(recentFeePeriods[1].feePeriodId);
+        emitFeePeriodClosed(_recentFeePeriodsStorage(1).feePeriodId);
     }
 
     /**
@@ -377,7 +398,7 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         require(availableFees > 0 || availableRewards > 0, "No fees or rewards available for period, or fees already claimed");
 
         // Record the address has claimed for this period
-        _setLastFeeWithdrawal(claimingAddress, recentFeePeriods[1].feePeriodId);
+        _setLastFeeWithdrawal(claimingAddress, _recentFeePeriodsStorage(1).feePeriodId);
 
         if (availableFees > 0) {
             // Record the fee payment in our recentFeePeriods
@@ -407,13 +428,15 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         optionalProxy_onlyOwner
         onlyDuringSetup
     {
-        recentFeePeriods[feePeriodIndex].feePeriodId = uint64(feePeriodId);
-        recentFeePeriods[feePeriodIndex].startingDebtIndex = uint64(startingDebtIndex);
-        recentFeePeriods[feePeriodIndex].startTime = uint64(startTime);
-        recentFeePeriods[feePeriodIndex].feesToDistribute = feesToDistribute;
-        recentFeePeriods[feePeriodIndex].feesClaimed = feesClaimed;
-        recentFeePeriods[feePeriodIndex].rewardsToDistribute = rewardsToDistribute;
-        recentFeePeriods[feePeriodIndex].rewardsClaimed = rewardsClaimed;
+        _recentFeePeriods[(_currentFeePeriod + feePeriodIndex) % FEE_PERIOD_LENGTH] = FeePeriod({
+            feePeriodId: uint64(feePeriodId),
+            startingDebtIndex: uint64(startingDebtIndex),
+            startTime: uint64(startTime),
+            feesToDistribute: feesToDistribute,
+            feesClaimed: feesClaimed,
+            rewardsToDistribute: rewardsToDistribute,
+            rewardsClaimed: rewardsClaimed
+        });
     }
 
     /**
@@ -465,13 +488,13 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         // until we've exhausted the amount.
         // The condition checks for overflow because we're going to 0 with an unsigned int.
         for (uint i = FEE_PERIOD_LENGTH - 1; i < FEE_PERIOD_LENGTH; i--) {
-            uint delta = recentFeePeriods[i].feesToDistribute.sub(recentFeePeriods[i].feesClaimed);
+            uint delta = _recentFeePeriodsStorage(i).feesToDistribute.sub(_recentFeePeriodsStorage(i).feesClaimed);
 
             if (delta > 0) {
                 // Take the smaller of the amount left to claim in the period and the amount we need to allocate
                 uint amountInPeriod = delta < remainingToAllocate ? delta : remainingToAllocate;
 
-                recentFeePeriods[i].feesClaimed = recentFeePeriods[i].feesClaimed.add(amountInPeriod);
+                _recentFeePeriodsStorage(i).feesClaimed = _recentFeePeriodsStorage(i).feesClaimed.add(amountInPeriod);
                 remainingToAllocate = remainingToAllocate.sub(amountInPeriod);
                 feesPaid = feesPaid.add(amountInPeriod);
 
@@ -506,13 +529,13 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         // until we've exhausted the amount.
         // The condition checks for overflow because we're going to 0 with an unsigned int.
         for (uint i = FEE_PERIOD_LENGTH - 1; i < FEE_PERIOD_LENGTH; i--) {
-            uint toDistribute = recentFeePeriods[i].rewardsToDistribute.sub(recentFeePeriods[i].rewardsClaimed);
+            uint toDistribute = _recentFeePeriodsStorage(i).rewardsToDistribute.sub(_recentFeePeriodsStorage(i).rewardsClaimed);
 
             if (toDistribute > 0) {
                 // Take the smaller of the amount left to claim in the period and the amount we need to allocate
                 uint amountInPeriod = toDistribute < remainingToAllocate ? toDistribute : remainingToAllocate;
 
-                recentFeePeriods[i].rewardsClaimed = recentFeePeriods[i].rewardsClaimed.add(amountInPeriod);
+                _recentFeePeriodsStorage(i).rewardsClaimed = _recentFeePeriodsStorage(i).rewardsClaimed.add(amountInPeriod);
                 remainingToAllocate = remainingToAllocate.sub(amountInPeriod);
                 rewardPaid = rewardPaid.add(amountInPeriod);
 
@@ -691,8 +714,8 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
 
         // Fees in fee period [0] are not yet available for withdrawal
         for (uint i = 1; i < FEE_PERIOD_LENGTH; i++) {
-            totalFees = totalFees.add(recentFeePeriods[i].feesToDistribute);
-            totalFees = totalFees.sub(recentFeePeriods[i].feesClaimed);
+            totalFees = totalFees.add(_recentFeePeriodsStorage(i).feesToDistribute);
+            totalFees = totalFees.sub(_recentFeePeriodsStorage(i).feesClaimed);
         }
 
         return synthetix.effectiveValue("XDR", totalFees, currencyKey);
@@ -710,8 +733,8 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
 
         // Rewards in fee period [0] are not yet available for withdrawal
         for (uint i = 1; i < FEE_PERIOD_LENGTH; i++) {
-            totalRewards = totalRewards.add(recentFeePeriods[i].rewardsToDistribute);
-            totalRewards = totalRewards.sub(recentFeePeriods[i].rewardsClaimed);
+            totalRewards = totalRewards.add(_recentFeePeriodsStorage(i).rewardsToDistribute);
+            totalRewards = totalRewards.sub(_recentFeePeriodsStorage(i).rewardsClaimed);
         }
 
         return totalRewards;
@@ -811,11 +834,11 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         // Condition checks for periods > 0
         for (uint i = FEE_PERIOD_LENGTH - 1; i > 0; i--) {
             uint next = i - 1;
-            FeePeriod memory nextPeriod = recentFeePeriods[next];
+            FeePeriod storage nextPeriod = _recentFeePeriodsStorage(next);
 
             // We can skip period if no debt minted during period
             if (nextPeriod.startingDebtIndex > 0 &&
-            getLastFeeWithdrawal(account) < recentFeePeriods[i].feePeriodId) {
+            getLastFeeWithdrawal(account) < _recentFeePeriodsStorage(i).feePeriodId) {
 
                 // We calculate a feePeriod's closingDebtIndex by looking at the next feePeriod's startingDebtIndex
                 // we can use the most recent issuanceData[0] for the current feePeriod
@@ -852,16 +875,16 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
 
         // If period has closed we want to calculate debtPercentage for the period
         if (period > 0) {
-            uint closingDebtIndex = uint256(recentFeePeriods[period - 1].startingDebtIndex).sub(1);
+            uint closingDebtIndex = uint256(_recentFeePeriodsStorage(period - 1).startingDebtIndex).sub(1);
             debtOwnershipForPeriod = _effectiveDebtRatioForPeriod(closingDebtIndex, ownershipPercentage, debtEntryIndex);
         }
 
         // Calculate their percentage of the fees / rewards in this period
         // This is a high precision integer.
-        uint feesFromPeriod = recentFeePeriods[period].feesToDistribute
+        uint feesFromPeriod = _recentFeePeriodsStorage(period).feesToDistribute
             .multiplyDecimal(debtOwnershipForPeriod);
 
-        uint rewardsFromPeriod = recentFeePeriods[period].rewardsToDistribute
+        uint rewardsFromPeriod = _recentFeePeriodsStorage(period).rewardsToDistribute
             .multiplyDecimal(debtOwnershipForPeriod);
 
         return (
@@ -896,9 +919,9 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         require(period < FEE_PERIOD_LENGTH, "Exceeds the FEE_PERIOD_LENGTH");
 
         // No debt minted during period as next period starts at 0
-        if (recentFeePeriods[period - 1].startingDebtIndex == 0) return;
+        if (_recentFeePeriodsStorage(period - 1).startingDebtIndex == 0) return;
 
-        uint closingDebtIndex = uint256(recentFeePeriods[period - 1].startingDebtIndex).sub(1);
+        uint closingDebtIndex = uint256(_recentFeePeriodsStorage(period - 1).startingDebtIndex).sub(1);
 
         uint ownershipPercentage;
         uint debtEntryIndex;

--- a/test/FeePoolState.js
+++ b/test/FeePoolState.js
@@ -73,7 +73,7 @@ contract('FeePoolState', async accounts => {
 			expectedEntryIndex,
 			expectedDebtPercentage
 		) {
-			const accountLedger = await feePoolState.accountIssuanceLedger(address, issuanceLedgerIndex); // accountIssuanceLedger[address][index]
+			const accountLedger = await feePoolState.getAccountsDebtEntry(address, issuanceLedgerIndex); // accountIssuanceLedger[address][index]
 			// console.log(
 			// 	'debtEntryIndex, debtPercentage',
 			// 	issuanceLedgerIndex,
@@ -220,7 +220,7 @@ contract('FeePoolState', async accounts => {
 			// Iterate the accounts
 			for (let i = 0; i < accounts.length; i++) {
 				// accountIssuanceLedger[address][index]
-				const accountLedger = await feePoolState.accountIssuanceLedger(
+				const accountLedger = await feePoolState.getAccountsDebtEntry(
 					accounts[i],
 					issuanceLedgerIndex
 				);
@@ -410,7 +410,7 @@ contract('FeePoolState', async accounts => {
 
 	// 	// And feePool.accountIssuanceLedger[account1] should record debt minted
 	// 	const issuanceDataFromState = await synthetixState.issuanceData(account1);
-	// 	const feePoolLedger = await feePool.accountIssuanceLedger(account1, 0);
+	// 	const feePoolLedger = await feePool.getAccountsDebtEntry(account1, 0);
 
 	// 	assert.bnEqual(feePoolLedger.debtEntryIndex, 0);
 	// 	assert.bnEqual(feePoolLedger.debtEntryIndex, issuanceDataFromState.debtEntryIndex);
@@ -445,7 +445,7 @@ contract('FeePoolState', async accounts => {
 	// 	// And feePool.accountIssuanceLedger[account1] should record debt minted
 	// 	let issuanceDataFromState, feePoolLedger;
 	// 	issuanceDataFromState = await synthetixState.issuanceData(account1);
-	// 	feePoolLedger = await feePool.accountIssuanceLedger(account1, 0);
+	// 	feePoolLedger = await feePool.getAccountsDebtEntry(account1, 0);
 
 	// 	assert.bnEqual(feePoolLedger.debtEntryIndex, 0);
 	// 	assert.bnEqual(feePoolLedger.debtEntryIndex, issuanceDataFromState.debtEntryIndex);
@@ -459,7 +459,7 @@ contract('FeePoolState', async accounts => {
 	// 	assert.bnEqual(await synthetix.debtBalanceOf(account1, sUSD), toUnit('400'));
 
 	// 	issuanceDataFromState = await synthetixState.issuanceData(account1);
-	// 	feePoolLedger = await feePool.accountIssuanceLedger(account1, 0);
+	// 	feePoolLedger = await feePool.getAccountsDebtEntry(account1, 0);
 
 	// 	// debtEntryIndex is updated to 1 and still own whole system
 	// 	assert.bnEqual(feePoolLedger.debtEntryIndex, 1);


### PR DESCRIPTION
- Potentially 40k gas win on creation and 10k gas win on structure update.
- Avoid 2 full FeePool copying in storage by mutating index only.

Gas optimization PR according to GitCoin bounty: https://gitcoin.co/issue/Synthetixio/synthetix/196/3430