### PR TITLE
Rigil fixes for alpha, solhint cleanup and Synthetix swing trade reduction

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -1,19 +1,26 @@
 {
-  "extends": ["solhint:recommended"],
-  "rules": {
-    "const-name-snakecase": "off",
-    "expression-indent": "off",
-    "func-order": "off",
-    "func-param-name-mixedcase": "off",
-    "indent": "off",
-    "max-line-length": "off",
-    "no-inline-assembly": "off",
-    "no-simple-event-func-name": "off",
-    "separate-by-one-line-in-contract": "off",
-    "two-lines-top-level-separator": "off",
-    "var-name-mixedcase": "off",
-    "visibility-modifier-order": "off",
-    "mark-callable-contracts": "off",
-    "compiler-version": ["error", "0.4.25"]
-  }
+	"extends": ["solhint:recommended"],
+	"rules": {
+		"bracket-align": "off",
+		"compiler-version": ["error", "0.4.25"],
+		"const-name-snakecase": "off",
+		"expression-indent": "off",
+		"func-order": "off",
+		"func-param-name-mixedcase": "off",
+		"imports-on-top": "off",
+		"indent": ["error", 4],
+		"mark-callable-contracts": "off",
+		"max-line-length": "off",
+		"no-inline-assembly": "off",
+		"no-simple-event-func-name": "off",
+		"not-rely-on-time": "off",
+		"no-unused-vars": "warn",
+		"quotes": ["error", "double"],
+		"security/no-block-members": ["error", ["blockhash"]],
+		"security/no-inline-assembly": "off",
+		"separate-by-one-line-in-contract": "off",
+		"two-lines-top-level-separator": "off",
+		"var-name-mixedcase": "off",
+		"visibility-modifier-order": "off"
+	}
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
 	"solidity.compileUsingRemoteVersion": "soljson-v0.4.25+commit.59dbf8f1",
 	"solidity.linter": "solhint",
 	"solidity.compilerOptimization": 200,
+	"solidity.packageDefaultDependenciesContractsDirectory": "",
 	"solidity.packageDefaultDependenciesDirectory": "node_modules"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,11 +1,6 @@
 {
 	"solidity.compileUsingRemoteVersion": "soljson-v0.4.25+commit.59dbf8f1",
-	"solidity.soliumRules": {
-		"imports-on-top": 0,
-		"variable-declarations": 0,
-		"indentation": ["error", 4],
-		"quotes": ["error", "double"],
-		"security/no-block-members": ["error", ["blockhash"]],
-		"security/no-inline-assembly": "off"
-	}
+	"solidity.linter": "solhint",
+	"solidity.compilerOptimization": 200,
+	"solidity.packageDefaultDependenciesDirectory": "node_modules"
 }

--- a/contracts/Depot.sol
+++ b/contracts/Depot.sol
@@ -131,7 +131,7 @@ contract Depot is SelfDestructible, Pausable {
         // Other contracts needed
         ISynthetix _synthetix,
         ISynth _synth,
-		IFeePool _feePool,
+        IFeePool _feePool,
 
         // Oracle values - Allows for price updates
         address _oracle,

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -478,18 +478,18 @@ contract Synthetix is ExternStateToken {
             // Get the exchange fee rate
             uint exchangeFeeRate = feePool.exchangeFeeRate();
 
-            // Exchanges from sUSD or into sUSD should have same exchange fee
-            if (sourceCurrencyKey == "sUSD" || destinationCurrencyKey == "sUSD"){
-                amountReceived = destinationAmount.multiplyDecimal(SafeDecimalMath.unit().sub(exchangeFeeRate));
-            }
+            uint multiplier = 1;
+
             // Is this a swing trade? long to short or sort to long.
-            else if ( sourceCurrencyKey[0] == 0x73 && destinationCurrencyKey[0] == 0x69 ||
-                sourceCurrencyKey[0] == 0x69 && destinationCurrencyKey[0] == 0x73){
+            if (
+                (sourceCurrencyKey[0] == 0x73 && sourceCurrencyKey != "sUSD" && destinationCurrencyKey[0] == 0x69) ||
+                (sourceCurrencyKey[0] == 0x69 && destinationCurrencyKey != "sUSD" && destinationCurrencyKey[0] == 0x73)
+            ) {
                 // Double the exchange fee and sub the fee from the amountReceived
-                amountReceived = destinationAmount.multiplyDecimal(SafeDecimalMath.unit().sub(exchangeFeeRate.mul(2)));
-            } else {
-                amountReceived = destinationAmount.multiplyDecimal(SafeDecimalMath.unit().sub(exchangeFeeRate));
+                multiplier = 2;
             }
+
+            amountReceived = destinationAmount.multiplyDecimal(SafeDecimalMath.unit().sub(exchangeFeeRate.mul(multiplier)));
             fee = destinationAmount.sub(amountReceived);
         }
 

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -23,14 +23,14 @@ contract IERC20 {
     function decimals() public view returns (uint8);
 
     event Transfer(
-      address indexed from,
-      address indexed to,
-      uint value
+        address indexed from,
+        address indexed to,
+        uint value
     );
 
     event Approval(
-      address indexed owner,
-      address indexed spender,
-      uint value
+        address indexed owner,
+        address indexed spender,
+        uint value
     );
 }

--- a/contracts/interfaces/ISynth.sol
+++ b/contracts/interfaces/ISynth.sol
@@ -1,9 +1,9 @@
 pragma solidity 0.4.25;
 
 interface ISynth {
-  function burn(address account, uint amount) external;
-  function issue(address account, uint amount) external;
-  function transfer(address to, uint value) public returns (bool);
-  function triggerTokenFallbackIfNeeded(address sender, address recipient, uint amount) external;
-  function transferFrom(address from, address to, uint value) public returns (bool);
+    function burn(address account, uint amount) external;
+    function issue(address account, uint amount) external;
+    function transfer(address to, uint value) public returns (bool);
+    function triggerTokenFallbackIfNeeded(address sender, address recipient, uint amount) external;
+    function transferFrom(address from, address to, uint value) public returns (bool);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,9 +25,9 @@
 			}
 		},
 		"@babel/runtime": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.6.3.tgz",
-			"integrity": "sha512-kq6anf9JGjW8Nt5rYfEuGRaEAaH1mkv3Bbu6rYvLOpPh/RusSJXuKPEAoZ7L7gybZkchE8+NV5g9vKF4AGAtsA==",
+			"version": "7.7.1",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.1.tgz",
+			"integrity": "sha512-SQ0sS7KUJDvgCI2cpZG0nJygO6002oTbhgSuw4WcocsnbxLwL5Q8I3fqbJdyBAc3uFrWZiR2JomseuxSuci3SQ==",
 			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.2"
@@ -104,9 +104,9 @@
 			}
 		},
 		"@types/node": {
-			"version": "10.17.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.0.tgz",
-			"integrity": "sha512-wuJwN2KV4tIRz1bu9vq5kSPasJ8IsEjZaP1ZR7KlmdUZvGF/rXy8DmXOVwUD0kAtvtJ7aqMKPqUXC0NUTDbrDg==",
+			"version": "10.17.4",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.4.tgz",
+			"integrity": "sha512-F2pgg+LcIr/elguz+x+fdBX5KeZXGUOp7TV8M0TVIrDezYLFRNt8oMTyps0VQ1kj5WGGoR18RdxnRDHXrIFHMQ==",
 			"dev": true
 		},
 		"@types/qs": {
@@ -405,12 +405,6 @@
 			"integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
 			"dev": true
 		},
-		"ast-metadata-inferer": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/ast-metadata-inferer/-/ast-metadata-inferer-0.1.1.tgz",
-			"integrity": "sha512-hc9w8Qrgg9Lf9iFcZVhNjUnhrd2BBpTlyCnegPVvCe6O0yMrF57a6Cmh7k+xUsfUOMh9wajOL5AsGOBNEyTCcw==",
-			"dev": true
-		},
 		"astral-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -562,6 +556,15 @@
 			"integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
 			"dev": true
 		},
+		"bindings": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"requires": {
+				"file-uri-to-path": "1.0.0"
+			}
+		},
 		"bip39": {
 			"version": "2.6.0",
 			"resolved": "https://registry.npmjs.org/bip39/-/bip39-2.6.0.tgz",
@@ -573,6 +576,15 @@
 				"randombytes": "^2.0.1",
 				"safe-buffer": "^5.0.1",
 				"unorm": "^1.3.3"
+			}
+		},
+		"bip66": {
+			"version": "1.1.5",
+			"resolved": "https://registry.npmjs.org/bip66/-/bip66-1.1.5.tgz",
+			"integrity": "sha1-AfqHSHhcpwlV1QESF9GzE5lpyiI=",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.0.1"
 			}
 		},
 		"bl": {
@@ -853,17 +865,6 @@
 				"parse-asn1": "^5.0.0"
 			}
 		},
-		"browserslist": {
-			"version": "4.7.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
-			"integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
-			"dev": true,
-			"requires": {
-				"caniuse-lite": "^1.0.30001004",
-				"electron-to-chromium": "^1.3.295",
-				"node-releases": "^1.1.38"
-			}
-		},
 		"buffer": {
 			"version": "5.4.3",
 			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.4.3.tgz",
@@ -1062,18 +1063,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-3.0.0.tgz",
 			"integrity": "sha1-MvxLn82vhF/N9+c7uXysImHwqwo="
-		},
-		"caniuse-db": {
-			"version": "1.0.30001005",
-			"resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30001005.tgz",
-			"integrity": "sha512-MSRfm2N6FRDSpAJ00ipCuFe0CNink5JJOFzl4S7fLSBJdowhGq3uMxzkWGTjvvReo1PuWfK5YYJydJJ+9mJebw==",
-			"dev": true
-		},
-		"caniuse-lite": {
-			"version": "1.0.30001005",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001005.tgz",
-			"integrity": "sha512-g78miZm1Z5njjYR216a5812oPiLgV1ssndgGxITHWUopmjUrCswMisA0a2kSB7a0vZRox6JOKhM51+efmYN8Mg==",
-			"dev": true
 		},
 		"cardinal": {
 			"version": "2.1.1",
@@ -1981,9 +1970,9 @@
 			"dev": true
 		},
 		"defer-to-connect": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.0.2.tgz",
-			"integrity": "sha512-k09hcQcTDY+cwgiwa6PYKLm3jlagNzQ+RSvhjzESOGOx+MNOuXkxTfEvPrO1IOQ81tArCFYQgi631clB70RpQw==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.0.tgz",
+			"integrity": "sha512-WE2sZoctWm/v4smfCAdjYbrfS55JiMRdlY9ZubFhsYbteCK9+BvAx4YV7nPjYM6ZnX5BcoVKwfmyx9sIFTgQMQ==",
 			"dev": true
 		},
 		"define-properties": {
@@ -2169,6 +2158,17 @@
 			"integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==",
 			"dev": true
 		},
+		"drbg.js": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/drbg.js/-/drbg.js-1.0.1.tgz",
+			"integrity": "sha1-Pja2xCs3BDgjzbwzLVjzHiRFSAs=",
+			"dev": true,
+			"requires": {
+				"browserify-aes": "^1.0.6",
+				"create-hash": "^1.1.2",
+				"create-hmac": "^1.1.4"
+			}
+		},
 		"duplexer3": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
@@ -2233,12 +2233,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
 			"integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
-			"dev": true
-		},
-		"electron-to-chromium": {
-			"version": "1.3.296",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.296.tgz",
-			"integrity": "sha512-s5hv+TSJSVRsxH190De66YHb50pBGTweT9XGWYu/LMR20KX6TsjFzObo36CjVAzM+PUeeKSBRtm/mISlCzeojQ==",
 			"dev": true
 		},
 		"elliptic": {
@@ -2338,14 +2332,14 @@
 			}
 		},
 		"es5-ext": {
-			"version": "0.10.51",
-			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.51.tgz",
-			"integrity": "sha512-oRpWzM2WcLHVKpnrcyB7OW8j/s67Ba04JCm0WnNv3RiABSvs7mrQlutB8DBv793gKcp0XENR8Il8WxGTlZ73gQ==",
+			"version": "0.10.52",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.52.tgz",
+			"integrity": "sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==",
 			"dev": true,
 			"requires": {
 				"es6-iterator": "~2.0.3",
-				"es6-symbol": "~3.1.1",
-				"next-tick": "^1.0.0"
+				"es6-symbol": "~3.1.2",
+				"next-tick": "~1.0.0"
 			}
 		},
 		"es6-iterator": {
@@ -2375,13 +2369,13 @@
 			}
 		},
 		"es6-symbol": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.2.tgz",
-			"integrity": "sha512-/ZypxQsArlv+KHpGvng52/Iz8by3EQPxhmbuz8yFG89N/caTFBSbcXONDw0aMjy827gQg26XAjP4uXFvnfINmQ==",
+			"version": "3.1.3",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.3.tgz",
+			"integrity": "sha512-NJ6Yn3FuDinBaBRWl/q5X/s4koRHBrgKAu+yGI6JCBeiu3qrcbJhwT2GeR/EXVfylRk8dpQVJoLEFhK+Mu31NA==",
 			"dev": true,
 			"requires": {
 				"d": "^1.0.1",
-				"es5-ext": "^0.10.51"
+				"ext": "^1.1.2"
 			}
 		},
 		"escape-html": {
@@ -2559,29 +2553,6 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
 					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-					"dev": true
-				}
-			}
-		},
-		"eslint-plugin-compat": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-compat/-/eslint-plugin-compat-3.3.0.tgz",
-			"integrity": "sha512-QCgYy3pZ+zH10dkBJus1xER0359h1UhJjufhQRqp9Owm6BEoLZeSqxf2zINwL1OGao9Yc96xPYIW3nQj5HUryg==",
-			"dev": true,
-			"requires": {
-				"@babel/runtime": "^7.4.5",
-				"ast-metadata-inferer": "^0.1.1",
-				"browserslist": "^4.6.3",
-				"caniuse-db": "^1.0.30000977",
-				"lodash.memoize": "4.1.2",
-				"mdn-browser-compat-data": "^0.0.84",
-				"semver": "^6.1.2"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
 					"dev": true
 				}
 			}
@@ -2943,6 +2914,12 @@
 					"dev": true
 				}
 			}
+		},
+		"ethereumjs-common": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/ethereumjs-common/-/ethereumjs-common-1.4.0.tgz",
+			"integrity": "sha512-ser2SAplX/YI5W2AnzU8wmSjKRy4KQd4uxInJ36BzjS3m18E/B9QedPUIresZN1CSEQb/RgNQ2gN7C/XbpTafA==",
+			"dev": true
 		},
 		"ethereumjs-testrpc-sc": {
 			"version": "6.5.1-sc.1",
@@ -3683,10 +3660,35 @@
 				}
 			}
 		},
+		"ethereumjs-tx": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/ethereumjs-tx/-/ethereumjs-tx-2.1.1.tgz",
+			"integrity": "sha512-QtVriNqowCFA19X9BCRPMgdVNJ0/gMBS91TQb1DfrhsbR748g4STwxZptFAwfqehMyrF8rDwB23w87PQwru0wA==",
+			"dev": true,
+			"requires": {
+				"ethereumjs-common": "^1.3.1",
+				"ethereumjs-util": "^6.0.0"
+			}
+		},
+		"ethereumjs-util": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.1.0.tgz",
+			"integrity": "sha512-URESKMFbDeJxnAxPppnk2fN6Y3BIatn9fwn76Lm8bQlt+s52TpG8dN9M66MLPuRAiAOIqL3dfwqWJf0sd0fL0Q==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.11.0",
+				"create-hash": "^1.1.2",
+				"ethjs-util": "0.1.6",
+				"keccak": "^1.0.2",
+				"rlp": "^2.0.0",
+				"safe-buffer": "^5.1.1",
+				"secp256k1": "^3.0.1"
+			}
+		},
 		"ethers": {
-			"version": "4.0.38",
-			"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.38.tgz",
-			"integrity": "sha512-l7l7RIfk2/rIFgRRVLFY3H06S9dhXXPUdMlYm6SCelB6oG+ABmoRig7xSVOLcHLayBfSwssjAAYLKxf1jWhbuQ==",
+			"version": "4.0.39",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.39.tgz",
+			"integrity": "sha512-QVtC8TTUgTrnlQjQvdFJ7fkSWKwp8HVTbKRmrdbVryrPzJHMTf3WSeRNvLF2enGyAFtyHJyFNnjN0fSshcEr9w==",
 			"dev": true,
 			"requires": {
 				"@types/node": "^10.3.2",
@@ -3731,6 +3733,16 @@
 					"integrity": "sha1-UzRK2xRhehP26N0s4okF0cC6MhU=",
 					"dev": true
 				}
+			}
+		},
+		"ethjs-util": {
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/ethjs-util/-/ethjs-util-0.1.6.tgz",
+			"integrity": "sha512-CUnVOQq7gSpDHZVVrQW8ExxUETWrnrvXYvYz55wOU8Uj4VCgw56XC2B/fVqQN+f7gmrnRHSLVnFAwsCuNwji8w==",
+			"dev": true,
+			"requires": {
+				"is-hex-prefixed": "1.0.0",
+				"strip-hex-prefix": "1.0.0"
 			}
 		},
 		"eventemitter3": {
@@ -3849,6 +3861,23 @@
 				}
 			}
 		},
+		"ext": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/ext/-/ext-1.1.2.tgz",
+			"integrity": "sha512-/KLjJdTNyDepCihrk4HQt57nAE1IRCEo5jUt+WgWGCr1oARhibDvmI2DMcSNWood1T9AUWwq+jaV1wvRqaXfnA==",
+			"dev": true,
+			"requires": {
+				"type": "^2.0.0"
+			},
+			"dependencies": {
+				"type": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/type/-/type-2.0.0.tgz",
+					"integrity": "sha512-KBt58xCHry4Cejnc2ISQAF7QY+ORngsWfxezO68+12hKV6lQY8P/psIkcbjeHWn7MqcgciWJyCCevFMJdIXpow==",
+					"dev": true
+				}
+			}
+		},
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -3963,6 +3992,12 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/file-type/-/file-type-5.2.0.tgz",
 			"integrity": "sha1-LdvqfHP/42No365J3DOMBYwritY=",
+			"dev": true
+		},
+		"file-uri-to-path": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
 			"dev": true
 		},
 		"filename-regex": {
@@ -5681,12 +5716,11 @@
 			"dev": true
 		},
 		"handlebars": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.0.tgz",
-			"integrity": "sha512-yss1ZbupTpRfe86dpM1abxnnSfxa6eIRn3laqBPIgRYy87qgYtX6xinSOeybjYo/4AVzdTTWK5Kr06A6AllxJg==",
+			"version": "4.5.1",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+			"integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
 			"dev": true,
 			"requires": {
-				"eslint-plugin-compat": "^3.3.0",
 				"neo-async": "^2.6.0",
 				"optimist": "^0.6.1",
 				"source-map": "^0.6.1",
@@ -6720,6 +6754,18 @@
 				"verror": "1.10.0"
 			}
 		},
+		"keccak": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/keccak/-/keccak-1.4.0.tgz",
+			"integrity": "sha512-eZVaCpblK5formjPjeTBik7TAg+pqnDrMHIffSvi9Lh7PQgM1+hSzakUeZFCk9DVVG0dacZJuaz2ntwlzZUIBw==",
+			"dev": true,
+			"requires": {
+				"bindings": "^1.2.1",
+				"inherits": "^2.0.3",
+				"nan": "^2.2.1",
+				"safe-buffer": "^5.1.0"
+			}
+		},
 		"keccakjs": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/keccakjs/-/keccakjs-0.2.3.tgz",
@@ -6860,12 +6906,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
 			"integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
 		},
-		"lodash.memoize": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4=",
-			"dev": true
-		},
 		"lodash.toarray": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/lodash.toarray/-/lodash.toarray-4.4.0.tgz",
@@ -6994,15 +7034,6 @@
 				"hash-base": "^3.0.0",
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.1.2"
-			}
-		},
-		"mdn-browser-compat-data": {
-			"version": "0.0.84",
-			"resolved": "https://registry.npmjs.org/mdn-browser-compat-data/-/mdn-browser-compat-data-0.0.84.tgz",
-			"integrity": "sha512-fAznuGNaQMQiWLVf+gyp33FaABTglYWqMT7JqvH+4RZn2UQPD12gbMqxwP9m0lj8AAbNpu5/kD6n4Ox1SOffpw==",
-			"dev": true,
-			"requires": {
-				"extend": "3.0.2"
 			}
 		},
 		"media-typer": {
@@ -7294,9 +7325,9 @@
 			}
 		},
 		"mock-fs": {
-			"version": "4.10.2",
-			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.2.tgz",
-			"integrity": "sha512-ewPQ83O4U8/Gd8I15WoB6vgTTmq5khxBskUWCRvswUqjCfOOTREmxllztQOm+PXMWUxATry+VBWXQJloAyxtbQ==",
+			"version": "4.10.3",
+			"resolved": "https://registry.npmjs.org/mock-fs/-/mock-fs-4.10.3.tgz",
+			"integrity": "sha512-bcukePBvuA3qovmq0Qtqu9+1APCIGkFHnsozrPIVromt5XFGGgkQSfaN0H6RI8gStHkO/hRgimvS3tooNes4pQ==",
 			"dev": true
 		},
 		"move-concurrently": {
@@ -7469,23 +7500,6 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
-		"node-releases": {
-			"version": "1.1.39",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.39.tgz",
-			"integrity": "sha512-8MRC/ErwNCHOlAFycy9OPca46fQYUjbJRDcZTHVWIGXIjYLM73k70vv3WkYutVnM4cCo4hE0MqBVVZjP6vjISA==",
-			"dev": true,
-			"requires": {
-				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
-			}
-		},
 		"nopt": {
 			"version": "3.0.6",
 			"resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
@@ -7528,9 +7542,9 @@
 			"dev": true
 		},
 		"npm-check-updates": {
-			"version": "3.1.25",
-			"resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-3.1.25.tgz",
-			"integrity": "sha512-B2tAgclEby1VyoN4cZp5Zm+iam72jQV1c2uZIcoNwB0cBbJQZaI1Xj+uxkYkoDs2w4DuaM1hQUavIZgfGKkCgg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-3.2.0.tgz",
+			"integrity": "sha512-Gqxd6Fv+EoGNKg2thclx3LPs9dHa1Tp/R+/59iYAgbliJ5NsDd/D6j6kjhnLtKh+7XMX7co3gTrVzsSqTPNRAg==",
 			"dev": true,
 			"requires": {
 				"chalk": "^2.4.2",
@@ -7999,9 +8013,9 @@
 			}
 		},
 		"pacote": {
-			"version": "9.5.8",
-			"resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.8.tgz",
-			"integrity": "sha512-0Tl8Oi/K0Lo4MZmH0/6IsT3gpGf9eEAznLXEQPKgPq7FscnbUOyopnVpwXlnQdIbCUaojWy1Wd7VMyqfVsRrIw==",
+			"version": "9.5.9",
+			"resolved": "https://registry.npmjs.org/pacote/-/pacote-9.5.9.tgz",
+			"integrity": "sha512-S1nYW9ly+3btn3VmwRAk2LG3TEh8mkrFdY+psbnHSk8oPODbZ28uG0Z0d3yI0EpqcpLR6BukoVRf3H4IbGCkPQ==",
 			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.3",
@@ -8578,9 +8592,9 @@
 			}
 		},
 		"rc-config-loader": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-2.0.4.tgz",
-			"integrity": "sha512-k06UzRbYDWgF4Mc/YrsZsmzSpDLuHoThJxep+vq5H09hiX8rbA5Ue/Ra0dwWm5MQvWYW4YBXgA186inNxuxidQ==",
+			"version": "2.0.5",
+			"resolved": "https://registry.npmjs.org/rc-config-loader/-/rc-config-loader-2.0.5.tgz",
+			"integrity": "sha512-T464K2MQlnNWOblUDIglpFhyN+zYJq7jSlL++/N0hUkcmIXeNFumwXFVdtf8qhUGohn4RYQ0wdi74R575I44PQ==",
 			"dev": true,
 			"requires": {
 				"debug": "^4.1.1",
@@ -9126,33 +9140,33 @@
 			}
 		},
 		"request-promise": {
-			"version": "4.2.4",
-			"resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.4.tgz",
-			"integrity": "sha512-8wgMrvE546PzbR5WbYxUQogUnUDfM0S7QIFZMID+J73vdFARkFy+HElj4T+MWYhpXwlLp0EQ8Zoj8xUA0he4Vg==",
+			"version": "4.2.5",
+			"resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.5.tgz",
+			"integrity": "sha512-ZgnepCykFdmpq86fKGwqntyTiUrHycALuGggpyCZwMvGaZWgxW6yagT0FHkgo5LzYvOaCNvxYwWYIjevSH1EDg==",
 			"dev": true,
 			"requires": {
 				"bluebird": "^3.5.0",
-				"request-promise-core": "1.1.2",
+				"request-promise-core": "1.1.3",
 				"stealthy-require": "^1.1.1",
 				"tough-cookie": "^2.3.3"
 			}
 		},
 		"request-promise-core": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.2.tgz",
-			"integrity": "sha512-UHYyq1MO8GsefGEt7EprS8UrXsm1TxEvFUX1IMTuSLU2Rh7fTIdFtl8xD7JiEYiWU2dl+NYAjCTksTehQUxPag==",
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.3.tgz",
+			"integrity": "sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==",
 			"dev": true,
 			"requires": {
-				"lodash": "^4.17.11"
+				"lodash": "^4.17.15"
 			}
 		},
 		"request-promise-native": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.7.tgz",
-			"integrity": "sha512-rIMnbBdgNViL37nZ1b3L/VfPOpSi0TqVDQPAvO6U14lMzOLrt5nilxCQqtDKhZeDiW0/hkCXGoQjhgJd/tCh6w==",
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/request-promise-native/-/request-promise-native-1.0.8.tgz",
+			"integrity": "sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==",
 			"dev": true,
 			"requires": {
-				"request-promise-core": "1.1.2",
+				"request-promise-core": "1.1.3",
 				"stealthy-require": "^1.1.1",
 				"tough-cookie": "^2.3.3"
 			}
@@ -9263,6 +9277,15 @@
 				"inherits": "^2.0.1"
 			}
 		},
+		"rlp": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.4.tgz",
+			"integrity": "sha512-fdq2yYCWpAQBhwkZv+Z8o/Z4sPmYm1CUq6P7n6lVTOdb949CnqA0sndXal5C1NleSVSZm6q5F3iEbauyVln/iw==",
+			"dev": true,
+			"requires": {
+				"bn.js": "^4.11.1"
+			}
+		},
 		"run-async": {
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
@@ -9316,11 +9339,67 @@
 			"integrity": "sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=",
 			"dev": true
 		},
+		"scrypt-shim": {
+			"version": "github:web3-js/scrypt-shim#be5e616323a8b5e568788bf94d03c1b8410eac54",
+			"from": "github:web3-js/scrypt-shim",
+			"dev": true,
+			"requires": {
+				"scryptsy": "^2.1.0",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+					"dev": true
+				}
+			}
+		},
 		"scryptsy": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/scryptsy/-/scryptsy-2.1.0.tgz",
 			"integrity": "sha512-1CdSqHQowJBnMAFyPEBRfqag/YP9OF394FV+4YREIJX4ljD7OxvQRDayyoyyCk+senRjSkP6VnUNQmVQqB6g7w==",
 			"dev": true
+		},
+		"secp256k1": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-3.7.1.tgz",
+			"integrity": "sha512-1cf8sbnRreXrQFdH6qsg2H71Xw91fCCS9Yp021GnUNJzWJS/py96fS4lHbnTnouLp08Xj6jBoBB6V78Tdbdu5g==",
+			"dev": true,
+			"requires": {
+				"bindings": "^1.5.0",
+				"bip66": "^1.1.5",
+				"bn.js": "^4.11.8",
+				"create-hash": "^1.2.0",
+				"drbg.js": "^1.0.1",
+				"elliptic": "^6.4.1",
+				"nan": "^2.14.0",
+				"safe-buffer": "^5.1.2"
+			},
+			"dependencies": {
+				"elliptic": {
+					"version": "6.5.1",
+					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+					"integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
+					"dev": true,
+					"requires": {
+						"bn.js": "^4.4.0",
+						"brorand": "^1.0.1",
+						"hash.js": "^1.0.0",
+						"hmac-drbg": "^1.0.0",
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0",
+						"minimalistic-crypto-utils": "^1.0.0"
+					}
+				},
+				"nan": {
+					"version": "2.14.0",
+					"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+					"integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+					"dev": true
+				}
+			}
 		},
 		"seedrandom": {
 			"version": "2.4.4",
@@ -9858,17 +9937,6 @@
 						"minimalistic-crypto-utils": "^1.0.0"
 					}
 				},
-				"eth-lib": {
-					"version": "0.2.8",
-					"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
-					"integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
-					"dev": true,
-					"requires": {
-						"bn.js": "^4.11.6",
-						"elliptic": "^6.4.0",
-						"xhr-request-promise": "^0.1.2"
-					}
-				},
 				"req-cwd": {
 					"version": "1.0.1",
 					"resolved": "https://registry.npmjs.org/req-cwd/-/req-cwd-1.0.1.tgz",
@@ -9893,11 +9961,20 @@
 					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
 					"dev": true
 				},
-				"utf8": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
-					"integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
-					"dev": true
+				"web3": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/web3/-/web3-1.2.1.tgz",
+					"integrity": "sha512-nNMzeCK0agb5i/oTWNdQ1aGtwYfXzHottFP2Dz0oGIzavPMGSKyVlr8ibVb1yK5sJBjrWVnTdGaOC2zKDFuFRw==",
+					"dev": true,
+					"requires": {
+						"web3-bzz": "1.2.1",
+						"web3-core": "1.2.1",
+						"web3-eth": "1.2.1",
+						"web3-eth-personal": "1.2.1",
+						"web3-net": "1.2.1",
+						"web3-shh": "1.2.1",
+						"web3-utils": "1.2.1"
+					}
 				},
 				"web3-eth-abi": {
 					"version": "1.0.0-beta.55",
@@ -9909,24 +9986,58 @@
 						"ethers": "^4.0.27",
 						"lodash": "^4.17.11",
 						"web3-utils": "1.0.0-beta.55"
+					},
+					"dependencies": {
+						"eth-lib": {
+							"version": "0.2.8",
+							"resolved": "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz",
+							"integrity": "sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==",
+							"dev": true,
+							"requires": {
+								"bn.js": "^4.11.6",
+								"elliptic": "^6.4.0",
+								"xhr-request-promise": "^0.1.2"
+							}
+						},
+						"utf8": {
+							"version": "2.1.1",
+							"resolved": "https://registry.npmjs.org/utf8/-/utf8-2.1.1.tgz",
+							"integrity": "sha1-LgHbAvfY0JRPdxBPFgnrDDBM92g=",
+							"dev": true
+						},
+						"web3-utils": {
+							"version": "1.0.0-beta.55",
+							"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.55.tgz",
+							"integrity": "sha512-ASWqUi8gtWK02Tp8ZtcoAbHenMpQXNvHrakgzvqTNNZn26wgpv+Q4mdPi0KOR6ZgHFL8R/9b5BBoUTglS1WPpg==",
+							"dev": true,
+							"requires": {
+								"@babel/runtime": "^7.3.1",
+								"@types/bn.js": "^4.11.4",
+								"@types/node": "^10.12.18",
+								"bn.js": "4.11.8",
+								"eth-lib": "0.2.8",
+								"ethjs-unit": "^0.1.6",
+								"lodash": "^4.17.11",
+								"number-to-bn": "1.7.0",
+								"randombytes": "^2.1.0",
+								"utf8": "2.1.1"
+							}
+						}
 					}
 				},
 				"web3-utils": {
-					"version": "1.0.0-beta.55",
-					"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.0.0-beta.55.tgz",
-					"integrity": "sha512-ASWqUi8gtWK02Tp8ZtcoAbHenMpQXNvHrakgzvqTNNZn26wgpv+Q4mdPi0KOR6ZgHFL8R/9b5BBoUTglS1WPpg==",
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+					"integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
 					"dev": true,
 					"requires": {
-						"@babel/runtime": "^7.3.1",
-						"@types/bn.js": "^4.11.4",
-						"@types/node": "^10.12.18",
 						"bn.js": "4.11.8",
-						"eth-lib": "0.2.8",
-						"ethjs-unit": "^0.1.6",
-						"lodash": "^4.17.11",
+						"eth-lib": "0.2.7",
+						"ethjs-unit": "0.1.6",
 						"number-to-bn": "1.7.0",
-						"randombytes": "^2.1.0",
-						"utf8": "2.1.1"
+						"randomhex": "0.1.5",
+						"underscore": "1.9.1",
+						"utf8": "3.0.0"
 					}
 				}
 			}
@@ -10329,9 +10440,9 @@
 			}
 		},
 		"source-map-support": {
-			"version": "0.5.13",
-			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-			"integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+			"version": "0.5.16",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+			"integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
 			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
@@ -10942,9 +11053,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "8.10.56",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.56.tgz",
-					"integrity": "sha512-5yWs9hy3UWdandOgvmmPCNJ3jI5/o8syatQWOmiAO/9/PptOQ+0O2ANKHltFhE4MGCt/QiVkoxQFUbeha9Yf4w==",
+					"version": "8.10.58",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.58.tgz",
+					"integrity": "sha512-NNcUk/rAdR7Pie7WiA5NHp345dTkD62qaxqscQXVIjCjog/ZXsrG8Wo7dZMZAzE7PSpA+qR2S3TYTeFCKuBFxQ==",
 					"dev": true
 				}
 			}
@@ -11097,9 +11208,9 @@
 			"dev": true
 		},
 		"truffle": {
-			"version": "5.0.41",
-			"resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.41.tgz",
-			"integrity": "sha512-vQm7OHRN8qh4Te3QZ9A74JsDoZfcYoJLuI1FrcLpJoicdTrzCZU4UXGIYFUIZ+UmOTlMS07lUufxDSraSHxpdg==",
+			"version": "5.0.43",
+			"resolved": "https://registry.npmjs.org/truffle/-/truffle-5.0.43.tgz",
+			"integrity": "sha512-PbqOjgtYlkNAbJqzHeiMGvgBCLSuPVAWbM4+TNIGsRyqVCRIvXdLeQXUmdCRcGMWMteCvQ9Knhu4zNzT2Eo53A==",
 			"dev": true,
 			"requires": {
 				"app-module-path": "^2.2.0",
@@ -11194,9 +11305,9 @@
 			}
 		},
 		"uglify-js": {
-			"version": "3.6.4",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.4.tgz",
-			"integrity": "sha512-9Yc2i881pF4BPGhjteCXQNaXx1DCwm3dtOyBaG2hitHjLWOczw/ki8vD1bqyT3u6K0Ms/FpCShkmfg+FtlOfYA==",
+			"version": "3.6.8",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
+			"integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
 			"dev": true,
 			"optional": true,
 			"requires": {
@@ -11480,18 +11591,278 @@
 			}
 		},
 		"web3": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/web3/-/web3-1.2.1.tgz",
-			"integrity": "sha512-nNMzeCK0agb5i/oTWNdQ1aGtwYfXzHottFP2Dz0oGIzavPMGSKyVlr8ibVb1yK5sJBjrWVnTdGaOC2zKDFuFRw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/web3/-/web3-1.2.2.tgz",
+			"integrity": "sha512-/ChbmB6qZpfGx6eNpczt5YSUBHEA5V2+iUCbn85EVb3Zv6FVxrOo5Tv7Lw0gE2tW7EEjASbCyp3mZeiZaCCngg==",
 			"dev": true,
 			"requires": {
-				"web3-bzz": "1.2.1",
-				"web3-core": "1.2.1",
-				"web3-eth": "1.2.1",
-				"web3-eth-personal": "1.2.1",
-				"web3-net": "1.2.1",
-				"web3-shh": "1.2.1",
-				"web3-utils": "1.2.1"
+				"@types/node": "^12.6.1",
+				"web3-bzz": "1.2.2",
+				"web3-core": "1.2.2",
+				"web3-eth": "1.2.2",
+				"web3-eth-personal": "1.2.2",
+				"web3-net": "1.2.2",
+				"web3-shh": "1.2.2",
+				"web3-utils": "1.2.2"
+			},
+			"dependencies": {
+				"@types/node": {
+					"version": "12.12.6",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.6.tgz",
+					"integrity": "sha512-FjsYUPzEJdGXjwKqSpE0/9QEh6kzhTAeObA54rn6j3rR4C/mzpI9L0KNfoeASSPMMdxIsoJuCLDWcM/rVjIsSA==",
+					"dev": true
+				},
+				"uuid": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+					"dev": true
+				},
+				"web3-bzz": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.2.2.tgz",
+					"integrity": "sha512-b1O2ObsqUN1lJxmFSjvnEC4TsaCbmh7Owj3IAIWTKqL9qhVgx7Qsu5O9cD13pBiSPNZJ68uJPaKq380QB4NWeA==",
+					"dev": true,
+					"requires": {
+						"@types/node": "^10.12.18",
+						"got": "9.6.0",
+						"swarm-js": "0.1.39",
+						"underscore": "1.9.1"
+					},
+					"dependencies": {
+						"@types/node": {
+							"version": "10.17.4",
+							"resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.4.tgz",
+							"integrity": "sha512-F2pgg+LcIr/elguz+x+fdBX5KeZXGUOp7TV8M0TVIrDezYLFRNt8oMTyps0VQ1kj5WGGoR18RdxnRDHXrIFHMQ==",
+							"dev": true
+						}
+					}
+				},
+				"web3-core": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.2.2.tgz",
+					"integrity": "sha512-miHAX3qUgxV+KYfaOY93Hlc3kLW2j5fH8FJy6kSxAv+d4d5aH0wwrU2IIoJylQdT+FeenQ38sgsCnFu9iZ1hCQ==",
+					"dev": true,
+					"requires": {
+						"@types/bn.js": "^4.11.4",
+						"@types/node": "^12.6.1",
+						"web3-core-helpers": "1.2.2",
+						"web3-core-method": "1.2.2",
+						"web3-core-requestmanager": "1.2.2",
+						"web3-utils": "1.2.2"
+					}
+				},
+				"web3-core-helpers": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.2.2.tgz",
+					"integrity": "sha512-HJrRsIGgZa1jGUIhvGz4S5Yh6wtOIo/TMIsSLe+Xay+KVnbseJpPprDI5W3s7H2ODhMQTbogmmUFquZweW2ImQ==",
+					"dev": true,
+					"requires": {
+						"underscore": "1.9.1",
+						"web3-eth-iban": "1.2.2",
+						"web3-utils": "1.2.2"
+					}
+				},
+				"web3-core-method": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.2.2.tgz",
+					"integrity": "sha512-szR4fDSBxNHaF1DFqE+j6sFR/afv9Aa36OW93saHZnrh+iXSrYeUUDfugeNcRlugEKeUCkd4CZylfgbK2SKYJA==",
+					"dev": true,
+					"requires": {
+						"underscore": "1.9.1",
+						"web3-core-helpers": "1.2.2",
+						"web3-core-promievent": "1.2.2",
+						"web3-core-subscriptions": "1.2.2",
+						"web3-utils": "1.2.2"
+					}
+				},
+				"web3-core-promievent": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.2.2.tgz",
+					"integrity": "sha512-tKvYeT8bkUfKABcQswK6/X79blKTKYGk949urZKcLvLDEaWrM3uuzDwdQT3BNKzQ3vIvTggFPX9BwYh0F1WwqQ==",
+					"dev": true,
+					"requires": {
+						"any-promise": "1.3.0",
+						"eventemitter3": "3.1.2"
+					}
+				},
+				"web3-core-requestmanager": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.2.2.tgz",
+					"integrity": "sha512-a+gSbiBRHtHvkp78U2bsntMGYGF2eCb6219aMufuZWeAZGXJ63Wc2321PCbA8hF9cQrZI4EoZ4kVLRI4OF15Hw==",
+					"dev": true,
+					"requires": {
+						"underscore": "1.9.1",
+						"web3-core-helpers": "1.2.2",
+						"web3-providers-http": "1.2.2",
+						"web3-providers-ipc": "1.2.2",
+						"web3-providers-ws": "1.2.2"
+					}
+				},
+				"web3-core-subscriptions": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.2.2.tgz",
+					"integrity": "sha512-QbTgigNuT4eicAWWr7ahVpJyM8GbICsR1Ys9mJqzBEwpqS+RXTRVSkwZ2IsxO+iqv6liMNwGregbJLq4urMFcQ==",
+					"dev": true,
+					"requires": {
+						"eventemitter3": "3.1.2",
+						"underscore": "1.9.1",
+						"web3-core-helpers": "1.2.2"
+					}
+				},
+				"web3-eth": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.2.2.tgz",
+					"integrity": "sha512-UXpC74mBQvZzd4b+baD4Ocp7g+BlwxhBHumy9seyE/LMIcMlePXwCKzxve9yReNpjaU16Mmyya6ZYlyiKKV8UA==",
+					"dev": true,
+					"requires": {
+						"underscore": "1.9.1",
+						"web3-core": "1.2.2",
+						"web3-core-helpers": "1.2.2",
+						"web3-core-method": "1.2.2",
+						"web3-core-subscriptions": "1.2.2",
+						"web3-eth-abi": "1.2.2",
+						"web3-eth-accounts": "1.2.2",
+						"web3-eth-contract": "1.2.2",
+						"web3-eth-ens": "1.2.2",
+						"web3-eth-iban": "1.2.2",
+						"web3-eth-personal": "1.2.2",
+						"web3-net": "1.2.2",
+						"web3-utils": "1.2.2"
+					}
+				},
+				"web3-eth-accounts": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.2.2.tgz",
+					"integrity": "sha512-KzHOEyXOEZ13ZOkWN3skZKqSo5f4Z1ogPFNn9uZbKCz+kSp+gCAEKxyfbOsB/JMAp5h7o7pb6eYsPCUBJmFFiA==",
+					"dev": true,
+					"requires": {
+						"any-promise": "1.3.0",
+						"crypto-browserify": "3.12.0",
+						"eth-lib": "0.2.7",
+						"ethereumjs-common": "^1.3.2",
+						"ethereumjs-tx": "^2.1.1",
+						"scrypt-shim": "github:web3-js/scrypt-shim",
+						"underscore": "1.9.1",
+						"uuid": "3.3.2",
+						"web3-core": "1.2.2",
+						"web3-core-helpers": "1.2.2",
+						"web3-core-method": "1.2.2",
+						"web3-utils": "1.2.2"
+					}
+				},
+				"web3-eth-contract": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.2.2.tgz",
+					"integrity": "sha512-EKT2yVFws3FEdotDQoNsXTYL798+ogJqR2//CaGwx3p0/RvQIgfzEwp8nbgA6dMxCsn9KOQi7OtklzpnJMkjtA==",
+					"dev": true,
+					"requires": {
+						"@types/bn.js": "^4.11.4",
+						"underscore": "1.9.1",
+						"web3-core": "1.2.2",
+						"web3-core-helpers": "1.2.2",
+						"web3-core-method": "1.2.2",
+						"web3-core-promievent": "1.2.2",
+						"web3-core-subscriptions": "1.2.2",
+						"web3-eth-abi": "1.2.2",
+						"web3-utils": "1.2.2"
+					}
+				},
+				"web3-eth-ens": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.2.2.tgz",
+					"integrity": "sha512-CFjkr2HnuyMoMFBoNUWojyguD4Ef+NkyovcnUc/iAb9GP4LHohKrODG4pl76R5u61TkJGobC2ij6TyibtsyVYg==",
+					"dev": true,
+					"requires": {
+						"eth-ens-namehash": "2.0.8",
+						"underscore": "1.9.1",
+						"web3-core": "1.2.2",
+						"web3-core-helpers": "1.2.2",
+						"web3-core-promievent": "1.2.2",
+						"web3-eth-abi": "1.2.2",
+						"web3-eth-contract": "1.2.2",
+						"web3-utils": "1.2.2"
+					}
+				},
+				"web3-eth-iban": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.2.2.tgz",
+					"integrity": "sha512-gxKXBoUhaTFHr0vJB/5sd4i8ejF/7gIsbM/VvemHT3tF5smnmY6hcwSMmn7sl5Gs+83XVb/BngnnGkf+I/rsrQ==",
+					"dev": true,
+					"requires": {
+						"bn.js": "4.11.8",
+						"web3-utils": "1.2.2"
+					}
+				},
+				"web3-eth-personal": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.2.2.tgz",
+					"integrity": "sha512-4w+GLvTlFqW3+q4xDUXvCEMU7kRZ+xm/iJC8gm1Li1nXxwwFbs+Y+KBK6ZYtoN1qqAnHR+plYpIoVo27ixI5Rg==",
+					"dev": true,
+					"requires": {
+						"@types/node": "^12.6.1",
+						"web3-core": "1.2.2",
+						"web3-core-helpers": "1.2.2",
+						"web3-core-method": "1.2.2",
+						"web3-net": "1.2.2",
+						"web3-utils": "1.2.2"
+					}
+				},
+				"web3-net": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.2.2.tgz",
+					"integrity": "sha512-K07j2DXq0x4UOJgae65rWZKraOznhk8v5EGSTdFqASTx7vWE/m+NqBijBYGEsQY1lSMlVaAY9UEQlcXK5HzXTw==",
+					"dev": true,
+					"requires": {
+						"web3-core": "1.2.2",
+						"web3-core-method": "1.2.2",
+						"web3-utils": "1.2.2"
+					}
+				},
+				"web3-providers-http": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.2.2.tgz",
+					"integrity": "sha512-BNZ7Hguy3eBszsarH5gqr9SIZNvqk9eKwqwmGH1LQS1FL3NdoOn7tgPPdddrXec4fL94CwgNk4rCU+OjjZRNDg==",
+					"dev": true,
+					"requires": {
+						"web3-core-helpers": "1.2.2",
+						"xhr2-cookies": "1.1.0"
+					}
+				},
+				"web3-providers-ipc": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.2.2.tgz",
+					"integrity": "sha512-t97w3zi5Kn/LEWGA6D9qxoO0LBOG+lK2FjlEdCwDQatffB/+vYrzZ/CLYVQSoyFZAlsDoBasVoYSWZK1n39aHA==",
+					"dev": true,
+					"requires": {
+						"oboe": "2.1.4",
+						"underscore": "1.9.1",
+						"web3-core-helpers": "1.2.2"
+					}
+				},
+				"web3-providers-ws": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.2.2.tgz",
+					"integrity": "sha512-Wb1mrWTGMTXOpJkL0yGvL/WYLt8fUIXx8k/l52QB2IiKzvyd42dTWn4+j8IKXGSYYzOm7NMqv6nhA5VDk12VfA==",
+					"dev": true,
+					"requires": {
+						"underscore": "1.9.1",
+						"web3-core-helpers": "1.2.2",
+						"websocket": "github:web3-js/WebSocket-Node#polyfill/globalThis"
+					}
+				},
+				"web3-shh": {
+					"version": "1.2.2",
+					"resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.2.2.tgz",
+					"integrity": "sha512-og258NPhlBn8yYrDWjoWBBb6zo1OlBgoWGT+LL5/LPqRbjPe09hlOYHgscAAr9zZGtohTOty7RrxYw6Z6oDWCg==",
+					"dev": true,
+					"requires": {
+						"web3-core": "1.2.2",
+						"web3-core-method": "1.2.2",
+						"web3-core-subscriptions": "1.2.2",
+						"web3-net": "1.2.2"
+					}
+				}
 			}
 		},
 		"web3-bzz": {
@@ -11515,6 +11886,23 @@
 				"web3-core-method": "1.2.1",
 				"web3-core-requestmanager": "1.2.1",
 				"web3-utils": "1.2.1"
+			},
+			"dependencies": {
+				"web3-utils": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+					"integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+					"dev": true,
+					"requires": {
+						"bn.js": "4.11.8",
+						"eth-lib": "0.2.7",
+						"ethjs-unit": "0.1.6",
+						"number-to-bn": "1.7.0",
+						"randomhex": "0.1.5",
+						"underscore": "1.9.1",
+						"utf8": "3.0.0"
+					}
+				}
 			}
 		},
 		"web3-core-helpers": {
@@ -11526,6 +11914,23 @@
 				"underscore": "1.9.1",
 				"web3-eth-iban": "1.2.1",
 				"web3-utils": "1.2.1"
+			},
+			"dependencies": {
+				"web3-utils": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+					"integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+					"dev": true,
+					"requires": {
+						"bn.js": "4.11.8",
+						"eth-lib": "0.2.7",
+						"ethjs-unit": "0.1.6",
+						"number-to-bn": "1.7.0",
+						"randomhex": "0.1.5",
+						"underscore": "1.9.1",
+						"utf8": "3.0.0"
+					}
+				}
 			}
 		},
 		"web3-core-method": {
@@ -11539,6 +11944,23 @@
 				"web3-core-promievent": "1.2.1",
 				"web3-core-subscriptions": "1.2.1",
 				"web3-utils": "1.2.1"
+			},
+			"dependencies": {
+				"web3-utils": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+					"integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+					"dev": true,
+					"requires": {
+						"bn.js": "4.11.8",
+						"eth-lib": "0.2.7",
+						"ethjs-unit": "0.1.6",
+						"number-to-bn": "1.7.0",
+						"randomhex": "0.1.5",
+						"underscore": "1.9.1",
+						"utf8": "3.0.0"
+					}
+				}
 			}
 		},
 		"web3-core-promievent": {
@@ -11630,6 +12052,21 @@
 						"underscore": "1.9.1",
 						"web3-utils": "1.2.1"
 					}
+				},
+				"web3-utils": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+					"integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+					"dev": true,
+					"requires": {
+						"bn.js": "4.11.8",
+						"eth-lib": "0.2.7",
+						"ethjs-unit": "0.1.6",
+						"number-to-bn": "1.7.0",
+						"randomhex": "0.1.5",
+						"underscore": "1.9.1",
+						"utf8": "3.0.0"
+					}
 				}
 			}
 		},
@@ -11667,22 +12104,6 @@
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
 					"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
 					"dev": true
-				},
-				"web3-utils": {
-					"version": "1.2.2",
-					"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
-					"integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
-					"dev": true,
-					"requires": {
-						"bn.js": "4.11.8",
-						"eth-lib": "0.2.7",
-						"ethereum-bloom-filters": "^1.0.6",
-						"ethjs-unit": "0.1.6",
-						"number-to-bn": "1.7.0",
-						"randombytes": "^2.1.0",
-						"underscore": "1.9.1",
-						"utf8": "3.0.0"
-					}
 				}
 			}
 		},
@@ -11716,6 +12137,21 @@
 					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
 					"dev": true
+				},
+				"web3-utils": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+					"integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+					"dev": true,
+					"requires": {
+						"bn.js": "4.11.8",
+						"eth-lib": "0.2.7",
+						"ethjs-unit": "0.1.6",
+						"number-to-bn": "1.7.0",
+						"randomhex": "0.1.5",
+						"underscore": "1.9.1",
+						"utf8": "3.0.0"
+					}
 				}
 			}
 		},
@@ -11768,6 +12204,21 @@
 						"ethers": "4.0.0-beta.3",
 						"underscore": "1.9.1",
 						"web3-utils": "1.2.1"
+					}
+				},
+				"web3-utils": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+					"integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+					"dev": true,
+					"requires": {
+						"bn.js": "4.11.8",
+						"eth-lib": "0.2.7",
+						"ethjs-unit": "0.1.6",
+						"number-to-bn": "1.7.0",
+						"randomhex": "0.1.5",
+						"underscore": "1.9.1",
+						"utf8": "3.0.0"
 					}
 				}
 			}
@@ -11822,6 +12273,21 @@
 						"underscore": "1.9.1",
 						"web3-utils": "1.2.1"
 					}
+				},
+				"web3-utils": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+					"integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+					"dev": true,
+					"requires": {
+						"bn.js": "4.11.8",
+						"eth-lib": "0.2.7",
+						"ethjs-unit": "0.1.6",
+						"number-to-bn": "1.7.0",
+						"randomhex": "0.1.5",
+						"underscore": "1.9.1",
+						"utf8": "3.0.0"
+					}
 				}
 			}
 		},
@@ -11833,6 +12299,23 @@
 			"requires": {
 				"bn.js": "4.11.8",
 				"web3-utils": "1.2.1"
+			},
+			"dependencies": {
+				"web3-utils": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+					"integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+					"dev": true,
+					"requires": {
+						"bn.js": "4.11.8",
+						"eth-lib": "0.2.7",
+						"ethjs-unit": "0.1.6",
+						"number-to-bn": "1.7.0",
+						"randomhex": "0.1.5",
+						"underscore": "1.9.1",
+						"utf8": "3.0.0"
+					}
+				}
 			}
 		},
 		"web3-eth-personal": {
@@ -11846,6 +12329,23 @@
 				"web3-core-method": "1.2.1",
 				"web3-net": "1.2.1",
 				"web3-utils": "1.2.1"
+			},
+			"dependencies": {
+				"web3-utils": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+					"integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+					"dev": true,
+					"requires": {
+						"bn.js": "4.11.8",
+						"eth-lib": "0.2.7",
+						"ethjs-unit": "0.1.6",
+						"number-to-bn": "1.7.0",
+						"randomhex": "0.1.5",
+						"underscore": "1.9.1",
+						"utf8": "3.0.0"
+					}
+				}
 			}
 		},
 		"web3-net": {
@@ -11857,6 +12357,23 @@
 				"web3-core": "1.2.1",
 				"web3-core-method": "1.2.1",
 				"web3-utils": "1.2.1"
+			},
+			"dependencies": {
+				"web3-utils": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
+					"integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+					"dev": true,
+					"requires": {
+						"bn.js": "4.11.8",
+						"eth-lib": "0.2.7",
+						"ethjs-unit": "0.1.6",
+						"number-to-bn": "1.7.0",
+						"randomhex": "0.1.5",
+						"underscore": "1.9.1",
+						"utf8": "3.0.0"
+					}
+				}
 			}
 		},
 		"web3-providers-http": {
@@ -11904,16 +12421,17 @@
 			}
 		},
 		"web3-utils": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.1.tgz",
-			"integrity": "sha512-Mrcn3l58L+yCKz3zBryM6JZpNruWuT0OCbag8w+reeNROSGVlXzUQkU+gtAwc9JCZ7tKUyg67+2YUGqUjVcyBA==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.2.2.tgz",
+			"integrity": "sha512-joF+s3243TY5cL7Z7y4h1JsJpUCf/kmFmj+eJar7Y2yNIGVcW961VyrAms75tjUysSuHaUQ3eQXjBEUJueT52A==",
 			"dev": true,
 			"requires": {
 				"bn.js": "4.11.8",
 				"eth-lib": "0.2.7",
+				"ethereum-bloom-filters": "^1.0.6",
 				"ethjs-unit": "0.1.6",
 				"number-to-bn": "1.7.0",
-				"randomhex": "0.1.5",
+				"randombytes": "^2.1.0",
 				"underscore": "1.9.1",
 				"utf8": "3.0.0"
 			}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 		"coverage": "solidity-coverage",
 		"ganache": "ganache-cli -e 1000000000000 -l 8000000 -t 2018-03-13T00:00:00",
 		"ganache:int": "npm run ganache -- --acctKeys keys.json",
-		"lint": "solhint contracts/**/*.sol && eslint \"**/*.js\"",
+		"lint": "solhint \"contracts/**/*.sol\" && eslint \"**/*.js\"",
 		"lint:fix": "eslint --fix \"**/*.js\"",
 		"test": "concurrently --kill-others --success first \"npm run ganache > /dev/null\" \"truffle compile && wait-port 8545 && truffle test\"",
 		"test:gas": "npm test; EXIT_CODE=$?; cat test-gas-used.log; printf \"\\n\"; exit $EXIT_CODE;",
@@ -75,11 +75,11 @@
 		"solidity-coverage": "0.6.7",
 		"solium": "1.1.8",
 		"table": "^5.0.2",
-		"truffle": "5.0.41",
+		"truffle": "5.0.43",
 		"typedarray-to-buffer": "^3.1.5",
 		"wait-port": "^0.2.2",
-		"web3": "1.2.1",
-		"web3-utils": "1.2.1"
+		"web3": "1.2.2",
+		"web3-utils": "1.2.2"
 	},
 	"dependencies": {
 		"commander": "^2.19.0",

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -539,18 +539,18 @@ const deploy = async ({
 	}
 
 	// setup gasLimitOracle on Synthetix
-	// setup exchange gasPriceLimit on Synthetix
-	const gasPriceLimit = w3utils.toWei('35', 'gwei');
-	if (network === 'local') {
-		await runStep({
-			contract: 'Synthetix',
-			target: synthetix,
-			read: 'gasLimitOracle',
-			expected: input => input === oracleGasLimit,
-			write: 'setGasLimitOracle',
-			writeArg: oracleGasLimit,
-		});
+	await runStep({
+		contract: 'Synthetix',
+		target: synthetix,
+		read: 'gasLimitOracle',
+		expected: input => input === oracleGasLimit,
+		write: 'setGasLimitOracle',
+		writeArg: oracleGasLimit,
+	});
 
+	// setup exchange gasPriceLimit on Synthetix for local only
+	if (network === 'local') {
+		const gasPriceLimit = w3utils.toWei('35', 'gwei');
 		await runStep({
 			contract: 'Synthetix',
 			target: synthetix,
@@ -1070,6 +1070,10 @@ module.exports = {
 				'The address of the fee authority for this network (default is to use existing)'
 			)
 			.option('-g, --gas-price <value>', 'Gas price in GWEI', DEFAULTS.gasPrice)
+			.option(
+				'-l, --oracle-gas-limit <value>',
+				'The address of the gas limit oracle for this network (default is use existing)'
+			)
 			.option(
 				'-m, --method-call-gas-limit <value>',
 				'Method call gas limit',

--- a/test/Synthetix.js
+++ b/test/Synthetix.js
@@ -2778,6 +2778,7 @@ contract('Synthetix', async accounts => {
 										from: iBTC,
 										to: sAUD,
 										toContract: sAUDContract,
+										exchangeFeeRateMultiplier: 2,
 									});
 								});
 
@@ -2804,6 +2805,7 @@ contract('Synthetix', async accounts => {
 												from: iBTC,
 												to: sEUR,
 												toContract: sEURContract,
+												exchangeFeeRateMultiplier: 2,
 											});
 										});
 									});
@@ -2822,6 +2824,7 @@ contract('Synthetix', async accounts => {
 												from: iBTC,
 												to: sEUR,
 												toContract: sEURContract,
+												exchangeFeeRateMultiplier: 2,
 											});
 										});
 									});

--- a/test/Synthetix.js
+++ b/test/Synthetix.js
@@ -2693,7 +2693,7 @@ contract('Synthetix', async accounts => {
 							from: oracle,
 						});
 					});
-					describe('when the user tries to mints 1% of their SNX value', () => {
+					describe('when the user tries to mint 1% of their SNX value', () => {
 						const amountIssued = toUnit(1e3);
 						beforeEach(async () => {
 							// Issue
@@ -2703,23 +2703,28 @@ contract('Synthetix', async accounts => {
 							const assertExchangeSucceeded = async ({
 								amountExchanged,
 								txn,
+								exchangeFeeRateMultiplier = 1,
 								from = sUSD,
 								to = iBTC,
 								toContract = iBTCContract,
+								prevBalance,
 							}) => {
 								// Note: this presumes balance was empty before the exchange - won't work when
 								// exchanging into sUSD as there is an existing sUSD balance from minting
 								const exchangeFeeRate = await feePool.exchangeFeeRate();
-								const doubleExchangeFeeRate = multiplyDecimal(exchangeFeeRate, toUnit(2));
-								const actualExchangeFee =
-									from === sUSD || to === sUSD ? exchangeFeeRate : doubleExchangeFeeRate;
+								const actualExchangeFee = multiplyDecimal(
+									exchangeFeeRate,
+									toUnit(exchangeFeeRateMultiplier)
+								);
 								const balance = await toContract.balanceOf(account1);
 								const effectiveValue = await synthetix.effectiveValue(from, amountExchanged, to);
 								const effectiveValueMinusFees = effectiveValue.sub(
 									multiplyDecimal(effectiveValue, actualExchangeFee)
 								);
 
-								assert.bnEqual(balance, effectiveValueMinusFees);
+								const balanceFromExchange = prevBalance ? balance.sub(prevBalance) : balance;
+
+								assert.bnEqual(balanceFromExchange, effectiveValueMinusFees);
 
 								// check logs
 								const synthExchangeEvent = txn.logs.find(log => log.event === 'SynthExchange');
@@ -2731,7 +2736,7 @@ contract('Synthetix', async accounts => {
 										fromCurrencyKey: bytesToString(from),
 										fromAmount: amountExchanged,
 										toCurrencyKey: bytesToString(to),
-										toAmount: balance,
+										toAmount: effectiveValueMinusFees,
 										toAddress: account1,
 									},
 									['toCurrencyKey', 'fromCurrencyKey']
@@ -2753,6 +2758,7 @@ contract('Synthetix', async accounts => {
 									txn: exchangeTxns[0],
 									from: sUSD,
 									to: iBTC,
+									toContract: iBTCContract,
 								});
 							});
 							describe('when the user tries to exchange some iBTC into another synth', () => {
@@ -2821,107 +2827,89 @@ contract('Synthetix', async accounts => {
 									});
 								});
 							});
-							describe('when the user tries to exchange some short iBTC into long sBTC', () => {
-								const iBTCexchangeAmount = toUnit(0.003); // current iBTC balance is a bit under 0.05
-
-								it('then the exchange fee doubles', async () => {
-									// const sBTCBalanceBefore = await sBTCContract.balanceOf(account1);
-									// console.log('account1 sBTCBalanceBefore', sBTCBalanceBefore.toString());
-
-									// Get the fees Before
-									const feePeriodZeroBefore = await feePool.recentFeePeriods(0);
-									// console.log(
-									// 	'feesToDistribute BEFORE',
-									// 	feePeriodZeroBefore.feesToDistribute.toString()
-									// );
-
-									// exchange from inverse to long
-									exchangeTxns.push(
-										await synthetix.exchange(iBTC, iBTCexchangeAmount, sBTC, ZERO_ADDRESS, {
+							describe('doubling of fees for swing trades', () => {
+								const iBTCexchangeAmount = toUnit(0.002); // current iBTC balance is a bit under 0.05
+								let txn;
+								describe('when the user tries to exchange some short iBTC into long sBTC', () => {
+									beforeEach(async () => {
+										txn = await synthetix.exchange(iBTC, iBTCexchangeAmount, sBTC, ZERO_ADDRESS, {
 											from: account1,
-										})
-									);
-
-									// Get the exchange Fee on the exchange amount
-									const iBTCExchangeFee = await feePool.exchangeFeeIncurred(iBTCexchangeAmount);
-									// console.log('iBTCExchangeFee', iBTCExchangeFee.toString());
-
-									// Double the exchangeFee
-									const iBTCExchangeFeeDoubled = iBTCExchangeFee.mul(web3.utils.toBN('2'));
-									// console.log('iBTCExchangeFeeDoubled', iBTCExchangeFeeDoubled.toString());
-
-									// Convert fee to XDR (already doubled)
-									const doubleXDRExchangeFee = await synthetix.effectiveValue(
-										iBTC,
-										iBTCExchangeFeeDoubled,
-										XDR
-									);
-
-									// Assert feesToDistribute now increased by exchangeFeeXDRDouble
-									const feePeriodZeroAfter = await feePool.recentFeePeriods(0);
-
-									const exchangeFeeInFeePool = feePeriodZeroAfter.feesToDistribute.sub(
-										feePeriodZeroBefore.feesToDistribute
-									);
-
-									assert.bnEqual(doubleXDRExchangeFee, exchangeFeeInFeePool);
-
-									// TODO
-									// // Assert account 1 has sBTC - exchangeFeeiBTCDouble
-									const sBTCBalance = await sBTCContract.balanceOf(account1);
-									// // console.log('account1 sBTCBalance', sBTCBalance.toString());
-
-									// // how much sBTC the user is supposed to get
-									const sBTCEffectiveValue = await synthetix.effectiveValue(
-										iBTC,
-										amountExchanged,
-										sBTC
-									);
-									// console.log('iBTC to sBTC effectiveValue', sBTCEffectiveValue.toString());
-									// console.log('exchangeFeeXDRDouble', doubleXDRExchangeFee.toString());
-
-									const effectiveValueMinusFees = sBTCEffectiveValue.sub(iBTCExchangeFeeDoubled);
-									console.log(
-										'iBTC to sBTC effectiveValueMinusFees',
-										effectiveValueMinusFees.toString()
-									);
-									console.log('sBTCBalance', sBTCBalance.toString());
-
-									// assert.bnEqual(effectiveValueMinusFees, sBTCBalance);
+										});
+									});
+									it('then it exchanges correctly from iBTC to sBTC, doubling the fee', async () => {
+										await assertExchangeSucceeded({
+											amountExchanged: iBTCexchangeAmount,
+											txn,
+											exchangeFeeRateMultiplier: 2,
+											from: iBTC,
+											to: sBTC,
+											toContract: sBTCContract,
+										});
+									});
+									describe('when the user tries to exchange some short iBTC into sEUR', () => {
+										beforeEach(async () => {
+											txn = await synthetix.exchange(iBTC, iBTCexchangeAmount, sEUR, ZERO_ADDRESS, {
+												from: account1,
+											});
+										});
+										it('then it exchanges correctly from iBTC to sEUR, doubling the fee', async () => {
+											await assertExchangeSucceeded({
+												amountExchanged: iBTCexchangeAmount,
+												txn,
+												exchangeFeeRateMultiplier: 2,
+												from: iBTC,
+												to: sEUR,
+												toContract: sEURContract,
+											});
+										});
+										describe('when the user tries to exchange some sEUR for iBTC', () => {
+											const sEURExchangeAmount = toUnit(0.001);
+											let prevBalance;
+											beforeEach(async () => {
+												prevBalance = await iBTCContract.balanceOf(account1);
+												txn = await synthetix.exchange(
+													sEUR,
+													sEURExchangeAmount,
+													iBTC,
+													ZERO_ADDRESS,
+													{
+														from: account1,
+													}
+												);
+											});
+											it('then it exchanges correctly from sEUR to iBTC, doubling the fee', async () => {
+												await assertExchangeSucceeded({
+													amountExchanged: sEURExchangeAmount,
+													txn,
+													exchangeFeeRateMultiplier: 2,
+													from: sEUR,
+													to: iBTC,
+													toContract: iBTCContract,
+													prevBalance,
+												});
+											});
+										});
+									});
 								});
-							});
-							describe('when the user tries to exchange some short iBTC into sUSD', () => {
-								const iBTCexchangeAmount = toUnit(0.003); // current iBTC balance is a bit under 0.05
+								describe('when the user tries to exchange some short iBTC for sUSD', () => {
+									let prevBalance;
 
-								it('then the exchange fee equals flat ExchangeFee', async () => {
-									// Get the fees Before
-									const feePeriodZeroBefore = await feePool.recentFeePeriods(0);
-
-									// exchange from inverse to sUSD
-									exchangeTxns.push(
-										await synthetix.exchange(iBTC, iBTCexchangeAmount, sUSD, ZERO_ADDRESS, {
+									beforeEach(async () => {
+										prevBalance = await sUSDContract.balanceOf(account1);
+										txn = await synthetix.exchange(iBTC, iBTCexchangeAmount, sUSD, ZERO_ADDRESS, {
 											from: account1,
-										})
-									);
-
-									// Get the exchange Fee on the exchange amount
-									const iBTCExchangeFee = await feePool.exchangeFeeIncurred(iBTCexchangeAmount);
-
-									// Convert fee to XDR
-									const exchangeFeeInXDR = await synthetix.effectiveValue(
-										iBTC,
-										iBTCExchangeFee,
-										XDR
-									);
-
-									// Assert feesToDistribute now increased by exchangeFeeInXDR
-									const feePeriodZeroAfter = await feePool.recentFeePeriods(0);
-
-									const exchangeFeeInFeePool = feePeriodZeroAfter.feesToDistribute.sub(
-										feePeriodZeroBefore.feesToDistribute
-									);
-
-									assert.bnEqual(exchangeFeeInXDR, exchangeFeeInFeePool);
+										});
+									});
+									it('then it exchanges correctly out of iBTC, with the regular fee', async () => {
+										await assertExchangeSucceeded({
+											amountExchanged: iBTCexchangeAmount,
+											txn,
+											from: iBTC,
+											to: sUSD,
+											toContract: sUSDContract,
+											prevBalance,
+										});
+									});
 								});
 							});
 						});

--- a/truffle.js
+++ b/truffle.js
@@ -1,7 +1,7 @@
 module.exports = {
 	networks: {
 		development: {
-			host: '127.0.0.1',
+			host: 'localhost',
 			port: 8545,
 			network_id: '*',
 			gas: 8000000,


### PR DESCRIPTION
A few fixes here

1. Cleaned up solhint rules
2. Better VSCode and solhint integration
3. Minor fix to `Synthetix.exchange` to reduce gas (from `6,770,253` to `6,742,558`) 
4. Minor upgrade of `truffle` and `web3`
5. Fixed `solhint` to take quoted glob (so that it actually checks subdirectories correctly)
6. Cleaned up test coverage of SIP-21
7. Fixed deploy script