### PR TITLE
Optimize debtBalanceOf, to avoid multiple subcalls to heavy totalIssuedSynths

### DIFF
--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -716,7 +716,7 @@ contract Synthetix is ExternStateToken {
         uint amountToRemove = debt < debtToRemove ? debt : debtToRemove;
 
         // Remove their debt from the ledger
-        _removeFromDebtRegister(amountToRemove);
+        _removeFromDebtRegister(amountToRemove, tisInXDR);
 
         uint amountToBurn = debtInCurrencyKey < amount ? debtInCurrencyKey : amount;
 
@@ -750,13 +750,10 @@ contract Synthetix is ExternStateToken {
      * @notice Remove a debt position from the register
      * @param amount The amount (in UNIT base) being presented in XDRs
      */
-    function _removeFromDebtRegister(uint amount)
+    function _removeFromDebtRegister(uint amount, uint totalDebtIssued)
         internal
     {
         uint debtToRemove = amount;
-
-        // What is the value of all issued synths of the system (priced in XDRs)?
-        uint totalDebtIssued = totalIssuedSynths("XDR");
 
         // How much debt do they have?
         uint existingDebt = _debtBalanceOf(messageSender, "XDR", totalDebtIssued);


### PR DESCRIPTION
Launched tests of `Synthetix.js` only:

<img width="658" alt="image" src="https://user-images.githubusercontent.com/702124/66926428-b1005500-f036-11e9-93a1-42388d557d22.png">
<img width="659" alt="image" src="https://user-images.githubusercontent.com/702124/66926459-bf4e7100-f036-11e9-971a-0a6357146309.png">