### PR TITLE
Add aggregators to deployment script via synths.json

### DIFF
--- a/contracts/ExchangeRates.sol
+++ b/contracts/ExchangeRates.sol
@@ -41,7 +41,7 @@ contract ExchangeRates is SelfDestructible {
     address public oracle;
 
     // Decentralized oracle networks that feed into pricing aggregators
-    mapping(bytes32 => AggregatorInterface) aggregators;
+    mapping(bytes32 => AggregatorInterface) public aggregators;
 
     // List of configure aggregator keys for convenient iteration
     bytes32[] public aggregatorKeys;

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -783,7 +783,7 @@ const deploy = async ({
 	// ----------------
 	let proxysETHAddress;
 	const synthetixProxyAddress = await synthetix.methods.proxy().call();
-	for (const { name: currencyKey, inverted, subclass } of synths) {
+	for (const { name: currencyKey, inverted, subclass, aggregator } of synths) {
 		const tokenStateForSynth = await deployContract({
 			name: `TokenState${currencyKey}`,
 			source: 'TokenState',
@@ -966,6 +966,19 @@ const deploy = async ({
 				expected: input => input === proxyFeePool.options.address,
 				write: 'setFeePoolProxy',
 				writeArg: proxyFeePool.options.address,
+			});
+		}
+
+		// now setup price aggregator if any for the synth
+		if (aggregator && w3utils.isAddress(aggregator) && exchangeRates) {
+			await runStep({
+				contract: `ExchangeRates`,
+				target: exchangeRates,
+				read: 'aggregators',
+				readArg: currencyKeyInBytes,
+				expected: input => input === aggregator,
+				write: 'addAggregator',
+				writeArg: [toBytes32(currencyKey), aggregator],
 			});
 		}
 

--- a/test/publish/index.js
+++ b/test/publish/index.js
@@ -36,6 +36,56 @@ const users = Object.entries(
 	private: `0x${pri}`,
 }));
 
+const web3 = new Web3(new Web3.providers.HttpProvider('http://127.0.0.1:8545'));
+
+// And this is our test sandboxing. It snapshots and restores between each test.
+let lastSnapshotId;
+
+const send = payload => {
+	if (!payload.jsonrpc) payload.jsonrpc = '2.0';
+	if (!payload.id) payload.id = new Date().getTime();
+
+	return new Promise((resolve, reject) => {
+		web3.currentProvider.send(payload, (error, result) => {
+			if (error) return reject(error);
+
+			return resolve(result);
+		});
+	});
+};
+
+/**
+ *  Takes a snapshot and returns the ID of the snapshot for restoring later.
+ */
+const takeSnapshot = async () => {
+	const { result } = await send({ method: 'evm_snapshot' });
+	await mineBlock();
+
+	return result;
+};
+
+/**
+ *  Restores a snapshot that was previously taken with takeSnapshot
+ *  @param id The ID that was returned when takeSnapshot was called.
+ */
+const restoreSnapshot = async id => {
+	await send({
+		method: 'evm_revert',
+		params: [id],
+	});
+	await mineBlock();
+};
+
+const mineBlock = () => send({ method: 'evm_mine' });
+
+beforeEach(async () => {
+	lastSnapshotId = await takeSnapshot();
+});
+
+afterEach(async () => {
+	await restoreSnapshot(lastSnapshotId);
+});
+
 describe('publish scripts', function() {
 	this.timeout(5e3);
 	const deploymentPath = path.join(__dirname, '..', '..', 'publish', 'deployed', 'local');
@@ -53,7 +103,6 @@ describe('publish scripts', function() {
 	let SNX;
 	let sUSD;
 	let sBTC;
-	let web3;
 	let compiledSources;
 
 	const resetConfigAndSynthFiles = () => {
@@ -62,7 +111,7 @@ describe('publish scripts', function() {
 		fs.writeFileSync(configJSONPath, configJSON);
 	};
 
-	beforeEach(async function() {
+	before(async function() {
 		fs.writeFileSync(logfilePath, ''); // reset log file
 		console.log = (...input) => fs.appendFileSync(logfilePath, input.join(' ') + '\n');
 		accounts = {
@@ -88,7 +137,6 @@ describe('publish scripts', function() {
 
 		gasLimit = 5000000;
 		[SNX, sUSD, sBTC] = ['SNX', 'sUSD', 'sBTC'].map(toBytes32);
-		web3 = new Web3(new Web3.providers.HttpProvider('http://127.0.0.1:8545'));
 		web3.eth.accounts.wallet.add(accounts.deployer.private);
 		gasPrice = web3.utils.toWei('5', 'gwei');
 	});
@@ -105,7 +153,7 @@ describe('publish scripts', function() {
 			let sUSDContract;
 			let sBTCContract;
 			let FeePool;
-			beforeEach(async function() {
+			before(async function() {
 				this.timeout(60000);
 
 				await commands.deploy({


### PR DESCRIPTION
If the synths.json has an `aggregator` field, include it in the deployment configuration. (This is particularly important in future upgrades to `ExchangeRates`).