### PR TITLE
Add cache for totalSupply methods

### DIFF
--- a/contracts/FeePool.sol
+++ b/contracts/FeePool.sol
@@ -551,14 +551,13 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         require(account != address(proxy), "Can't send fees to proxy");
         require(account != address(synthetix), "Can't send fees to synthetix");
 
-        Synth xdrSynth = synthetix.synths("XDR");
         Synth destinationSynth = synthetix.synths(destinationCurrencyKey);
 
         // Note: We don't need to check the fee pool balance as the burn() below will do a safe subtraction which requires
         // the subtraction to not overflow, which would happen if the balance is not sufficient.
 
         // Burn the source amount
-        xdrSynth.burn(FEE_ADDRESS, xdrAmount);
+        synthetix.burnByPool(FEE_ADDRESS, "XDR", xdrAmount);
 
         // How much should they get in the destination currency?
         uint destinationAmount = synthetix.effectiveValue("XDR", xdrAmount, destinationCurrencyKey);
@@ -566,7 +565,7 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup {
         // There's no fee on withdrawing fees, as that'd be way too meta.
 
         // Mint their new synths
-        destinationSynth.issue(account, destinationAmount);
+        synthetix.issueByPool(account, destinationCurrencyKey, destinationAmount);
 
         // Nothing changes as far as issuance data goes because the total value in the system hasn't changed.
 

--- a/contracts/Synth.sol
+++ b/contracts/Synth.sol
@@ -295,6 +295,7 @@ contract Synth is ExternStateToken {
         optionalProxy_onlyOwner
     {
         totalSupply = amount;
+        synthetix.nofityTotalSupplyChanged(this);
     }
 
     // Allow synthetix to trigger a token fallback call from our synths so users get notified on


### PR DESCRIPTION
This branch contains all commit from https://github.com/Synthetixio/synthetix/pull/228 plus caching for synths `totalSupply()` method. It is dirty a bit, so I am pointing on this problem and if you are interested I can refactor code to be cute.

Gas diff with origin:

| Method | Min | Max | Avg |
| --- | --- | --- | --- |
| Synthetix.issueSynths | -20.81% | -34.98%  | -29.73% |
| Synthetix.burnSynths | -60.57% | -41.33%  | -48.72% |
| ExchangeRates.updateRates | -16.23% |  -45.26% | -27.46% |
| FeePool.claimFees | -35.79% | -23.72%  | -30.73% |
| Synthetix.exchange | +9.12% | +18.75%  | +16.40% |

`alpha` (2eaef0dddf95d6c0e3a1acd4a96482aab8143d30):

```
·--------------------------------------------------------|---------------------------|-------------|----------------------------·
|          Solc version: 0.4.25+commit.59dbf8f1          ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 8000000 gas  │
·························································|···························|·············|·····························
|  Methods                                               ·               4 gwei/gas                ·       180.56 usd/eth       │
························|································|·············|·············|·············|··············|··············
|  Contract             ·  Method                        ·  Min        ·  Max        ·  Avg        ·  # calls     ·  usd (avg)  │
························|································|·············|·············|·············|··············|··············
|  Synthetix            ·  issueSynths                   ·     306850  ·     582310  ·     423915  ·         284  ·       0.31  │
························|································|·············|·············|·············|··············|··············
|  Synthetix            ·  burnSynths                    ·     476976  ·     664025  ·     561884  ·          99  ·       0.41  │
························|································|·············|·············|·············|··············|··············
|  ExchangeRates        ·  updateRates                   ·      56015  ·    6535679  ·     117042  ·         486  ·       0.08  │
························|································|·············|·············|·············|··············|··············
|  FeePool              ·  claimFees                     ·     390436  ·     514240  ·     441358  ·          41  ·       0.32  │
························|································|·············|·············|·············|··············|··············
|  Synthetix            ·  exchange                      ·      59871  ·     249564  ·     224765  ·          45  ·       0.16  │
························|································|·············|·············|·············|··············|··············
```

`optimize/cache-totalIssuedSynths` (011e13088452b359ec44a3af95061e78137fee8d):

```
·--------------------------------------------------------|---------------------------|-------------|----------------------------·
|          Solc version: 0.4.25+commit.59dbf8f1          ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 8000000 gas  │
·························································|···························|·············|·····························
|  Methods                                               ·               10 gwei/gas               ·       180.96 usd/eth       │
························|································|·············|·············|·············|··············|··············
|  Contract             ·  Method                        ·  Min        ·  Max        ·  Avg        ·  # calls     ·  usd (avg)  │
························|································|·············|·············|·············|··············|··············
|  Synthetix            ·  issueSynths                   ·     242984  ·     378567  ·     297905  ·         284  ·       0.54  │
························|································|·············|·············|·············|··············|··············
|  Synthetix            ·  burnSynths                    ·     188042  ·     389576  ·     288154  ·          99  ·       0.52  │
························|································|·············|·············|·············|··············|··············
|  ExchangeRates        ·  updateRates                   ·      46923  ·    3577067  ·      84907  ·         486  ·       0.15  │
························|································|·············|·············|·············|··············|··············
|  FeePool              ·  claimFees                     ·     250713  ·     392277  ·     305725  ·          41  ·       0.55  │
························|································|·············|·············|·············|··············|··············
|  Synthetix            ·  exchange                      ·      65334  ·     296347  ·     261633  ·          45  ·       0.47  │
························|································|·············|·············|·············|··············|··············
```