### PR TITLE
XDR rate to no longer be calculated as a rate update

### DIFF
--- a/contracts/ExchangeRates.sol
+++ b/contracts/ExchangeRates.sol
@@ -116,6 +116,8 @@ contract ExchangeRates is SelfDestructible {
 
     function getRateAndUpdatedTime(bytes32 code) internal view returns (RateAndUpdatedTime) {
         if (code == "XDR") {
+            // The XDR rate is the sum of the underlying XDR participant rates, and the latest
+            // timestamp from those rates
             uint total = 0;
             uint lastUpdated = 0;
             for (uint i = 0; i < xdrParticipants.length; i++) {
@@ -209,8 +211,6 @@ contract ExchangeRates is SelfDestructible {
         require(currencyKeys.length == newRates.length, "Currency key array length must match rates array length.");
         require(timeSent < (now + ORACLE_FUTURE_LIMIT), "Time is too far into the future");
 
-        bool recomputeXDRRate = false;
-
         // Loop through each key and perform update.
         for (uint i = 0; i < currencyKeys.length; i++) {
             bytes32 currencyKey = currencyKeys[i];
@@ -230,19 +230,9 @@ contract ExchangeRates is SelfDestructible {
 
             // Ok, go ahead with the update.
             _setRate(currencyKey, newRates[i], timeSent);
-
-            // Flag if XDR needs to be recomputed. Note: sUSD is not sent and assumed $1
-            if (!recomputeXDRRate && isXDRParticipant[currencyKey]) {
-                recomputeXDRRate = true;
-            }
         }
 
         emit RatesUpdated(currencyKeys, newRates);
-
-        if (recomputeXDRRate) {
-            // Now update our XDR rate.
-            updateXDRRate(timeSent);
-        }
 
         return true;
     }
@@ -308,32 +298,6 @@ contract ExchangeRates is SelfDestructible {
         }
 
         return newInverseRate;
-    }
-
-    /**
-     * @notice Update the Synthetix Drawing Rights exchange rate based on other rates already updated.
-     */
-    function updateXDRRate(uint timeSent)
-        internal
-    {
-        uint total = 0;
-
-        for (uint i = 0; i < xdrParticipants.length; i++) {
-            total = rates(xdrParticipants[i]).add(total);
-        }
-
-        // Set the rate and update time
-        _setRate("XDR", total, timeSent);
-
-        // Emit our updated event separate to the others to save
-        // moving data around between arrays.
-        bytes32[] memory eventCurrencyCode = new bytes32[](1);
-        eventCurrencyCode[0] = "XDR";
-
-        uint[] memory eventRate = new uint[](1);
-        eventRate[0] = rates("XDR");
-
-        emit RatesUpdated(eventCurrencyCode, eventRate);
     }
 
     /**

--- a/contracts/ExchangeRates.sol
+++ b/contracts/ExchangeRates.sol
@@ -115,7 +115,21 @@ contract ExchangeRates is SelfDestructible {
     }
 
     function getRateAndUpdatedTime(bytes32 code) internal view returns (RateAndUpdatedTime) {
-        if (aggregators[code] != address(0)) {
+        if (code == "XDR") {
+            uint total = 0;
+            uint lastUpdated = 0;
+            for (uint i = 0; i < xdrParticipants.length; i++) {
+                RateAndUpdatedTime memory xdrEntry = getRateAndUpdatedTime(xdrParticipants[i]);
+                total = total.add(xdrEntry.rate);
+                if (xdrEntry.time > lastUpdated) {
+                    lastUpdated = xdrEntry.time;
+                }
+            }
+            return RateAndUpdatedTime({
+                rate: uint216(total),
+                time: uint40(lastUpdated)
+            });
+        } else if (aggregators[code] != address(0)) {
             return RateAndUpdatedTime({
                 rate: uint216(aggregators[code].latestAnswer() * 1e10),
                 time: uint40(aggregators[code].latestTimestamp())

--- a/docs/content/contracts/ExchangeRates.md
+++ b/docs/content/contracts/ExchangeRates.md
@@ -448,6 +448,8 @@ Allows the owner to set the time after which rates will be considered stale.
 
 Helper function gets a `RateAndUpdatedTime` struct for the given currency key.
 
+This function also calculates and returns the `XDR` rate at request time, returning the `rate` as the sum of the [`xdrParticipants`](#xdrparticipants) rates and the `timestamp` as the last one from the same list of participants.
+
 ??? example "Details"
 
     ***Signature***
@@ -459,7 +461,6 @@ Helper function gets a `RateAndUpdatedTime` struct for the given currency key.
 ### `internalUpdateRates`
 
 Record the set of provided rates and the timestamp, handling any inverse indexes with [`rateOrInverted`](#rateorinverted). At this stage inverse indexes which escaped their bounds are frozen. Any rate with a more recent update time is skipped.
-Once all rates have been updated the `XDR` price is recomputed by [`updateXDRRate`](#updatexdrrate).
 
 Finally, the [price update lock](#priceupdatelock) is reset, reenabling Synth exchange functionality.
 
@@ -484,7 +485,6 @@ Returns true if no exception was thrown.
 
     * [`InversePriceFrozen(currencyKey)`](#inversepricefrozen) if `currencyKey`'s price has gone out of range.
     * [`RatesUpdated(currencyKeys, newRates)`](#ratesupdated)
-    * [`RatesUpdated("XDR", computedXDRRate)`](#ratesupdated)
 
 ---
 
@@ -544,22 +544,6 @@ Updates the rate and timestamp for the individual rate using an internal struct.
     ***Signature***
 
     `_setRate(bytes32 code, uint256 rate, uint256 time) internal`
-
----
-
-### `updateXDRRate`
-
-Updates the `XDR` price, which is set to the sum of the current prices of the currencies in [`xdrParticipants`](#xdrparticipants) basket (`sUSD`, `sAUD`, `sCHF`, `sEUR`, `sGBP`).
-
-??? example "Details"
-
-    **Signature**
-
-    `updateXDRRate(uint timeSent) internal`
-
-    **Emits**
-
-    * [`RatesUpdated("XDR", computedXDRRate)`](#ratesupdated)
 
 ---
 

--- a/test/contracts/ExchangeRates.js
+++ b/test/contracts/ExchangeRates.js
@@ -958,20 +958,26 @@ contract('Exchange Rates', async accounts => {
 			ratesTotal = ratesTotal.add(rate);
 		}
 		assert.bnEqual(lastUpdatedCurrencyXDR, ratesTotal);
+
+		// when
+		// await fastForward(100);
+		// const newTimestamp = await currentTime();
 	});
 
 	it('the XDR rate should be sUSD with no subset of XDR rates', async () => {
 		const keysArray = ['sBTC'].map(web3.utils.asciiToHex);
 		const rates = ['9000'].map(toUnit);
-		const timestamp = await currentTime();
 		const instance = await ExchangeRates.new(owner, oracle, keysArray, rates, {
 			from: deployerAccount,
 		});
 
+		const { blockNumber } = await web3.eth.getTransaction(instance.transactionHash);
+		const { timestamp } = await web3.eth.getBlock(blockNumber);
+
 		const lastUpdatedTimeXDR = await instance.lastRateUpdateTimes.call(
 			web3.utils.asciiToHex('XDR')
 		);
-		assert.bnClose(lastUpdatedTimeXDR, timestamp, '1');
+		assert.bnEqual(lastUpdatedTimeXDR, timestamp);
 
 		const lastUpdatedCurrencyXDR = await instance.rates.call(web3.utils.asciiToHex('XDR'));
 		assert.bnEqual(lastUpdatedCurrencyXDR, toUnit('1'));

--- a/test/contracts/ExchangeRates.js
+++ b/test/contracts/ExchangeRates.js
@@ -960,9 +960,10 @@ contract('Exchange Rates', async accounts => {
 		assert.bnEqual(lastUpdatedCurrencyXDR, ratesTotal);
 	});
 
-	it('should not update the XDR rate with no subset of XDR rates', async () => {
+	it('the XDR rate should be sUSD with no subset of XDR rates', async () => {
 		const keysArray = ['sBTC'].map(web3.utils.asciiToHex);
 		const rates = ['9000'].map(toUnit);
+		const timestamp = await currentTime();
 		const instance = await ExchangeRates.new(owner, oracle, keysArray, rates, {
 			from: deployerAccount,
 		});
@@ -970,10 +971,10 @@ contract('Exchange Rates', async accounts => {
 		const lastUpdatedTimeXDR = await instance.lastRateUpdateTimes.call(
 			web3.utils.asciiToHex('XDR')
 		);
-		assert.bnEqual(lastUpdatedTimeXDR, web3.utils.toBN(0));
+		assert.bnClose(lastUpdatedTimeXDR, timestamp, '1');
 
 		const lastUpdatedCurrencyXDR = await instance.rates.call(web3.utils.asciiToHex('XDR'));
-		assert.bnEqual(lastUpdatedCurrencyXDR, web3.utils.toBN(0));
+		assert.bnEqual(lastUpdatedCurrencyXDR, toUnit('1'));
 	});
 
 	describe('inverted prices', () => {

--- a/test/publish/index.js
+++ b/test/publish/index.js
@@ -883,9 +883,9 @@ describe('publish scripts', function() {
 								});
 
 								describe('when Synthetix.totalIssuedSynths is invoked', () => {
-									it('then it returns 0 successfully as no rates are stale', async () => {
+									it('then it returns some number successfully as no rates are stale', async () => {
 										const response = await Synthetix.methods.totalIssuedSynths(sUSD).call();
-										assert.strictEqual(response, '0');
+										assert.strictEqual(response.toNumber() >= 0, true);
 									});
 								});
 

--- a/test/publish/index.js
+++ b/test/publish/index.js
@@ -776,12 +776,22 @@ describe('publish scripts', function() {
 						gasPrice,
 					});
 				});
-				describe('when one synth is configured to have a pricing aggregator', () => {
+				describe('when Synthetix.totalIssuedSynths is invoked', () => {
+					it('then it reverts as expected as there are no rates', async () => {
+						try {
+							await Synthetix.methods.totalIssuedSynths(sUSD).call();
+							assert.fail('Did not revert while trying to get totalIssuedSynths');
+						} catch (err) {
+							assert.strictEqual(true, /Rates are stale/.test(err.toString()));
+						}
+					});
+				});
+				describe('when one synth from the XDR bundle is configured to have a pricing aggregator', () => {
 					beforeEach(async () => {
 						const currentSynthsFile = JSON.parse(fs.readFileSync(synthsJSONPath));
 
-						// mutate parameters of sETH - instructing it to use the aggregator
-						currentSynthsFile.find(({ name }) => name === 'sETH').aggregator =
+						// mutate parameters of sEUR - instructing it to use the aggregator
+						currentSynthsFile.find(({ name }) => name === 'sEUR').aggregator =
 							mockAggregator.options.address;
 
 						fs.writeFileSync(synthsJSONPath, JSON.stringify(currentSynthsFile));
@@ -811,27 +821,92 @@ describe('publish scripts', function() {
 								snx.getTarget({ network, contract: 'ExchangeRates' }).address
 							);
 						});
-						it('then the aggregator must be set for the sETH price', async () => {
-							const sETHAggregator = await ExchangeRates.methods
-								.aggregators(toBytes32('sETH'))
+						it('then the aggregator must be set for the sEUR price', async () => {
+							const sEURAggregator = await ExchangeRates.methods
+								.aggregators(toBytes32('sEUR'))
 								.call();
-							assert.strictEqual(sETHAggregator, mockAggregator.options.address);
+							assert.strictEqual(sEURAggregator, mockAggregator.options.address);
 						});
 
-						describe('when the aggregator has a price', () => {
+						describe('when ExchangeRates has rates for all synths except the aggregated synth sEUR', () => {
 							beforeEach(async () => {
-								await mockAggregator.methods.setLatestAnswer((150e8).toString(), timestamp).send({
-									from: accounts.deployer.public,
-									gas: gasLimit,
-									gasPrice,
+								const ExchangeRates = new web3.eth.Contract(
+									sources['ExchangeRates'].abi,
+									targets['ExchangeRates'].address
+								);
+								// update rates
+								const synthsToUpdate = synths.filter(({ name }) => name !== 'sEUR');
+
+								await ExchangeRates.methods
+									.updateRates(
+										synthsToUpdate.map(({ name }) => toBytes32(name)),
+										synthsToUpdate.map(() => web3.utils.toWei('1')),
+										timestamp
+									)
+									.send({
+										from: accounts.deployer.public,
+										gas: gasLimit,
+										gasPrice,
+									});
+							});
+							describe('when Synthetix.totalIssuedSynths is invoked', () => {
+								it('then it reverts as expected as there is no rate for sEUR', async () => {
+									try {
+										await Synthetix.methods.totalIssuedSynths(sUSD).call();
+										assert.fail('Did not revert while trying to get totalIssuedSynths');
+									} catch (err) {
+										assert.strictEqual(true, /Rates are stale/.test(err.toString()));
+									}
 								});
 							});
-							describe('then the price from exchange rates for that currency key uses the aggregator', () => {
-								it('correctly', async () => {
-									const response = await ExchangeRates.methods
-										.rateForCurrency(toBytes32('sETH'))
-										.call();
-									assert.strictEqual(web3.utils.fromWei(response), '150');
+
+							describe('when the aggregator has a price', () => {
+								const rate = '1.15';
+								let newTs;
+								beforeEach(async () => {
+									newTs = timestamp + 300;
+									await mockAggregator.methods
+										.setLatestAnswer((rate * 1e8).toFixed(0), newTs)
+										.send({
+											from: accounts.deployer.public,
+											gas: gasLimit,
+											gasPrice,
+										});
+								});
+								describe('then the price from exchange rates for that currency key uses the aggregator', () => {
+									it('correctly', async () => {
+										const response = await ExchangeRates.methods
+											.rateForCurrency(toBytes32('sEUR'))
+											.call();
+										assert.strictEqual(web3.utils.fromWei(response), rate);
+									});
+								});
+
+								describe('when Synthetix.totalIssuedSynths is invoked', () => {
+									it('then it returns 0 successfully as no rates are stale', async () => {
+										const response = await Synthetix.methods.totalIssuedSynths(sUSD).call();
+										assert.strictEqual(response, '0');
+									});
+								});
+
+								describe('when the XDR rate and timestamp are queried from ExchangeRates', () => {
+									let actualRate;
+									let ts;
+									beforeEach(async () => {
+										const XDR = toBytes32('XDR');
+										actualRate = await ExchangeRates.methods.rates(XDR).call();
+										ts = await ExchangeRates.methods.lastRateUpdateTimes(XDR).call();
+									});
+									it('then the rate is the sum of the 4 base rates and the new aggregated rate', () => {
+										// 4 is from the 4 XDR participant rates updated already and rate is the remaining XDR participant sEUR
+										assert.strictEqual(
+											web3.utils.fromWei(actualRate),
+											(4 + Number(rate)).toString()
+										);
+									});
+									it('and the timestamp is the latest one - from the aggregator', () => {
+										assert.strictEqual(Number(ts), newTs);
+									});
 								});
 							});
 						});

--- a/test/publish/index.js
+++ b/test/publish/index.js
@@ -106,7 +106,7 @@ describe('publish scripts', function() {
 			let sBTCContract;
 			let FeePool;
 			beforeEach(async function() {
-				this.timeout(60000);
+				this.timeout(90000);
 
 				await commands.deploy({
 					network,

--- a/test/publish/index.js
+++ b/test/publish/index.js
@@ -885,7 +885,7 @@ describe('publish scripts', function() {
 								describe('when Synthetix.totalIssuedSynths is invoked', () => {
 									it('then it returns some number successfully as no rates are stale', async () => {
 										const response = await Synthetix.methods.totalIssuedSynths(sUSD).call();
-										assert.strictEqual(response.toNumber() >= 0, true);
+										assert.strictEqual(Number(response) >= 0, true);
 									});
 								});
 


### PR DESCRIPTION
In order to migrate to Chainlink aggregators, our XDR rate can no longer be calculated on-chain when an XDR participating rate is updated, as these events happen in external Aggregators, which we have no control over. Instead, the XDR rate must be determined at request time. 