### PR TITLE
Deployment script fixes

### DIFF
--- a/publish/deployed/kovan/synths.json
+++ b/publish/deployed/kovan/synths.json
@@ -35,7 +35,7 @@
 		"category": "forex",
 		"sign": "$",
 		"desc": "Australian Dollars",
-		"aggregator": "0xfd4767f2136f277ddd36b563504797c46a2eff3b"
+		"aggregator": "0xFD4767F2136F277ddd36b563504797C46a2eFF3B"
 	},
 	{
 		"name": "sGBP",

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -275,7 +275,7 @@ const deploy = async ({
 	}
 
 	parameterNotice({
-		'Dry Run': dryRun,
+		'Dry Run': dryRun ? green('true') : yellow('⚠ NO'),
 		Network: network,
 		'Gas price to use': `${gasPrice} GWEI`,
 		'Deployment Path': new RegExp(network, 'gi').test(deploymentPath)
@@ -514,6 +514,19 @@ const deploy = async ({
 			expected: input => input === feePoolAddress,
 			write: 'setAssociatedContract',
 			writeArg: feePoolAddress,
+		});
+	}
+
+	if (feePool) {
+		// Set FeePool.targetThreshold to 1%
+		const targetThreshold = '0.01';
+		await runStep({
+			contract: 'FeePool',
+			target: feePool,
+			read: 'targetThreshold',
+			expected: input => input === w3utils.toWei(targetThreshold),
+			write: 'setTargetThreshold',
+			writeArg: (targetThreshold * 100).toString(), // arg expects percentage as uint
 		});
 	}
 

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -1089,20 +1089,28 @@ const deploy = async ({
 					upperLimit === +w3utils.fromWei(oldUpperLimit) &&
 					lowerLimit === +w3utils.fromWei(oldLowerLimit)
 				) {
-					const freezeAtUpperLimit = +w3utils.fromWei(currentRateForCurrency) === upperLimit;
-					console.log(
-						gray(
-							`Detected an existing inverted synth for ${currencyKey} with identical parameters. ` +
-								`Persisting its frozen status (${currentRateIsFrozen}) and if frozen, then freeze rate at upper (${freezeAtUpperLimit}) or lower (${!freezeAtUpperLimit}).`
-						)
-					);
+					if (oldExrates.options.address !== exchangeRatesAddress) {
+						const freezeAtUpperLimit = +w3utils.fromWei(currentRateForCurrency) === upperLimit;
+						console.log(
+							gray(
+								`Detected an existing inverted synth for ${currencyKey} with identical parameters and a newer ExchangeRates. ` +
+									`Persisting its frozen status (${currentRateIsFrozen}) and if frozen, then freeze rate at upper (${freezeAtUpperLimit}) or lower (${!freezeAtUpperLimit}).`
+							)
+						);
 
-					// then ensure it gets set to the same frozen status and frozen rate
-					// as the old exchange rates
-					await setInversePricing({
-						freeze: currentRateIsFrozen,
-						freezeAtUpperLimit,
-					});
+						// then ensure it gets set to the same frozen status and frozen rate
+						// as the old exchange rates
+						await setInversePricing({
+							freeze: currentRateIsFrozen,
+							freezeAtUpperLimit,
+						});
+					} else {
+						console.log(
+							gray(
+								`Detected an existing inverted synth for ${currencyKey} with identical parameters and no new ExchangeRates. Skipping check of frozen status.`
+							)
+						);
+					}
 				} else if (Number(currentRateForCurrency) === 0) {
 					console.log(gray(`Detected a new inverted synth for ${currencyKey}. Proceeding to add.`));
 					// Then a new inverted synth is being added (as there's no previous rate for it)


### PR DESCRIPTION
This fixes a few issues with the deployment script:

1. When not deploying a new `ExchangeRates`, this will no longer try to run `setInversePricing` unless the inverse parameters have changed;
2. `FeePool.targetThreshold` is checked to be `1%` as per https://sips.synthetix.io/sccp/sccp-6
3. Adds the useful `dryRun` feature to deploys