### PR TITLE
Remove Synthetix.effectiveValue in favor of ExchangeRates.effectiveValue

### DIFF
--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -201,8 +201,10 @@ contract Exchanger is MixinResolver {
         // // Issue their new synths
         _synthetix.synths(destinationCurrencyKey).issue(destinationAddress, amountReceived);
 
-        // Remit any fees if required
-        remitFeeIfAny(_exRates, _synthetix, fee, destinationCurrencyKey);
+        // Remit the fee if required
+        if (fee > 0) {
+            remitFee(_exRates, _synthetix, fee, destinationCurrencyKey);
+        }
 
         // Nothing changes as far as issuance data goes because the total value in the system hasn't changed.
 
@@ -234,14 +236,12 @@ contract Exchanger is MixinResolver {
 
     /* ========== INTERNAL FUNCTIONS ========== */
 
-    function remitFeeIfAny(IExchangeRates _exRates, ISynthetix _synthetix, uint fee, bytes32 currencyKey) internal {
+    function remitFee(IExchangeRates _exRates, ISynthetix _synthetix, uint fee, bytes32 currencyKey) internal {
         // Remit the fee in sUSDs
-        if (fee > 0) {
-            uint usdFeeAmount = _exRates.effectiveValue(currencyKey, fee, sUSD);
-            _synthetix.synths(sUSD).issue(feePool().FEE_ADDRESS(), usdFeeAmount);
-            // Tell the fee pool about this.
-            feePool().recordFeePaid(usdFeeAmount);
-        }
+        uint usdFeeAmount = _exRates.effectiveValue(currencyKey, fee, sUSD);
+        _synthetix.synths(sUSD).issue(feePool().FEE_ADDRESS(), usdFeeAmount);
+        // Tell the fee pool about this.
+        feePool().recordFeePaid(usdFeeAmount);
     }
 
     function _internalSettle(address from, bytes32 currencyKey) internal returns (uint reclaimed, uint refunded) {

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -174,6 +174,7 @@ contract Exchanger is MixinResolver {
         (, uint refunded) = _internalSettle(from, sourceCurrencyKey);
 
         ISynthetix _synthetix = synthetix();
+        IExchangeRates _exRates = exchangeRates();
 
         uint sourceAmountAfterSettlement = calculateAmountAfterSettlement(from, sourceCurrencyKey, sourceAmount, refunded);
 
@@ -183,7 +184,7 @@ contract Exchanger is MixinResolver {
         // Burn the source amount
         _synthetix.synths(sourceCurrencyKey).burn(from, sourceAmountAfterSettlement);
 
-        uint destinationAmount = _synthetix.effectiveValue(
+        uint destinationAmount = _exRates.effectiveValue(
             sourceCurrencyKey,
             sourceAmountAfterSettlement,
             destinationCurrencyKey
@@ -200,13 +201,8 @@ contract Exchanger is MixinResolver {
         // // Issue their new synths
         _synthetix.synths(destinationCurrencyKey).issue(destinationAddress, amountReceived);
 
-        // Remit the fee in sUSDs
-        if (fee > 0) {
-            uint usdFeeAmount = _synthetix.effectiveValue(destinationCurrencyKey, fee, sUSD);
-            _synthetix.synths(sUSD).issue(feePool().FEE_ADDRESS(), usdFeeAmount);
-            // Tell the fee pool about this.
-            feePool().recordFeePaid(usdFeeAmount);
-        }
+        // Remit any fees if required
+        remitFeeIfAny(_exRates, _synthetix, fee, destinationCurrencyKey);
 
         // Nothing changes as far as issuance data goes because the total value in the system hasn't changed.
 
@@ -237,6 +233,16 @@ contract Exchanger is MixinResolver {
     }
 
     /* ========== INTERNAL FUNCTIONS ========== */
+
+    function remitFeeIfAny(IExchangeRates _exRates, ISynthetix _synthetix, uint fee, bytes32 currencyKey) internal {
+        // Remit the fee in sUSDs
+        if (fee > 0) {
+            uint usdFeeAmount = _exRates.effectiveValue(currencyKey, fee, sUSD);
+            _synthetix.synths(sUSD).issue(feePool().FEE_ADDRESS(), usdFeeAmount);
+            // Tell the fee pool about this.
+            feePool().recordFeePaid(usdFeeAmount);
+        }
+    }
 
     function _internalSettle(address from, bytes32 currencyKey) internal returns (uint reclaimed, uint refunded) {
         require(maxSecsLeftInWaitingPeriod(from, currencyKey) == 0, "Cannot settle during waiting period");

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -121,20 +121,6 @@ contract Synthetix is ExternStateToken, MixinResolver {
     }
 
     /**
-     * @notice A function that lets you easily convert an amount in a source currency to an amount in the destination currency
-     * @param sourceCurrencyKey The currency the amount is specified in
-     * @param sourceAmount The source amount, specified in UNIT base
-     * @param destinationCurrencyKey The destination currency
-     */
-    function effectiveValue(bytes32 sourceCurrencyKey, uint sourceAmount, bytes32 destinationCurrencyKey)
-        public
-        view
-        returns (uint)
-    {
-        return exchangeRates().effectiveValue(sourceCurrencyKey, sourceAmount, destinationCurrencyKey);
-    }
-
-    /**
      * @notice Total amount of synths issued by the system, priced in currencyKey
      * @param currencyKey The currency to value the synths in
      */
@@ -148,7 +134,7 @@ contract Synthetix is ExternStateToken, MixinResolver {
 
         for (uint i = 0; i < availableSynths.length; i++) {
             // What's the total issued value of that synth in the destination currency?
-            // Note: We're not using our effectiveValue function because we don't want to go get the
+            // Note: We're not using exchangeRates().effectiveValue() because we don't want to go get the
             //       rate for the destination currency and check if it's stale repeatedly on every
             //       iteration of the loop
             uint totalSynths = availableSynths[i].totalSupply();
@@ -325,7 +311,7 @@ contract Synthetix is ExternStateToken, MixinResolver {
         )
     {
         // What is the value of their SNX balance in the destination currency?
-        uint destinationValue = effectiveValue("SNX", collateral(_issuer), sUSD);
+        uint destinationValue = exchangeRates().effectiveValue("SNX", collateral(_issuer), sUSD);
 
         // They're allowed to issue up to issuanceRatio of that value
         return destinationValue.multiplyDecimal(synthetixState().issuanceRatio());

--- a/contracts/SynthetixState.sol
+++ b/contracts/SynthetixState.sol
@@ -40,7 +40,6 @@ import "./LimitedSetup.sol";
 import "./SafeDecimalMath.sol";
 import "./State.sol";
 
-
 /**
  * @title Synthetix State
  * @notice Stores issuance information and preferred currency information of the Synthetix contract.
@@ -180,54 +179,10 @@ contract SynthetixState is State, LimitedSetup {
      * @dev Only used from importIssuerData above, meant to be disposable
      */
     function _addToDebtRegister(address account, uint amount) internal {
-        // This code is duplicated from Synthetix so that we can call it directly here
-        // during setup only.
-        Synthetix synthetix = Synthetix(associatedContract);
-
-        // What is the value of the requested debt in XDRs?
-        uint xdrValue = synthetix.effectiveValue("sUSD", amount, "XDR");
-
-        // What is the value that we've previously imported?
-        uint totalDebtIssued = importedXDRAmount;
-
-        // What will the new total be including the new value?
-        uint newTotalDebtIssued = xdrValue.add(totalDebtIssued);
-
-        // Save that for the next import.
-        importedXDRAmount = newTotalDebtIssued;
-
-        // What is their percentage (as a high precision int) of the total debt?
-        uint debtPercentage = xdrValue.divideDecimalRoundPrecise(newTotalDebtIssued);
-
-        // And what effect does this percentage have on the global debt holding of other issuers?
-        // The delta specifically needs to not take into account any existing debt as it's already
-        // accounted for in the delta from when they issued previously.
-        // The delta is a high precision integer.
-        uint delta = SafeDecimalMath.preciseUnit().sub(debtPercentage);
-
-        uint existingDebt = synthetix.debtBalanceOf(account, "XDR");
-
-        // And what does their debt ownership look like including this previous stake?
-        if (existingDebt > 0) {
-            debtPercentage = xdrValue.add(existingDebt).divideDecimalRoundPrecise(newTotalDebtIssued);
-        }
-
-        // Are they a new issuer? If so, record them.
-        if (issuanceData[account].initialDebtOwnership == 0) {
-            totalIssuerCount = totalIssuerCount.add(1);
-        }
-
-        // Save the debt entry parameters
-        issuanceData[account].initialDebtOwnership = debtPercentage;
-        issuanceData[account].debtEntryIndex = debtLedger.length;
-
-        // And if we're the first, push 1 as there was no effect to any other holders, otherwise push
-        // the change for the rest of the debt holders. The debt ledger holds high precision integers.
-        if (debtLedger.length > 0) {
-            debtLedger.push(debtLedger[debtLedger.length - 1].multiplyDecimalRoundPrecise(delta));
-        } else {
-            debtLedger.push(SafeDecimalMath.preciseUnit());
-        }
+        // Note: this function's implementation has been removed from the current Synthetix codebase
+        // as it could only habe been invoked during setup (see importIssuerData) which has since expired.
+        // There have been changes to the functions it requires, so to ensure compiles, the below has been removed.
+        // For the previous implementation, see Synthetix._addToDebtRegister()
     }
 
     /* ========== VIEWS ========== */

--- a/contracts/interfaces/ISynthetix.sol
+++ b/contracts/interfaces/ISynthetix.sol
@@ -12,7 +12,6 @@ import "../interfaces/IFeePool.sol";
 import "../interfaces/IExchangeRates.sol";
 import "../Synth.sol";
 
-
 contract ISynthetix {
     // ========== PUBLIC STATE VARIABLES ==========
 
@@ -29,11 +28,6 @@ contract ISynthetix {
     function transfer(address to, uint value) public returns (bool);
 
     function transferFrom(address from, address to, uint value) public returns (bool);
-
-    function effectiveValue(bytes32 sourceCurrencyKey, uint sourceAmount, bytes32 destinationCurrencyKey)
-        public
-        view
-        returns (uint);
 
     function exchange(bytes32 sourceCurrencyKey, uint sourceAmount, bytes32 destinationCurrencyKey)
         external

--- a/test/contracts/Exchanger.js
+++ b/test/contracts/Exchanger.js
@@ -1163,7 +1163,7 @@ contract('Exchanger (via Synthetix)', async accounts => {
 			await synthetix.exchange(sUSD, amountIssued, sAUD, { from: account1 });
 
 			// how much sAUD the user is supposed to get
-			const effectiveValue = await synthetix.effectiveValue(sUSD, amountIssued, sAUD);
+			const effectiveValue = await exchangeRates.effectiveValue(sUSD, amountIssued, sAUD);
 
 			// chargeFee = true so we need to minus the fees for this exchange
 			const effectiveValueMinusFees = await feePool.amountReceivedFromExchange(effectiveValue);
@@ -1262,7 +1262,11 @@ contract('Exchanger (via Synthetix)', async accounts => {
 										toUnit(exchangeFeeRateMultiplier)
 									);
 									const balance = await toContract.balanceOf(account1);
-									const effectiveValue = await synthetix.effectiveValue(from, amountExchanged, to);
+									const effectiveValue = await exchangeRates.effectiveValue(
+										from,
+										amountExchanged,
+										to
+									);
 									const effectiveValueMinusFees = effectiveValue.sub(
 										multiplyDecimal(effectiveValue, actualExchangeFee)
 									);

--- a/test/contracts/FeePool.js
+++ b/test/contracts/FeePool.js
@@ -1422,7 +1422,7 @@ contract('FeePool', async accounts => {
 			const newsUSDBalance = await sUSDContract.balanceOf(FEE_ADDRESS);
 
 			assert.bnEqual(newXDRBalance, 0);
-			const conversionAmount = await synthetix.effectiveValue(XDR, oldXDRBalance, sUSD);
+			const conversionAmount = await exchangeRates.effectiveValue(XDR, oldXDRBalance, sUSD);
 			assert.bnEqual(newsUSDBalance, conversionAmount);
 		});
 
@@ -1439,12 +1439,12 @@ contract('FeePool', async accounts => {
 
 			// Assert
 			for (let i = 0; i <= 3; i++) {
-				const feesToDistributesUSD = await synthetix.effectiveValue(
+				const feesToDistributesUSD = await exchangeRates.effectiveValue(
 					XDR,
 					oldFeePeriods[i].feesToDistribute,
 					sUSD
 				);
-				const feesClaimedsUSD = await synthetix.effectiveValue(
+				const feesClaimedsUSD = await exchangeRates.effectiveValue(
 					XDR,
 					oldFeePeriods[i].feesClaimed,
 					sUSD

--- a/test/contracts/PurgeableSynth.js
+++ b/test/contracts/PurgeableSynth.js
@@ -152,7 +152,7 @@ contract('PurgeableSynth', accounts => {
 					});
 					it('and they have the value added back to sUSD (with fees taken out)', async () => {
 						const userBalance = await sUSDContract.balanceOf(account1);
-						const effectiveValueOfPurgedSynths = await synthetix.effectiveValue(
+						const effectiveValueOfPurgedSynths = await exchangeRates.effectiveValue(
 							iETH,
 							balanceBeforePurge,
 							sUSD
@@ -395,7 +395,7 @@ contract('PurgeableSynth', accounts => {
 										let expectedBalancePurged;
 										beforeEach(async () => {
 											txn = await this.replacement.purge([account1], { from: owner });
-											const effectiveValueOfPurgedSynths = await synthetix.effectiveValue(
+											const effectiveValueOfPurgedSynths = await exchangeRates.effectiveValue(
 												sAUD,
 												userBalanceOfOldSynth,
 												sUSD

--- a/test/contracts/RewardsIntegrationTests.js
+++ b/test/contracts/RewardsIntegrationTests.js
@@ -602,7 +602,7 @@ contract('Rewards Integration Tests', async accounts => {
 			await synthetix.mint({ from: owner });
 
 			// Do some exchanging to generateFees
-			const sBTCAmount = await synthetix.effectiveValue(sUSD, tenK, sBTC);
+			const sBTCAmount = await exchangeRates.effectiveValue(sUSD, tenK, sBTC);
 			const sBTCAmountMinusFees = await feePool.amountReceivedFromExchange(sBTCAmount);
 			await synthetix.exchange(sBTC, sBTCAmountMinusFees, sUSD, { from: account1 });
 			await synthetix.exchange(sBTC, sBTCAmountMinusFees, sUSD, { from: account2 });
@@ -671,7 +671,7 @@ contract('Rewards Integration Tests', async accounts => {
 			// const acc1sBTCBalance = await sBTCContract.balanceOf(account1, { from: account1 });
 			// await synthetix.exchange(sBTC, acc1sBTCBalance, sUSD, { from: account1 });
 			// const amountAfterExchange = await feePool.amountReceivedFromExchange(acc1sBTCBalance);
-			// const amountAfterExchangeInUSD = await synthetix.effectiveValue(
+			// const amountAfterExchangeInUSD = await exchangeRates.effectiveValue(
 			// 	sBTC,
 			// 	amountAfterExchange,
 			// 	sUSD


### PR DESCRIPTION
cc @clementbalestrat @evgenyboxer - please make sure the dApps no longer reference `Synthetix.effectiveValue()` but rather invoke the same function on `ExchangeRates`