### PR TITLE
Optimize rates storage

### DIFF
--- a/contracts/ExchangeRates.sol
+++ b/contracts/ExchangeRates.sol
@@ -40,11 +40,13 @@ contract ExchangeRates is SelfDestructible {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
 
-    // Exchange rates stored by currency code, e.g. 'SNX', or 'sUSD'
-    mapping(bytes32 => uint) public rates;
+    struct RateAndUpdatedTime {
+        uint216 rate;
+        uint40 time;
+    }
 
-    // Update times stored by currency code, e.g. 'SNX', or 'sUSD'
-    mapping(bytes32 => uint) public lastRateUpdateTimes;
+    // Exchange rates and update times stored by currency code, e.g. 'SNX', or 'sUSD'
+    mapping(bytes32 => RateAndUpdatedTime) private _rates;
 
     // The address of the oracle which pushes rate updates to this contract
     address public oracle;
@@ -101,8 +103,7 @@ contract ExchangeRates is SelfDestructible {
         oracle = _oracle;
 
         // The sUSD rate is always 1 and is never stale.
-        rates["sUSD"] = SafeDecimalMath.unit();
-        lastRateUpdateTimes["sUSD"] = now;
+        _setRates("sUSD", SafeDecimalMath.unit(), now);
 
         // These are the currencies that make up the XDR basket.
         // These are hard coded because:
@@ -120,6 +121,21 @@ contract ExchangeRates is SelfDestructible {
         ];
 
         internalUpdateRates(_currencyKeys, _newRates, now);
+    }
+
+    function rates(bytes32 code) public view returns(uint256) {
+        return uint256(_rates[code].rate);
+    }
+
+    function lastRateUpdateTimes(bytes32 code) public view returns(uint256) {
+        return uint256(_rates[code].time);
+    }
+
+    function _setRates(bytes32 code, uint256 rate, uint256 time) internal {
+        _rates[code] = RateAndUpdatedTime({
+            rate: uint216(rate),
+            time: uint40(time)
+        });
     }
 
     /* ========== SETTERS ========== */
@@ -164,15 +180,14 @@ contract ExchangeRates is SelfDestructible {
             require(currencyKeys[i] != "sUSD", "Rate of sUSD cannot be updated, it's always UNIT.");
 
             // We should only update the rate if it's at least the same age as the last rate we've got.
-            if (timeSent < lastRateUpdateTimes[currencyKeys[i]]) {
+            if (timeSent < lastRateUpdateTimes(currencyKeys[i])) {
                 continue;
             }
 
             newRates[i] = rateOrInverted(currencyKeys[i], newRates[i]);
 
             // Ok, go ahead with the update.
-            rates[currencyKeys[i]] = newRates[i];
-            lastRateUpdateTimes[currencyKeys[i]] = timeSent;
+            _setRates(currencyKeys[i], newRates[i], timeSent);
         }
 
         emit RatesUpdated(currencyKeys, newRates);
@@ -202,7 +217,7 @@ contract ExchangeRates is SelfDestructible {
         }
 
         // set the rate to the current rate initially (if it's frozen, this is what will be returned)
-        uint newInverseRate = rates[currencyKey];
+        uint newInverseRate = rates(currencyKey);
 
         // get the new inverted rate if not frozen
         if (!inverse.frozen) {
@@ -241,14 +256,11 @@ contract ExchangeRates is SelfDestructible {
         uint total = 0;
 
         for (uint i = 0; i < xdrParticipants.length; i++) {
-            total = rates[xdrParticipants[i]].add(total);
+            total = rates(xdrParticipants[i]).add(total);
         }
 
-        // Set the rate
-        rates["XDR"] = total;
-
-        // Record that we updated the XDR rate.
-        lastRateUpdateTimes["XDR"] = timeSent;
+        // Set the rate and update time
+        _setRates("XDR", total, timeSent);
 
         // Emit our updated event separate to the others to save
         // moving data around between arrays.
@@ -256,7 +268,7 @@ contract ExchangeRates is SelfDestructible {
         eventCurrencyCode[0] = "XDR";
 
         uint[] memory eventRate = new uint[](1);
-        eventRate[0] = rates["XDR"];
+        eventRate[0] = rates("XDR");
 
         emit RatesUpdated(eventCurrencyCode, eventRate);
     }
@@ -269,10 +281,9 @@ contract ExchangeRates is SelfDestructible {
         external
         onlyOracle
     {
-        require(rates[currencyKey] > 0, "Rate is zero");
+        require(rates(currencyKey) > 0, "Rate is zero");
 
-        delete rates[currencyKey];
-        delete lastRateUpdateTimes[currencyKey];
+        delete _rates[currencyKey];
 
         emit RateDeleted(currencyKey);
     }
@@ -400,7 +411,7 @@ contract ExchangeRates is SelfDestructible {
         view
         returns (uint)
     {
-        return rates[currencyKey];
+        return rates(currencyKey);
     }
 
     /**
@@ -411,13 +422,13 @@ contract ExchangeRates is SelfDestructible {
         view
         returns (uint[])
     {
-        uint[] memory _rates = new uint[](currencyKeys.length);
+        uint[] memory _localRates = new uint[](currencyKeys.length);
 
         for (uint8 i = 0; i < currencyKeys.length; i++) {
-            _rates[i] = rates[currencyKeys[i]];
+            _localRates[i] = rates(currencyKeys[i]);
         }
 
-        return _rates;
+        return _localRates;
     }
 
     /**
@@ -428,7 +439,7 @@ contract ExchangeRates is SelfDestructible {
         view
         returns (uint)
     {
-        return lastRateUpdateTimes[currencyKey];
+        return lastRateUpdateTimes(currencyKey);
     }
 
     /**
@@ -442,7 +453,7 @@ contract ExchangeRates is SelfDestructible {
         uint[] memory lastUpdateTimes = new uint[](currencyKeys.length);
 
         for (uint8 i = 0; i < currencyKeys.length; i++) {
-            lastUpdateTimes[i] = lastRateUpdateTimes[currencyKeys[i]];
+            lastUpdateTimes[i] = lastRateUpdateTimes(currencyKeys[i]);
         }
 
         return lastUpdateTimes;
@@ -459,7 +470,7 @@ contract ExchangeRates is SelfDestructible {
         // sUSD is a special case and is never stale.
         if (currencyKey == "sUSD") return false;
 
-        return lastRateUpdateTimes[currencyKey].add(rateStalePeriod) < now;
+        return lastRateUpdateTimes(currencyKey).add(rateStalePeriod) < now;
     }
 
     /**
@@ -487,7 +498,7 @@ contract ExchangeRates is SelfDestructible {
 
         while (i < currencyKeys.length) {
             // sUSD is a special case and is never false
-            if (currencyKeys[i] != "sUSD" && lastRateUpdateTimes[currencyKeys[i]].add(rateStalePeriod) < now) {
+            if (currencyKeys[i] != "sUSD" && lastRateUpdateTimes(currencyKeys[i]).add(rateStalePeriod) < now) {
                 return true;
             }
             i += 1;

--- a/contracts/ExchangeRates.sol
+++ b/contracts/ExchangeRates.sol
@@ -432,6 +432,28 @@ contract ExchangeRates is SelfDestructible {
     }
 
     /**
+     * @notice Retrieve the rates and isAnyStale for a list of currencies
+     */
+    function ratesAndStaleForCurrencies(bytes32[] currencyKeys)
+        public
+        view
+        returns (uint[], bool)
+    {
+        uint[] memory _localRates = new uint[](currencyKeys.length);
+
+        bool anyRateStale = false;
+        for (uint8 i = 0; i < currencyKeys.length; i++) {
+            RateAndUpdatedTime memory rt = _rates[currencyKeys[i]];
+            _localRates[i] = uint256(rt.rate);
+            if (!anyRateStale) {
+                anyRateStale = (currencyKeys[i] != "sUSD" && uint256(rt.time).add(rateStalePeriod) < now);
+            }
+        }
+
+        return (_localRates, anyRateStale);
+    }
+
+    /**
      * @notice Retrieve a list of last update times for specific currencies
      */
     function lastRateUpdateTimeForCurrency(bytes32 currencyKey)

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -141,6 +141,7 @@ contract Synthetix is ExternStateToken {
     // Available Synths which can be used with the system
     Synth[] public availableSynths;
     mapping(bytes32 => Synth) public synths;
+    mapping(address => bytes32) public reverseSynths;
 
     IFeePool public feePool;
     ISynthetixEscrow public escrow;
@@ -221,9 +222,11 @@ contract Synthetix is ExternStateToken {
         bytes32 currencyKey = synth.currencyKey();
 
         require(synths[currencyKey] == Synth(0), "Synth already exists");
+        require(reverseSynths[synth] == bytes32(0), "Synth with same currencyKey already exists");
 
         availableSynths.push(synth);
         synths[currencyKey] = synth;
+        reverseSynths[synth] = currencyKey;
     }
 
     /**
@@ -259,6 +262,7 @@ contract Synthetix is ExternStateToken {
         }
 
         // And remove it from the synths mapping
+        delete reverseSynths[synths[currencyKey]];
         delete synths[currencyKey];
 
         // Note: No event here as our contract exceeds max contract size
@@ -322,7 +326,7 @@ contract Synthetix is ExternStateToken {
         bytes32[] memory availableCurrencyKeys = new bytes32[](availableSynths.length);
 
         for (uint8 i = 0; i < availableSynths.length; i++) {
-            availableCurrencyKeys[i] = availableSynths[i].currencyKey();
+            availableCurrencyKeys[i] = reverseSynths[availableSynths[i]];
         }
 
         return availableCurrencyKeys;
@@ -459,9 +463,9 @@ contract Synthetix is ExternStateToken {
         address destinationAddress
     )
         external
+        onlySynth
         returns (bool)
     {
-        _onlySynth();
         require(sourceCurrencyKey != destinationCurrencyKey, "Can't be same synth");
         require(sourceAmount > 0, "Zero amount");
 
@@ -490,10 +494,9 @@ contract Synthetix is ExternStateToken {
         uint sourceAmount
     )
         external
+        onlySynth
         returns (bool)
     {
-        _onlySynth();
-
         // Allow fee to be 0 and skip minting XDRs to feePool
         if (sourceAmount == 0) {
             return true;
@@ -1011,21 +1014,10 @@ contract Synthetix is ExternStateToken {
 
     /**
      * @notice Only a synth can call this function
-     * @dev This used to be a modifier but instead of duplicating the bytecode into
-     * The functions implementing it they now call this internal function to save bytecode space
      */
-    function _onlySynth() internal view {
-        bool isSynth = false;
-
-        // No need to repeatedly call this function either
-        for (uint8 i = 0; i < availableSynths.length; i++) {
-            if (availableSynths[i] == msg.sender) {
-                isSynth = true;
-                break;
-            }
-        }
-
-        require(isSynth, "Only synth allowed");
+    modifier onlySynth {
+        require(reverseSynths[msg.sender] != bytes32(0), "Only synth allowed");
+        _;
     }
 
     modifier onlyOracle

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -295,7 +295,8 @@ contract Synthetix is ExternStateToken {
         uint total = 0;
         uint currencyRate = exchangeRates.rateForCurrency(currencyKey);
 
-        require(!exchangeRates.anyRateIsStale(availableCurrencyKeys()), "Rates are stale");
+        (uint[] memory rates, bool anyRateStale) = exchangeRates.ratesAndStaleForCurrencies(availableCurrencyKeys());
+        require(!anyRateStale, "Rates are stale");
 
         for (uint8 i = 0; i < availableSynths.length; i++) {
             // What's the total issued value of that synth in the destination currency?
@@ -303,7 +304,7 @@ contract Synthetix is ExternStateToken {
             //       rate for the destination currency and check if it's stale repeatedly on every
             //       iteration of the loop
             uint synthValue = availableSynths[i].totalSupply()
-                .multiplyDecimalRound(exchangeRates.rateForCurrency(availableSynths[i].currencyKey()))
+                .multiplyDecimalRound(rates[i])
                 .divideDecimalRound(currencyRate);
             total = total.add(synthValue);
         }

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -289,7 +289,6 @@ contract Synthetix is ExternStateToken {
     function totalIssuedSynths(bytes32 currencyKey)
         public
         view
-        rateNotStale(currencyKey)
         returns (uint)
     {
         uint total = 0;


### PR DESCRIPTION
Hi,

**Each separate commit could be considered as separate optimization:**
- (1e2196d59bbd921bce144195e00d198548c64c28) Rates storage optimization
- (8dee408f558a60ad8980f536fa3b65a36be02a68) Join multiple rates calls into single
- (e5a2fe2a102b66e9c09bfd604a2bffd437d0259a) Remove duplicate stale rate check
- (247339d8edb9536b2e8da7ec501333b2489dd491) Added reverse cache for synth currencyKeys

//

I believe `uint40` should be enough for storing seconds (up to 35 000 years).
It seems like 27.77% gas optimization for **avg** `ExchangeRates.updateRates`.

`alpha` (2eaef0dddf95d6c0e3a1acd4a96482aab8143d30):

```
·--------------------------------------------------------|---------------------------|-------------|----------------------------·
|          Solc version: 0.4.25+commit.59dbf8f1          ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 8000000 gas  │
·························································|···························|·············|·····························
|  Methods                                               ·               4 gwei/gas                ·       180.56 usd/eth       │
························|································|·············|·············|·············|··············|··············
|  Contract             ·  Method                        ·  Min        ·  Max        ·  Avg        ·  # calls     ·  usd (avg)  │
························|································|·············|·············|·············|··············|··············
|  Synthetix            ·  issueSynths                   ·     306850  ·     582310  ·     423915  ·         284  ·       0.31  │
························|································|·············|·············|·············|··············|··············
|  Synthetix            ·  burnSynths                    ·     476976  ·     664025  ·     561884  ·          99  ·       0.41  │
························|································|·············|·············|·············|··············|··············
|  ExchangeRates        ·  updateRates                   ·      56015  ·    6535679  ·     117042  ·         486  ·       0.08  │
························|································|·············|·············|·············|··············|··············
|  FeePool              ·  claimFees                     ·     390436  ·     514240  ·     441358  ·          41  ·       0.32  │
························|································|·············|·············|·············|··············|··············
|  Synthetix            ·  exchange                      ·      59871  ·     249564  ·     224765  ·          45  ·       0.16  │
························|································|·············|·············|·············|··············|··············
```

`optimize/rates-storage` (1e2196d59bbd921bce144195e00d198548c64c28):

```
·--------------------------------------------------------|---------------------------|-------------|----------------------------·
|          Solc version: 0.4.25+commit.59dbf8f1          ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 8000000 gas  │
·························································|···························|·············|·····························
|  Methods                                               ·               4 gwei/gas                ·       180.56 usd/eth       │
························|································|·············|·············|·············|··············|··············
|  Contract             ·  Method                        ·  Min        ·  Max        ·  Avg        ·  # calls     ·  usd (avg)  │
························|································|·············|·············|·············|··············|··············
|  Synthetix            ·  issueSynths                   ·     307688  ·     584059  ·     426344  ·         284  ·       0.31  │
························|································|·············|·············|·············|··············|··············
|  Synthetix            ·  burnSynths                    ·     479100  ·     666231  ·     564608  ·          99  ·       0.41  │
························|································|·············|·············|·············|··············|··············
|  ExchangeRates        ·  updateRates                   ·      46830  ·    3566459  ·      84580  ·         486  ·       0.06  │
························|································|·············|·············|·············|··············|··············
|  FeePool              ·  claimFees                     ·     391534  ·     515471  ·     442495  ·          41  ·       0.32  │
························|································|·············|·············|·············|··············|··············
|  Synthetix            ·  exchange                      ·      59871  ·     249871  ·     225068  ·          45  ·       0.16  │
························|································|·············|·············|·············|··············|··············
```

Gas optimization PR according to GitCoin bounty: https://gitcoin.co/issue/Synthetixio/synthetix/196/3430