### PR TITLE
Moves emit call to be after state mutation

### DIFF
--- a/contracts/Owned.sol
+++ b/contracts/Owned.sol
@@ -61,9 +61,9 @@ contract Owned {
      */
     function acceptOwnership() external {
         require(msg.sender == nominatedOwner, "You must be nominated before you can accept ownership");
-        emit OwnerChanged(owner, nominatedOwner);
         owner = nominatedOwner;
         nominatedOwner = address(0);
+        emit OwnerChanged(owner, nominatedOwner);
     }
 
     modifier onlyOwner {


### PR DESCRIPTION
After consulting with @hav-noms I have moved the emit call on `acceptOwnership` to come after the state mutation.