### PR TITLE
Adding in view to read fee rate for exchange

### DIFF
--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -288,6 +288,30 @@ contract Synthetix is ExternStateToken {
         return availableSynths.length;
     }
 
+    /**
+     * @notice Determine the effective fee rate for the exchange, taking into considering swing trading
+     */
+    function feeRateForExchange(bytes32 sourceCurrencyKey, bytes32 destinationCurrencyKey)
+        public
+        view
+        returns (uint)
+    {
+         // Get the exchange fee rate
+        uint exchangeFeeRate = feePool.exchangeFeeRate();
+
+        uint multiplier = 1;
+
+        // Is this a swing trade? long to short or sort to long.
+        if (
+            (sourceCurrencyKey[0] == 0x73 && sourceCurrencyKey != "sUSD" && destinationCurrencyKey[0] == 0x69) ||
+            (sourceCurrencyKey[0] == 0x69 && destinationCurrencyKey != "sUSD" && destinationCurrencyKey[0] == 0x73)
+        ) {
+            // Double the exchange fee and sub the fee from the amountReceived
+            multiplier = 2;
+        }
+
+        return exchangeFeeRate.mul(multiplier);
+    }
     // ========== MUTATIVE FUNCTIONS ==========
 
     /**
@@ -476,20 +500,10 @@ contract Synthetix is ExternStateToken {
 
         if (chargeFee) {
             // Get the exchange fee rate
-            uint exchangeFeeRate = feePool.exchangeFeeRate();
+            uint exchangeFeeRate = feeRateForExchange(sourceCurrencyKey, destinationCurrencyKey);
 
-            uint multiplier = 1;
+            amountReceived = destinationAmount.multiplyDecimal(SafeDecimalMath.unit().sub(exchangeFeeRate));
 
-            // Is this a swing trade? long to short or sort to long.
-            if (
-                (sourceCurrencyKey[0] == 0x73 && sourceCurrencyKey != "sUSD" && destinationCurrencyKey[0] == 0x69) ||
-                (sourceCurrencyKey[0] == 0x69 && destinationCurrencyKey != "sUSD" && destinationCurrencyKey[0] == 0x73)
-            ) {
-                // Double the exchange fee and sub the fee from the amountReceived
-                multiplier = 2;
-            }
-
-            amountReceived = destinationAmount.multiplyDecimal(SafeDecimalMath.unit().sub(exchangeFeeRate.mul(multiplier)));
             fee = destinationAmount.sub(amountReceived);
         }
 

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -296,17 +296,18 @@ contract Synthetix is ExternStateToken {
         view
         returns (uint)
     {
-         // Get the exchange fee rate
+        // Get the base exchange fee rate
         uint exchangeFeeRate = feePool.exchangeFeeRate();
 
         uint multiplier = 1;
 
-        // Is this a swing trade? long to short or sort to long.
+        // Is this a swing trade? I.e. long to short or vice versa, excluding when going into or out of sUSD.
+        // Note: this assumes shorts begin with 'i' and longs with 's'.
         if (
             (sourceCurrencyKey[0] == 0x73 && sourceCurrencyKey != "sUSD" && destinationCurrencyKey[0] == 0x69) ||
             (sourceCurrencyKey[0] == 0x69 && destinationCurrencyKey != "sUSD" && destinationCurrencyKey[0] == 0x73)
         ) {
-            // Double the exchange fee and sub the fee from the amountReceived
+            // If so then double the exchange fee multipler
             multiplier = 2;
         }
 

--- a/test/Synthetix.js
+++ b/test/Synthetix.js
@@ -2830,7 +2830,7 @@ contract('Synthetix', async accounts => {
 									});
 								});
 							});
-							describe.only('doubling of fees for swing trades', () => {
+							describe('doubling of fees for swing trades', () => {
 								const iBTCexchangeAmount = toUnit(0.002); // current iBTC balance is a bit under 0.05
 								let txn;
 								describe('when the user tries to exchange some short iBTC into long sBTC', () => {

--- a/test/Synthetix.js
+++ b/test/Synthetix.js
@@ -2830,7 +2830,7 @@ contract('Synthetix', async accounts => {
 									});
 								});
 							});
-							describe('doubling of fees for swing trades', () => {
+							describe.only('doubling of fees for swing trades', () => {
 								const iBTCexchangeAmount = toUnit(0.002); // current iBTC balance is a bit under 0.05
 								let txn;
 								describe('when the user tries to exchange some short iBTC into long sBTC', () => {


### PR DESCRIPTION
This adds the following `view` to `Synthetix`: `feeRateForExchange(bytes32 source, bytes32 dest)`. This allows dApps and, more importantly, other contracts to determine what the fee would be a given `exchange`.

It adds gas to the `Synthetix` contract deployment, but only around `4k`: from `6,742,579` to `6,746,386` (as you can [see here in gas checks](https://github.com/Synthetixio/synthetix/runs/293117793))