### PR TITLE
Resolver reclaimer audit remediations

### DIFF
--- a/contracts/EtherCollateral.sol
+++ b/contracts/EtherCollateral.sol
@@ -10,7 +10,6 @@ import "./interfaces/IERC20.sol";
 import "./interfaces/IDepot.sol";
 import "./MixinResolver.sol";
 
-
 contract EtherCollateral is Owned, Pausable, ReentrancyGuard, MixinResolver {
     using SafeMath for uint256;
     using SafeDecimalMath for uint256;
@@ -388,18 +387,24 @@ contract EtherCollateral is Owned, Pausable, ReentrancyGuard, MixinResolver {
     /* ========== INTERNAL VIEWS ========== */
 
     function synthsETH() internal view returns (ISynth) {
-        require(resolver.getAddress("SynthsETH") != address(0), "Resolver is missing SynthsETH address");
-        return ISynth(resolver.getAddress("SynthsETH"));
+        address _foundAddress = resolver.getAddress("SynthsETH");
+        require(_foundAddress != address(0), "Resolver is missing SynthsETH address");
+        return ISynth(_foundAddress);
+
     }
 
     function synthsUSD() internal view returns (ISynth) {
-        require(resolver.getAddress("SynthsUSD") != address(0), "Resolver is missing SynthsUSD address");
-        return ISynth(resolver.getAddress("SynthsUSD"));
+        address _foundAddress = resolver.getAddress("SynthsUSD");
+        require(_foundAddress != address(0), "Resolver is missing SynthsUSD address");
+        return ISynth(_foundAddress);
+
     }
 
     function depot() internal view returns (IDepot) {
-        require(resolver.getAddress("Depot") != address(0), "Resolver is missing Depot address");
-        return IDepot(resolver.getAddress("Depot"));
+        address _foundAddress = resolver.getAddress("Depot");
+        require(_foundAddress != address(0), "Resolver is missing Depot address");
+        return IDepot(_foundAddress);
+
     }
 
     // ========== EVENTS ==========

--- a/contracts/ExchangeRates.sol
+++ b/contracts/ExchangeRates.sol
@@ -7,7 +7,6 @@ import "./SelfDestructible.sol";
 // AggregatorInterface from Chainlink represents a decentralized pricing network for a single currency keys
 import "chainlink/contracts/interfaces/AggregatorInterface.sol";
 
-
 /**
  * @title The repository for exchange rates
  */
@@ -49,7 +48,7 @@ contract ExchangeRates is SelfDestructible {
     mapping(bytes32 => InversePricing) public inversePricing;
     bytes32[] public invertedKeys;
 
-    mapping(bytes32 => uint) roundsForRates;
+    mapping(bytes32 => uint) currentRoundForRate;
 
     //
     // ========== CONSTRUCTOR ==========
@@ -122,11 +121,11 @@ contract ExchangeRates is SelfDestructible {
      * @param currencyKey The currency key you wish to delete the rate for
      */
     function deleteRate(bytes32 currencyKey) external onlyOracle {
-        require(rates(currencyKey) > 0, "Rate is zero");
+        require(getRate(currencyKey) > 0, "Rate is zero");
 
-        delete _rates[currencyKey][roundsForRates[currencyKey]];
+        delete _rates[currencyKey][currentRoundForRate[currencyKey]];
 
-        roundsForRates[currencyKey]--;
+        currentRoundForRate[currencyKey]--;
 
         emit RateDeleted(currencyKey);
     }
@@ -256,7 +255,7 @@ contract ExchangeRates is SelfDestructible {
             AggregatorInterface aggregator = aggregators[currencyKey];
             return aggregator.latestRound();
         } else {
-            return roundsForRates[currencyKey];
+            return currentRoundForRate[currencyKey];
         }
     }
 
@@ -283,17 +282,10 @@ contract ExchangeRates is SelfDestructible {
     /* ========== VIEWS ========== */
 
     /**
-     * @notice Retrieves the exchange rate (sUSD per unit) for a given currency key
-     */
-    function rates(bytes32 code) public view returns (uint256) {
-        return getRateAndUpdatedTime(code).rate;
-    }
-
-    /**
      * @notice Retrieves the timestamp the given rate was last updated.
      */
-    function lastRateUpdateTimes(bytes32 code) public view returns (uint256) {
-        return getRateAndUpdatedTime(code).time;
+    function lastRateUpdateTimes(bytes32 currencyKey) public view returns (uint256) {
+        return getRateAndUpdatedTime(currencyKey).time;
     }
 
     /**
@@ -327,26 +319,26 @@ contract ExchangeRates is SelfDestructible {
 
         // Calculate the effective value by going from source -> USD -> destination
         return
-            sourceAmount.multiplyDecimalRound(rateForCurrency(sourceCurrencyKey)).divideDecimalRound(
-                rateForCurrency(destinationCurrencyKey)
+            sourceAmount.multiplyDecimalRound(getRate(sourceCurrencyKey)).divideDecimalRound(
+                getRate(destinationCurrencyKey)
             );
     }
 
     /**
      * @notice Retrieve the rate for a specific currency
      */
-    function rateForCurrency(bytes32 currencyKey) public view returns (uint) {
-        return rates(currencyKey);
+    function rateForCurrency(bytes32 currencyKey) external view returns (uint) {
+        return getRateAndUpdatedTime(currencyKey).rate;
     }
 
     /**
      * @notice Retrieve the rates for a list of currencies
      */
-    function ratesForCurrencies(bytes32[] currencyKeys) public view returns (uint[]) {
+    function ratesForCurrencies(bytes32[] currencyKeys) external view returns (uint[]) {
         uint[] memory _localRates = new uint[](currencyKeys.length);
 
         for (uint i = 0; i < currencyKeys.length; i++) {
-            _localRates[i] = rates(currencyKeys[i]);
+            _localRates[i] = getRate(currencyKeys[i]);
         }
 
         return _localRates;
@@ -408,11 +400,14 @@ contract ExchangeRates is SelfDestructible {
 
     /* ========== INTERNAL FUNCTIONS ========== */
 
-    function _setRate(bytes32 code, uint256 rate, uint256 time) internal {
+    function _setRate(bytes32 currencyKey, uint256 rate, uint256 time) internal {
         // Note: this will effectively start the rounds at 1, which matches Chainlink's Agggregators
-        roundsForRates[code]++;
+        currentRoundForRate[currencyKey]++;
 
-        _rates[code][roundsForRates[code]] = RateAndUpdatedTime({rate: uint216(rate), time: uint40(time)});
+        _rates[currencyKey][currentRoundForRate[currencyKey]] = RateAndUpdatedTime({
+            rate: uint216(rate),
+            time: uint40(time)
+        });
     }
 
     /**
@@ -486,7 +481,7 @@ contract ExchangeRates is SelfDestructible {
         }
 
         // set the rate to the current rate initially (if it's frozen, this is what will be returned)
-        uint newInverseRate = rates(currencyKey);
+        uint newInverseRate = getRate(currencyKey);
 
         // get the new inverted rate if not frozen
         if (!inverse.frozen) {
@@ -516,15 +511,15 @@ contract ExchangeRates is SelfDestructible {
         return newInverseRate;
     }
 
-    function getRateAndUpdatedTime(bytes32 code) internal view returns (RateAndUpdatedTime) {
-        if (aggregators[code] != address(0)) {
+    function getRateAndUpdatedTime(bytes32 currencyKey) internal view returns (RateAndUpdatedTime) {
+        if (aggregators[currencyKey] != address(0)) {
             return
                 RateAndUpdatedTime({
-                    rate: uint216(aggregators[code].latestAnswer() * 1e10),
-                    time: uint40(aggregators[code].latestTimestamp())
+                    rate: uint216(aggregators[currencyKey].latestAnswer() * 1e10),
+                    time: uint40(aggregators[currencyKey].latestTimestamp())
                 });
         } else {
-            return _rates[code][roundsForRates[code]];
+            return _rates[currencyKey][currentRoundForRate[currencyKey]];
         }
     }
 
@@ -561,6 +556,10 @@ contract ExchangeRates is SelfDestructible {
             RateAndUpdatedTime storage update = _rates[currencyKey][roundId];
             return (update.rate, update.time);
         }
+    }
+
+    function getRate(bytes32 currencyKey) internal view returns (uint256) {
+        return getRateAndUpdatedTime(currencyKey).rate;
     }
 
     /* ========== MODIFIERS ========== */

--- a/contracts/ExchangeRates.sol
+++ b/contracts/ExchangeRates.sol
@@ -4,7 +4,7 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "./SafeDecimalMath.sol";
 import "./SelfDestructible.sol";
 
-// AggregatorInterface from Chainlink represents a decentralized pricing network for a single currency keys
+// AggregatorInterface from Chainlink represents a decentralized pricing network for a single currency key
 import "chainlink/contracts/interfaces/AggregatorInterface.sol";
 
 /**
@@ -29,7 +29,7 @@ contract ExchangeRates is SelfDestructible {
     // Decentralized oracle networks that feed into pricing aggregators
     mapping(bytes32 => AggregatorInterface) public aggregators;
 
-    // List of configure aggregator keys for convenient iteration
+    // List of aggregator keys for convenient iteration
     bytes32[] public aggregatorKeys;
 
     // Do not allow the oracle to submit times any further forward into the future than this constant.
@@ -108,7 +108,7 @@ contract ExchangeRates is SelfDestructible {
      * @notice Set the rates stored in this contract
      * @param currencyKeys The currency keys you wish to update the rates for (in order)
      * @param newRates The rates for each currency (in order)
-     * @param timeSent The timestamp of when the update was sent, specified in seconds since epoch (e.g. the same as the now keyword in solidity).contract
+     * @param timeSent The timestamp of when the update was sent, specified in seconds since epoch (e.g. the same as the now keyword in solidity).
      *                 This is useful because transactions can take a while to confirm, so this way we know how old the oracle's datapoint was exactly even
      *                 if it takes a long time for the transaction to confirm.
      */
@@ -217,7 +217,7 @@ contract ExchangeRates is SelfDestructible {
 
     /**
      * @notice Remove a pricing aggregator for the given key
-     * @param currencyKey THe currency key to remove an aggregator for
+     * @param currencyKey The currency key to remove an aggregator for
      */
     function removeAggregator(bytes32 currencyKey) external onlyOwner {
         address aggregator = aggregators[currencyKey];

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -111,7 +111,7 @@ contract Exchanger is MixinResolver {
             (uint amountShouldHaveReceived, ) = calculateExchangeAmountMinusFees(src, dest, destinationAmount);
 
             if (amountReceived > amountShouldHaveReceived) {
-                // if they recevied more than they should have, add to the reclaim tally
+                // if they received more than they should have, add to the reclaim tally
                 reclaimAmount = reclaimAmount.add(amountReceived.sub(amountShouldHaveReceived));
             } else if (amountShouldHaveReceived > amountReceived) {
                 // if less, add to the rebate tally

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -9,7 +9,6 @@ import "./interfaces/ISynthetix.sol";
 import "./interfaces/IFeePool.sol";
 import "./interfaces/IIssuer.sol";
 
-
 contract Exchanger is MixinResolver {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
@@ -28,23 +27,31 @@ contract Exchanger is MixinResolver {
     /* ========== VIEWS ========== */
 
     function exchangeState() internal view returns (IExchangeState) {
-        require(resolver.getAddress("ExchangeState") != address(0), "Resolver is missing ExchangeState address");
-        return IExchangeState(resolver.getAddress("ExchangeState"));
+        address _foundAddress = resolver.getAddress("ExchangeState");
+        require(_foundAddress != address(0), "Resolver is missing ExchangeState address");
+        return IExchangeState(_foundAddress);
+
     }
 
     function exchangeRates() internal view returns (IExchangeRates) {
-        require(resolver.getAddress("ExchangeRates") != address(0), "Resolver is missing ExchangeRates address");
-        return IExchangeRates(resolver.getAddress("ExchangeRates"));
+        address _foundAddress = resolver.getAddress("ExchangeRates");
+        require(_foundAddress != address(0), "Resolver is missing ExchangeRates address");
+        return IExchangeRates(_foundAddress);
+
     }
 
     function synthetix() internal view returns (ISynthetix) {
-        require(resolver.getAddress("Synthetix") != address(0), "Resolver is missing Synthetix address");
-        return ISynthetix(resolver.getAddress("Synthetix"));
+        address _foundAddress = resolver.getAddress("Synthetix");
+        require(_foundAddress != address(0), "Resolver is missing Synthetix address");
+        return ISynthetix(_foundAddress);
+
     }
 
     function feePool() internal view returns (IFeePool) {
-        require(resolver.getAddress("FeePool") != address(0), "Resolver is missing FeePool address");
-        return IFeePool(resolver.getAddress("FeePool"));
+        address _foundAddress = resolver.getAddress("FeePool");
+        require(_foundAddress != address(0), "Resolver is missing FeePool address");
+        return IFeePool(_foundAddress);
+
     }
 
     function maxSecsLeftInWaitingPeriod(address account, bytes32 currencyKey) public view returns (uint) {

--- a/contracts/FeePool.sol
+++ b/contracts/FeePool.sol
@@ -16,7 +16,6 @@ import "./FeePoolState.sol";
 import "./FeePoolEternalStorage.sol";
 import "./DelegateApprovals.sol";
 
-
 contract FeePool is Proxyable, SelfDestructible, LimitedSetup, MixinResolver {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
@@ -91,13 +90,17 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup, MixinResolver {
     /* ========== VIEWS ========== */
 
     function synthetix() internal view returns (ISynthetix) {
-        require(resolver.getAddress("Synthetix") != address(0), "Resolver is missing Synthetix address");
-        return ISynthetix(resolver.getAddress("Synthetix"));
+        address _foundAddress = resolver.getAddress("Synthetix");
+        require(_foundAddress != address(0), "Resolver is missing Synthetix address");
+        return ISynthetix(_foundAddress);
+
     }
 
     function feePoolState() internal view returns (FeePoolState) {
-        require(resolver.getAddress("FeePoolState") != address(0), "Resolver is missing FeePoolState address");
-        return FeePoolState(resolver.getAddress("FeePoolState"));
+        address _foundAddress = resolver.getAddress("FeePoolState");
+        require(_foundAddress != address(0), "Resolver is missing FeePoolState address");
+        return FeePoolState(_foundAddress);
+
     }
 
     function feePoolEternalStorage() internal view returns (FeePoolEternalStorage) {
@@ -109,28 +112,38 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup, MixinResolver {
     }
 
     function exchanger() internal view returns (IExchanger) {
-        require(resolver.getAddress("Exchanger") != address(0), "Resolver is missing Exchanger address");
-        return IExchanger(resolver.getAddress("Exchanger"));
+        address _foundAddress = resolver.getAddress("Exchanger");
+        require(_foundAddress != address(0), "Resolver is missing Exchanger address");
+        return IExchanger(_foundAddress);
+
     }
 
     function issuer() internal view returns (IIssuer) {
-        require(resolver.getAddress("Issuer") != address(0), "Resolver is missing Issuer address");
-        return IIssuer(resolver.getAddress("Issuer"));
+        address _foundAddress = resolver.getAddress("Issuer");
+        require(_foundAddress != address(0), "Resolver is missing Issuer address");
+        return IIssuer(_foundAddress);
+
     }
 
     function synthetixState() internal view returns (ISynthetixState) {
-        require(resolver.getAddress("SynthetixState") != address(0), "Resolver is missing the SynthetixState address");
-        return ISynthetixState(resolver.getAddress("SynthetixState"));
+        address _foundAddress = resolver.getAddress("SynthetixState");
+        require(_foundAddress != address(0), "Resolver is missing the SynthetixState address");
+        return ISynthetixState(_foundAddress);
+
     }
 
     function rewardEscrow() internal view returns (ISynthetixEscrow) {
-        require(resolver.getAddress("RewardEscrow") != address(0), "Resolver is missing RewardEscrow address");
-        return ISynthetixEscrow(resolver.getAddress("RewardEscrow"));
+        address _foundAddress = resolver.getAddress("RewardEscrow");
+        require(_foundAddress != address(0), "Resolver is missing RewardEscrow address");
+        return ISynthetixEscrow(_foundAddress);
+
     }
 
     function delegateApprovals() internal view returns (DelegateApprovals) {
-        require(resolver.getAddress("DelegateApprovals") != address(0), "Resolver is missing DelegateApprovals address");
-        return DelegateApprovals(resolver.getAddress("DelegateApprovals"));
+        address _foundAddress = resolver.getAddress("DelegateApprovals");
+        require(_foundAddress != address(0), "Resolver is missing DelegateApprovals address");
+        return DelegateApprovals(_foundAddress);
+
     }
 
     function recentFeePeriods(uint index)
@@ -574,6 +587,7 @@ contract FeePool is Proxyable, SelfDestructible, LimitedSetup, MixinResolver {
         //          return _value;
         //      }
         //      return fee;
+
     }
 
     /**

--- a/contracts/Issuer.sol
+++ b/contracts/Issuer.sol
@@ -8,7 +8,6 @@ import "./interfaces/IFeePool.sol";
 import "./interfaces/ISynthetixState.sol";
 import "./interfaces/IExchanger.sol";
 
-
 contract Issuer is MixinResolver {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
@@ -19,23 +18,31 @@ contract Issuer is MixinResolver {
 
     /* ========== VIEWS ========== */
     function synthetix() internal view returns (ISynthetix) {
-        require(resolver.getAddress("Synthetix") != address(0), "Resolver is missing Synthetix address");
-        return ISynthetix(resolver.getAddress("Synthetix"));
+        address _foundAddress = resolver.getAddress("Synthetix");
+        require(_foundAddress != address(0), "Resolver is missing Synthetix address");
+        return ISynthetix(_foundAddress);
+
     }
 
     function exchanger() internal view returns (IExchanger) {
-        require(resolver.getAddress("Exchanger") != address(0), "Resolver is missing Exchanger address");
-        return IExchanger(resolver.getAddress("Exchanger"));
+        address _foundAddress = resolver.getAddress("Exchanger");
+        require(_foundAddress != address(0), "Resolver is missing Exchanger address");
+        return IExchanger(_foundAddress);
+
     }
 
     function synthetixState() internal view returns (ISynthetixState) {
-        require(resolver.getAddress("SynthetixState") != address(0), "Resolver is missing the SynthetixState address");
-        return ISynthetixState(resolver.getAddress("SynthetixState"));
+        address _foundAddress = resolver.getAddress("SynthetixState");
+        require(_foundAddress != address(0), "Resolver is missing the SynthetixState address");
+        return ISynthetixState(_foundAddress);
+
     }
 
     function feePool() internal view returns (IFeePool) {
-        require(resolver.getAddress("FeePool") != address(0), "Resolver is missing FeePool address");
-        return IFeePool(resolver.getAddress("FeePool"));
+        address _foundAddress = resolver.getAddress("FeePool");
+        require(_foundAddress != address(0), "Resolver is missing FeePool address");
+        return IFeePool(_foundAddress);
+
     }
 
     /* ========== SETTERS ========== */

--- a/contracts/MultiCollateralSynth.sol
+++ b/contracts/MultiCollateralSynth.sol
@@ -19,7 +19,6 @@ pragma solidity 0.4.25;
 
 import "./Synth.sol";
 
-
 contract MultiCollateralSynth is Synth {
     /* ========== CONSTRUCTOR ========== */
     bytes32 public multiCollateralKey;
@@ -41,8 +40,9 @@ contract MultiCollateralSynth is Synth {
     /* ========== VIEWS ======================= */
 
     function multiCollateral() internal view returns (address) {
-        require(resolver.getAddress(multiCollateralKey) != address(0), "Resolver is missing multiCollateral address");
-        return resolver.getAddress(multiCollateralKey);
+        address _foundAddress = resolver.getAddress(multiCollateralKey);
+        require(_foundAddress != address(0), "Resolver is missing multiCollateral address");
+        return _foundAddress;
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */

--- a/contracts/PurgeableSynth.sol
+++ b/contracts/PurgeableSynth.sol
@@ -5,7 +5,6 @@ import "./Synth.sol";
 import "./interfaces/IExchangeRates.sol";
 import "./interfaces/ISynthetix.sol";
 
-
 contract PurgeableSynth is Synth {
     using SafeDecimalMath for uint;
 
@@ -28,8 +27,10 @@ contract PurgeableSynth is Synth {
     /* ========== VIEWS ========== */
 
     function exchangeRates() internal view returns (IExchangeRates) {
-        require(resolver.getAddress("ExchangeRates") != address(0), "Resolver is missing ExchangeRates address");
-        return IExchangeRates(resolver.getAddress("ExchangeRates"));
+        address _foundAddress = resolver.getAddress("ExchangeRates");
+        require(_foundAddress != address(0), "Resolver is missing ExchangeRates address");
+        return IExchangeRates(_foundAddress);
+
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */

--- a/contracts/Synth.sol
+++ b/contracts/Synth.sol
@@ -7,7 +7,6 @@ import "./interfaces/IExchanger.sol";
 import "./interfaces/IIssuer.sol";
 import "./MixinResolver.sol";
 
-
 contract Synth is ExternStateToken, MixinResolver {
     /* ========== STATE VARIABLES ========== */
 
@@ -139,23 +138,31 @@ contract Synth is ExternStateToken, MixinResolver {
 
     /* ========== VIEWS ========== */
     function synthetix() internal view returns (ISynthetix) {
-        require(resolver.getAddress("Synthetix") != address(0), "Resolver is missing Synthetix address");
-        return ISynthetix(resolver.getAddress("Synthetix"));
+        address _foundAddress = resolver.getAddress("Synthetix");
+        require(_foundAddress != address(0), "Resolver is missing Synthetix address");
+        return ISynthetix(_foundAddress);
+
     }
 
     function feePool() internal view returns (IFeePool) {
-        require(resolver.getAddress("FeePool") != address(0), "Resolver is missing FeePool address");
-        return IFeePool(resolver.getAddress("FeePool"));
+        address _foundAddress = resolver.getAddress("FeePool");
+        require(_foundAddress != address(0), "Resolver is missing FeePool address");
+        return IFeePool(_foundAddress);
+
     }
 
     function exchanger() internal view returns (IExchanger) {
-        require(resolver.getAddress("Exchanger") != address(0), "Resolver is missing Exchanger address");
-        return IExchanger(resolver.getAddress("Exchanger"));
+        address _foundAddress = resolver.getAddress("Exchanger");
+        require(_foundAddress != address(0), "Resolver is missing Exchanger address");
+        return IExchanger(_foundAddress);
+
     }
 
     function issuer() internal view returns (IIssuer) {
-        require(resolver.getAddress("Issuer") != address(0), "Resolver is missing Issuer address");
-        return IIssuer(resolver.getAddress("Issuer"));
+        address _foundAddress = resolver.getAddress("Issuer");
+        require(_foundAddress != address(0), "Resolver is missing Issuer address");
+        return IIssuer(_foundAddress);
+
     }
 
     function _ensureCanTransfer(address from, uint value) internal view {

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -14,7 +14,6 @@ import "./interfaces/IExchanger.sol";
 import "./interfaces/IIssuer.sol";
 import "./interfaces/IEtherCollateral.sol";
 
-
 /**
  * @title Synthetix ERC20 contract.
  * @notice The Synthetix contracts not only facilitates transfers, exchanges, and tracks balances,
@@ -52,53 +51,73 @@ contract Synthetix is ExternStateToken, MixinResolver {
     /* ========== VIEWS ========== */
 
     function exchanger() internal view returns (IExchanger) {
-        require(resolver.getAddress("Exchanger") != address(0), "Resolver is missing Exchanger address");
-        return IExchanger(resolver.getAddress("Exchanger"));
+        address _foundAddress = resolver.getAddress("Exchanger");
+        require(_foundAddress != address(0), "Resolver is missing Exchanger address");
+        return IExchanger(_foundAddress);
+
     }
 
     function etherCollateral() internal view returns (IEtherCollateral) {
-        require(resolver.getAddress("EtherCollateral") != address(0), "Resolver is missing EtherCollateral address");
-        return IEtherCollateral(resolver.getAddress("EtherCollateral"));
+        address _foundAddress = resolver.getAddress("EtherCollateral");
+        require(_foundAddress != address(0), "Resolver is missing EtherCollateral address");
+        return IEtherCollateral(_foundAddress);
+
     }
 
     function issuer() internal view returns (IIssuer) {
-        require(resolver.getAddress("Issuer") != address(0), "Resolver is missing Issuer address");
-        return IIssuer(resolver.getAddress("Issuer"));
+        address _foundAddress = resolver.getAddress("Issuer");
+        require(_foundAddress != address(0), "Resolver is missing Issuer address");
+        return IIssuer(_foundAddress);
+
     }
 
     function synthetixState() internal view returns (ISynthetixState) {
-        require(resolver.getAddress("SynthetixState") != address(0), "Resolver is missing the SynthetixState address");
-        return ISynthetixState(resolver.getAddress("SynthetixState"));
+        address _foundAddress = resolver.getAddress("SynthetixState");
+        require(_foundAddress != address(0), "Resolver is missing the SynthetixState address");
+        return ISynthetixState(_foundAddress);
+
     }
 
     function exchangeRates() internal view returns (IExchangeRates) {
-        require(resolver.getAddress("ExchangeRates") != address(0), "Resolver is missing ExchangeRates address");
-        return IExchangeRates(resolver.getAddress("ExchangeRates"));
+        address _foundAddress = resolver.getAddress("ExchangeRates");
+        require(_foundAddress != address(0), "Resolver is missing ExchangeRates address");
+        return IExchangeRates(_foundAddress);
+
     }
 
     function feePool() internal view returns (IFeePool) {
-        require(resolver.getAddress("FeePool") != address(0), "Resolver is missing FeePool address");
-        return IFeePool(resolver.getAddress("FeePool"));
+        address _foundAddress = resolver.getAddress("FeePool");
+        require(_foundAddress != address(0), "Resolver is missing FeePool address");
+        return IFeePool(_foundAddress);
+
     }
 
     function supplySchedule() internal view returns (SupplySchedule) {
-        require(resolver.getAddress("SupplySchedule") != address(0), "Resolver is missing SupplySchedule address");
-        return SupplySchedule(resolver.getAddress("SupplySchedule"));
+        address _foundAddress = resolver.getAddress("SupplySchedule");
+        require(_foundAddress != address(0), "Resolver is missing SupplySchedule address");
+        return SupplySchedule(_foundAddress);
+
     }
 
     function rewardEscrow() internal view returns (ISynthetixEscrow) {
-        require(resolver.getAddress("RewardEscrow") != address(0), "Resolver is missing RewardEscrow address");
-        return ISynthetixEscrow(resolver.getAddress("RewardEscrow"));
+        address _foundAddress = resolver.getAddress("RewardEscrow");
+        require(_foundAddress != address(0), "Resolver is missing RewardEscrow address");
+        return ISynthetixEscrow(_foundAddress);
+
     }
 
     function synthetixEscrow() internal view returns (ISynthetixEscrow) {
-        require(resolver.getAddress("SynthetixEscrow") != address(0), "Resolver is missing SynthetixEscrow address");
-        return ISynthetixEscrow(resolver.getAddress("SynthetixEscrow"));
+        address _foundAddress = resolver.getAddress("SynthetixEscrow");
+        require(_foundAddress != address(0), "Resolver is missing SynthetixEscrow address");
+        return ISynthetixEscrow(_foundAddress);
+
     }
 
     function rewardsDistribution() internal view returns (IRewardsDistribution) {
-        require(resolver.getAddress("RewardsDistribution") != address(0), "Resolver is missing RewardsDistribution address");
-        return IRewardsDistribution(resolver.getAddress("RewardsDistribution"));
+        address _foundAddress = resolver.getAddress("RewardsDistribution");
+        require(_foundAddress != address(0), "Resolver is missing RewardsDistribution address");
+        return IRewardsDistribution(_foundAddress);
+
     }
 
     /**
@@ -239,6 +258,7 @@ contract Synthetix is ExternStateToken, MixinResolver {
         // Note: No event here as Synthetix contract exceeds max contract size
         // with these events, and it's unlikely people will need to
         // track these events specifically.
+
     }
 
     /**

--- a/test/contracts/ExchangeRates.js
+++ b/test/contracts/ExchangeRates.js
@@ -83,11 +83,11 @@ contract('Exchange Rates', async accounts => {
 			assert.equal(await instance.selfDestructBeneficiary(), owner);
 			assert.equal(await instance.oracle(), oracle);
 
-			assert.etherEqual(await instance.rates.call(sUSD), '1');
-			assert.etherEqual(await instance.rates.call(SNX), '0.2');
+			assert.etherEqual(await instance.rateForCurrency(sUSD), '1');
+			assert.etherEqual(await instance.rateForCurrency(SNX), '0.2');
 
 			// Ensure that when the rate isn't found, 0 is returned as the exchange rate.
-			assert.etherEqual(await instance.rates.call(toBytes32('OTHER')), '0');
+			assert.etherEqual(await instance.rateForCurrency(toBytes32('OTHER')), '0');
 
 			const lastUpdatedTimeSUSD = await instance.lastRateUpdateTimes.call(sUSD);
 			assert.isAtLeast(lastUpdatedTimeSUSD.toNumber(), creationTime);
@@ -116,8 +116,8 @@ contract('Exchange Rates', async accounts => {
 				}
 			);
 
-			assert.etherEqual(await instance.rates.call(toBytes32('CARTER')), firstAmount);
-			assert.etherEqual(await instance.rates.call(toBytes32('CARTOON')), secondAmount);
+			assert.etherEqual(await instance.rateForCurrency(toBytes32('CARTER')), firstAmount);
+			assert.etherEqual(await instance.rateForCurrency(toBytes32('CARTOON')), secondAmount);
 
 			const lastUpdatedTime = await instance.lastRateUpdateTimes.call(toBytes32('CARTER'));
 			assert.isAtLeast(lastUpdatedTime.toNumber(), creationTime);
@@ -151,11 +151,11 @@ contract('Exchange Rates', async accounts => {
 			);
 
 			assert.etherEqual(
-				await instance.rates.call(toBytes32('ABCDEFGHIJKLMNOPQRSTUVXYZ1234567')),
+				await instance.rateForCurrency(toBytes32('ABCDEFGHIJKLMNOPQRSTUVXYZ1234567')),
 				amount
 			);
 			assert.etherNotEqual(
-				await instance.rates.call(toBytes32('ABCDEFGHIJKLMNOPQRSTUVXYZ123456')),
+				await instance.rateForCurrency(toBytes32('ABCDEFGHIJKLMNOPQRSTUVXYZ123456')),
 				amount
 			);
 
@@ -183,7 +183,7 @@ contract('Exchange Rates', async accounts => {
 			});
 
 			for (let i = 0; i < currencyKeys.length; i++) {
-				assert.bnEqual(await instance.rates.call(currencyKeys[i]), rates[i]);
+				assert.bnEqual(await instance.rateForCurrency(currencyKeys[i]), rates[i]);
 				const lastUpdatedTime = await instance.lastRateUpdateTimes.call(currencyKeys[i]);
 				assert.isAtLeast(lastUpdatedTime.toNumber(), creationTime);
 			}
@@ -219,9 +219,9 @@ contract('Exchange Rates', async accounts => {
 			const updatedTimelDEF = await instance.lastRateUpdateTimes.call(toBytes32('lDEF'));
 			const updatedTimelGHI = await instance.lastRateUpdateTimes.call(toBytes32('lGHI'));
 
-			assert.etherEqual(await instance.rates.call(toBytes32('lABC')), updatedRate);
-			assert.etherEqual(await instance.rates.call(toBytes32('lDEF')), '2.4');
-			assert.etherEqual(await instance.rates.call(toBytes32('lGHI')), '3.5');
+			assert.etherEqual(await instance.rateForCurrency(toBytes32('lABC')), updatedRate);
+			assert.etherEqual(await instance.rateForCurrency(toBytes32('lDEF')), '2.4');
+			assert.etherEqual(await instance.rateForCurrency(toBytes32('lGHI')), '3.5');
 
 			const lastUpdatedTimeLABC = await instance.lastRateUpdateTimes.call(toBytes32('lABC'));
 			assert.equal(lastUpdatedTimeLABC.toNumber(), updatedTime);
@@ -262,9 +262,9 @@ contract('Exchange Rates', async accounts => {
 				{ from: oracle }
 			);
 
-			assert.etherEqual(await instance.rates.call(toBytes32('lABC')), updatedRate1);
-			assert.etherEqual(await instance.rates.call(toBytes32('lDEF')), updatedRate2);
-			assert.etherEqual(await instance.rates.call(toBytes32('lGHI')), updatedRate3);
+			assert.etherEqual(await instance.rateForCurrency(toBytes32('lABC')), updatedRate1);
+			assert.etherEqual(await instance.rateForCurrency(toBytes32('lDEF')), updatedRate2);
+			assert.etherEqual(await instance.rateForCurrency(toBytes32('lGHI')), updatedRate3);
 
 			const lastUpdatedTimeLABC = await instance.lastRateUpdateTimes.call(toBytes32('lABC'));
 			assert.equal(lastUpdatedTimeLABC.toNumber(), updatedTime);
@@ -311,7 +311,7 @@ contract('Exchange Rates', async accounts => {
 			await instance.updateRates(currencyKeys, rates, updatedTime, { from: oracle });
 
 			for (let i = 0; i < currencyKeys.length; i++) {
-				assert.equal(await instance.rates.call(currencyKeys[i]), rates[i]);
+				assert.equal(await instance.rateForCurrency(currencyKeys[i]), rates[i]);
 				const lastUpdatedTime = await instance.lastRateUpdateTimes.call(currencyKeys[i]);
 				assert.equal(lastUpdatedTime.toNumber(), updatedTime);
 			}
@@ -352,8 +352,8 @@ contract('Exchange Rates', async accounts => {
 				skipPassCheck: true,
 			});
 
-			assert.etherNotEqual(await instance.rates.call(toBytes32('GOLD')), '10');
-			assert.etherNotEqual(await instance.rates.call(toBytes32('FOOL')), '0.9');
+			assert.etherNotEqual(await instance.rateForCurrency(toBytes32('GOLD')), '10');
+			assert.etherNotEqual(await instance.rateForCurrency(toBytes32('FOOL')), '0.9');
 
 			const updatedTime = await currentTime();
 
@@ -363,8 +363,8 @@ contract('Exchange Rates', async accounts => {
 				updatedTime,
 				{ from: oracle }
 			);
-			assert.etherEqual(await instance.rates.call(toBytes32('GOLD')), '10');
-			assert.etherEqual(await instance.rates.call(toBytes32('FOOL')), '0.9');
+			assert.etherEqual(await instance.rateForCurrency(toBytes32('GOLD')), '10');
+			assert.etherEqual(await instance.rateForCurrency(toBytes32('FOOL')), '0.9');
 
 			const lastUpdatedTimeGOLD = await instance.lastRateUpdateTimes.call(toBytes32('GOLD'));
 			assert.equal(lastUpdatedTimeGOLD.toNumber(), updatedTime);
@@ -427,12 +427,12 @@ contract('Exchange Rates', async accounts => {
 				{ from: oracle }
 			);
 
-			const beforeRate = await instance.rates.call(encodedRateGOLD);
+			const beforeRate = await instance.rateForCurrency(encodedRateGOLD);
 			const beforeRateUpdatedTime = await instance.lastRateUpdateTimes.call(encodedRateGOLD);
 
 			await instance.deleteRate(encodedRateGOLD, { from: oracle });
 
-			const afterRate = await instance.rates.call(encodedRateGOLD);
+			const afterRate = await instance.rateForCurrency(encodedRateGOLD);
 			const afterRateUpdatedTime = await instance.lastRateUpdateTimes.call(encodedRateGOLD);
 			assert.notEqual(afterRate, beforeRate);
 			assert.equal(afterRate, '0');
@@ -440,7 +440,7 @@ contract('Exchange Rates', async accounts => {
 			assert.equal(afterRateUpdatedTime, '0');
 
 			// Other rates are unaffected
-			assert.etherEqual(await instance.rates.call(toBytes32('FOOL')), foolsRate);
+			assert.etherEqual(await instance.rateForCurrency(toBytes32('FOOL')), foolsRate);
 		});
 
 		it('only oracle can delete a rate', async () => {
@@ -463,14 +463,14 @@ contract('Exchange Rates', async accounts => {
 		it("deleting rate that doesn't exist causes revert", async () => {
 			// This key shouldn't exist but let's do the best we can to ensure that it doesn't
 			const encodedCurrencyKey = toBytes32('7NEQ');
-			const currentRate = await instance.rates.call(encodedCurrencyKey);
+			const currentRate = await instance.rateForCurrency(encodedCurrencyKey);
 			if (currentRate > 0) {
 				await instance.deleteRate(encodedCurrencyKey, { from: oracle });
 			}
 
 			// Ensure rate deletion attempt results in revert
 			await assert.revert(instance.deleteRate(encodedCurrencyKey, { from: oracle }));
-			assert.etherEqual(await instance.rates.call(encodedCurrencyKey), '0');
+			assert.etherEqual(await instance.rateForCurrency(encodedCurrencyKey), '0');
 		});
 
 		it('should emit RateDeleted event when rate deleted', async () => {
@@ -521,7 +521,7 @@ contract('Exchange Rates', async accounts => {
 
 		it('Fetching non-existent rate returns 0', async () => {
 			const encodedRateKey = toBytes32('GOLD');
-			const currentRate = await instance.rates.call(encodedRateKey);
+			const currentRate = await instance.rateForCurrency(encodedRateKey);
 			if (currentRate > 0) {
 				await instance.deleteRate(encodedRateKey, { from: oracle });
 			}
@@ -612,7 +612,7 @@ contract('Exchange Rates', async accounts => {
 			// Set up rates for test
 			await instance.setRateStalePeriod(30, { from: owner });
 			const encodedRateKey = toBytes32('GOLD');
-			const currentRate = await instance.rates.call(encodedRateKey);
+			const currentRate = await instance.rateForCurrency(encodedRateKey);
 			if (currentRate > 0) {
 				await instance.deleteRate(encodedRateKey, { from: oracle });
 			}


### PR DESCRIPTION
1. Gas improvements in all `addressResolver` getters
2. Removing `ExchangeRates.rates()` (it was redundant - converted to internal `getRate()` and `rateForCurrency()` was changed to `external`.
3. Variable renames in `ExchangeRates`
4. Spelling issues in a couple of contracts.