### PR TITLE
SIP-47 Ensure only exchanges with settlements adjust amounts down

### DIFF
--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -173,12 +173,12 @@ contract Exchanger is MixinResolver {
 
         uint sourceAmountAfterSettlement = sourceAmount;
 
-        // when the are entries that were settled
+        // when settlement was required
         if (numEntriesSettled > 0) {
             // ensure the sourceAmount takes this into account
             sourceAmountAfterSettlement = calculateAmountAfterSettlement(from, sourceCurrencyKey, sourceAmount, refunded);
 
-            // If, after settlement the user has no balance  left (highly unlikely), then return to prevent
+            // If, after settlement the user has no balance left (highly unlikely), then return to prevent
             // emitting events of 0 and don't revert so as to ensure the settlement queue is emptied
             if (sourceAmountAfterSettlement == 0) {
                 return 0;

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -250,7 +250,7 @@ contract Exchanger is MixinResolver {
 
     function _internalSettle(address from, bytes32 currencyKey)
         internal
-        returns (uint reclaimed, uint refunded, uint numEntries)
+        returns (uint reclaimed, uint refunded, uint numEntriesSettled)
     {
         require(maxSecsLeftInWaitingPeriod(from, currencyKey) == 0, "Cannot settle during waiting period");
 
@@ -264,7 +264,7 @@ contract Exchanger is MixinResolver {
             refund(from, currencyKey, refunded);
         }
 
-        numEntries = entries;
+        numEntriesSettled = entries;
 
         // Now remove all entries, even if no reclaim and no rebate
         exchangeState().removeEntries(from, currencyKey);

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -79,10 +79,10 @@ contract Exchanger is MixinResolver {
     function settlementOwing(address account, bytes32 currencyKey)
         public
         view
-        returns (uint reclaimAmount, uint rebateAmount)
+        returns (uint reclaimAmount, uint rebateAmount, uint numEntries)
     {
         // Need to sum up all reclaim and rebate amounts for the user and the currency key
-        uint numEntries = exchangeState().getLengthOfEntries(account, currencyKey);
+        numEntries = exchangeState().getLengthOfEntries(account, currencyKey);
 
         // For each unsettled exchange
         for (uint i = 0; i < numEntries; i++) {
@@ -117,7 +117,7 @@ contract Exchanger is MixinResolver {
             }
         }
 
-        return (reclaimAmount, rebateAmount);
+        return (reclaimAmount, rebateAmount, numEntries);
     }
 
     /* ========== SETTERS ========== */
@@ -169,20 +169,23 @@ contract Exchanger is MixinResolver {
         require(sourceAmount > 0, "Zero amount");
         require(exchangeEnabled, "Exchanging is disabled");
 
-        (, uint refunded) = _internalSettle(from, sourceCurrencyKey);
+        (, uint refunded, uint numEntriesSettled) = _internalSettle(from, sourceCurrencyKey);
 
-        ISynthetix _synthetix = synthetix();
-        IExchangeRates _exRates = exchangeRates();
+        uint sourceAmountAfterSettlement = sourceAmount;
 
-        uint sourceAmountAfterSettlement = calculateAmountAfterSettlement(from, sourceCurrencyKey, sourceAmount, refunded);
+        // when the are entries that were settled
+        if (numEntriesSettled > 0) {
+            // ensure the sourceAmount takes this into account
+            sourceAmountAfterSettlement = calculateAmountAfterSettlement(from, sourceCurrencyKey, sourceAmount, refunded);
+        }
 
         // Note: We don't need to check their balance as the burn() below will do a safe subtraction which requires
         // the subtraction to not overflow, which would happen if their balance is not sufficient.
 
         // Burn the source amount
-        _synthetix.synths(sourceCurrencyKey).burn(from, sourceAmountAfterSettlement);
+        synthetix().synths(sourceCurrencyKey).burn(from, sourceAmountAfterSettlement);
 
-        uint destinationAmount = _exRates.effectiveValue(
+        uint destinationAmount = exchangeRates().effectiveValue(
             sourceCurrencyKey,
             sourceAmountAfterSettlement,
             destinationCurrencyKey
@@ -197,17 +200,17 @@ contract Exchanger is MixinResolver {
         );
 
         // // Issue their new synths
-        _synthetix.synths(destinationCurrencyKey).issue(destinationAddress, amountReceived);
+        synthetix().synths(destinationCurrencyKey).issue(destinationAddress, amountReceived);
 
         // Remit the fee if required
         if (fee > 0) {
-            remitFee(_exRates, _synthetix, fee, destinationCurrencyKey);
+            remitFee(exchangeRates(), synthetix(), fee, destinationCurrencyKey);
         }
 
         // Nothing changes as far as issuance data goes because the total value in the system hasn't changed.
 
         // Let the DApps know there was a Synth exchange
-        _synthetix.emitSynthExchange(
+        synthetix().emitSynthExchange(
             from,
             sourceCurrencyKey,
             sourceAmountAfterSettlement,
@@ -226,7 +229,10 @@ contract Exchanger is MixinResolver {
         );
     }
 
-    function settle(address from, bytes32 currencyKey) external returns (uint reclaimed, uint refunded) {
+    function settle(address from, bytes32 currencyKey)
+        external
+        returns (uint reclaimed, uint refunded, uint numEntriesSettled)
+    {
         // Note: this function can be called by anyone on behalf of anyone else
 
         return _internalSettle(from, currencyKey);
@@ -242,10 +248,13 @@ contract Exchanger is MixinResolver {
         feePool().recordFeePaid(usdFeeAmount);
     }
 
-    function _internalSettle(address from, bytes32 currencyKey) internal returns (uint reclaimed, uint refunded) {
+    function _internalSettle(address from, bytes32 currencyKey)
+        internal
+        returns (uint reclaimed, uint refunded, uint numEntries)
+    {
         require(maxSecsLeftInWaitingPeriod(from, currencyKey) == 0, "Cannot settle during waiting period");
 
-        (uint reclaimAmount, uint rebateAmount) = settlementOwing(from, currencyKey);
+        (uint reclaimAmount, uint rebateAmount, uint entries) = settlementOwing(from, currencyKey);
 
         if (reclaimAmount > rebateAmount) {
             reclaimed = reclaimAmount.sub(rebateAmount);
@@ -254,6 +263,8 @@ contract Exchanger is MixinResolver {
             refunded = rebateAmount.sub(reclaimAmount);
             refund(from, currencyKey, refunded);
         }
+
+        numEntries = entries;
 
         // Now remove all entries, even if no reclaim and no rebate
         exchangeState().removeEntries(from, currencyKey);

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -177,6 +177,12 @@ contract Exchanger is MixinResolver {
         if (numEntriesSettled > 0) {
             // ensure the sourceAmount takes this into account
             sourceAmountAfterSettlement = calculateAmountAfterSettlement(from, sourceCurrencyKey, sourceAmount, refunded);
+
+            // If, after settlement the user has no balance  left (highly unlikely), then return to prevent
+            // emitting events of 0 and don't revert so as to ensure the settlement queue is emptied
+            if (sourceAmountAfterSettlement == 0) {
+                return 0;
+            }
         }
 
         // Note: We don't need to check their balance as the burn() below will do a safe subtraction which requires

--- a/contracts/Issuer.sol
+++ b/contracts/Issuer.sol
@@ -138,14 +138,18 @@ contract Issuer is MixinResolver {
         require(canBurnSynths(from), "Minimum stake time not reached");
 
         // First settle anything pending into sUSD as burning or issuing impacts the size of the debt pool
-        (, uint refunded) = exchanger().settle(from, sUSD);
+        (, uint refunded, uint numEntriesSettled) = exchanger().settle(from, sUSD);
 
         // How much debt do they have?
         (uint existingDebt, uint totalSystemValue) = synthetix().debtBalanceOfAndTotalDebt(from, sUSD);
 
         require(existingDebt > 0, "No debt to forgive");
 
-        uint debtToRemoveAfterSettlement = exchanger().calculateAmountAfterSettlement(from, sUSD, amount, refunded);
+        uint debtToRemoveAfterSettlement = amount;
+
+        if (numEntriesSettled > 0) {
+            debtToRemoveAfterSettlement = exchanger().calculateAmountAfterSettlement(from, sUSD, amount, refunded);
+        }
 
         _internalBurnSynths(from, debtToRemoveAfterSettlement, existingDebt, totalSystemValue);
     }

--- a/contracts/Synth.sol
+++ b/contracts/Synth.sol
@@ -69,10 +69,14 @@ contract Synth is ExternStateToken, MixinResolver {
     }
 
     function transferAndSettle(address to, uint value) public optionalProxy returns (bool) {
-        exchanger().settle(messageSender, currencyKey);
+        (, , uint numEntriesSettled) = exchanger().settle(messageSender, currencyKey);
 
         // Save gas instead of calling transferableSynths
-        uint balanceAfter = tokenState.balanceOf(messageSender);
+        uint balanceAfter = value;
+
+        if (numEntriesSettled > 0) {
+            balanceAfter = tokenState.balanceOf(messageSender);
+        }
 
         // Reduce the value to transfer if balance is insufficient after reclaimed
         value = value > balanceAfter ? balanceAfter : value;
@@ -87,10 +91,14 @@ contract Synth is ExternStateToken, MixinResolver {
     }
 
     function transferFromAndSettle(address from, address to, uint value) public optionalProxy returns (bool) {
-        exchanger().settle(from, currencyKey);
+        (, , uint numEntriesSettled) = exchanger().settle(from, currencyKey);
 
         // Save gas instead of calling transferableSynths
-        uint balanceAfter = tokenState.balanceOf(from);
+        uint balanceAfter = value;
+
+        if (numEntriesSettled > 0) {
+            balanceAfter = tokenState.balanceOf(from);
+        }
 
         // Reduce the value to transfer if balance is insufficient after reclaimed
         value = value >= balanceAfter ? balanceAfter : value;

--- a/contracts/Synth.sol
+++ b/contracts/Synth.sol
@@ -176,7 +176,7 @@ contract Synth is ExternStateToken, MixinResolver {
     }
 
     function transferableSynths(address account) public view returns (uint) {
-        (uint reclaimAmount, ) = exchanger().settlementOwing(account, currencyKey);
+        (uint reclaimAmount, , ) = exchanger().settlementOwing(account, currencyKey);
 
         // Note: ignoring rebate amount here because a settle() is required in order to
         // allow the transfer to actually work

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -293,7 +293,11 @@ contract Synthetix is ExternStateToken, MixinResolver {
         return exchanger().exchange(messageSender, sourceCurrencyKey, sourceAmount, destinationCurrencyKey, messageSender);
     }
 
-    function settle(bytes32 currencyKey) external optionalProxy returns (uint reclaimed, uint refunded) {
+    function settle(bytes32 currencyKey)
+        external
+        optionalProxy
+        returns (uint reclaimed, uint refunded, uint numEntriesSettled)
+    {
         return exchanger().settle(messageSender, currencyKey);
     }
 

--- a/contracts/interfaces/IExchanger.sol
+++ b/contracts/interfaces/IExchanger.sol
@@ -9,9 +9,9 @@ interface IExchanger {
     function settlementOwing(address account, bytes32 currencyKey)
         external
         view
-        returns (uint reclaimAmount, uint rebateAmount);
+        returns (uint reclaimAmount, uint rebateAmount, uint numEntries);
 
-    function settle(address from, bytes32 currencyKey) external returns (uint reclaimed, uint refunded);
+    function settle(address from, bytes32 currencyKey) external returns (uint reclaimed, uint refunded, uint numEntries);
 
     function exchange(
         address from,

--- a/contracts/interfaces/ISynthetix.sol
+++ b/contracts/interfaces/ISynthetix.sol
@@ -42,7 +42,7 @@ contract ISynthetix {
 
     function burnSynthsToTarget() external;
 
-    function settle(bytes32 currencyKey) external returns (uint reclaimed, uint refunded);
+    function settle(bytes32 currencyKey) external returns (uint reclaimed, uint refunded, uint numEntries);
 
     function collateralisationRatio(address issuer) public view returns (uint);
 
@@ -51,10 +51,16 @@ contract ISynthetix {
     function totalIssuedSynthsExcludeEtherCollateral(bytes32 currencyKey) public view returns (uint);
 
     function debtBalanceOf(address issuer, bytes32 currencyKey) public view returns (uint);
-    
-    function debtBalanceOfAndTotalDebt(address issuer, bytes32 currencyKey) public view returns (uint debtBalance, uint totalSystemValue);
 
-    function remainingIssuableSynths(address issuer) public view returns (uint maxIssuable, uint alreadyIssued, uint totalSystemDebt);
+    function debtBalanceOfAndTotalDebt(address issuer, bytes32 currencyKey)
+        public
+        view
+        returns (uint debtBalance, uint totalSystemValue);
+
+    function remainingIssuableSynths(address issuer)
+        public
+        view
+        returns (uint maxIssuable, uint alreadyIssued, uint totalSystemDebt);
 
     function maxIssuableSynths(address issuer) public view returns (uint maxIssuable);
 

--- a/contracts/test-helpers/MockExchanger.sol
+++ b/contracts/test-helpers/MockExchanger.sol
@@ -15,7 +15,11 @@ contract MockExchanger {
     }
 
     // Mock settle function
-    function settle(address from, bytes32 currencyKey) external view returns (uint256 reclaimed, uint256 refunded) {
+    function settle(address from, bytes32 currencyKey)
+        external
+        view
+        returns (uint256 reclaimed, uint256 refunded, uint numEntriesSettled)
+    {
         if (_mockReclaimAmount > 0) {
             synthetix.synths(currencyKey).burn(from, _mockReclaimAmount);
         }
@@ -24,7 +28,7 @@ contract MockExchanger {
             synthetix.synths(currencyKey).issue(from, _mockRefundAmount);
         }
 
-        return (_mockReclaimAmount, _mockRefundAmount);
+        return (_mockReclaimAmount, _mockRefundAmount, _mockNumEntries);
     }
 
     function settlementOwing(address account, bytes32 currencyKey) public view returns (uint, uint, uint) {

--- a/contracts/test-helpers/MockExchanger.sol
+++ b/contracts/test-helpers/MockExchanger.sol
@@ -6,6 +6,7 @@ import "../interfaces/ISynthetix.sol";
 contract MockExchanger {
     uint256 private _mockReclaimAmount;
     uint256 private _mockRefundAmount;
+    uint256 private _mockNumEntries;
 
     ISynthetix synthetix;
 
@@ -26,12 +27,8 @@ contract MockExchanger {
         return (_mockReclaimAmount, _mockRefundAmount);
     }
 
-    function settlementOwing(address account, bytes32 currencyKey)
-        public
-        view
-        returns (uint reclaimAmount, uint rebateAmount)
-    {
-        return (_mockReclaimAmount, _mockRefundAmount);
+    function settlementOwing(address account, bytes32 currencyKey) public view returns (uint, uint, uint) {
+        return (_mockReclaimAmount, _mockRefundAmount, _mockNumEntries);
     }
 
     function setReclaim(uint256 _reclaimAmount) external {
@@ -40,5 +37,9 @@ contract MockExchanger {
 
     function setRefund(uint256 _refundAmount) external {
         _mockRefundAmount = _refundAmount;
+    }
+
+    function setNumEntries(uint256 _numEntries) external {
+        _mockNumEntries = _numEntries;
     }
 }

--- a/test/contracts/Issuer.js
+++ b/test/contracts/Issuer.js
@@ -439,7 +439,7 @@ contract('Issuer (via Synthetix)', async accounts => {
 		await assert.revert(synthetix.burnSynths(toUnit('10'), { from: account2 }));
 	});
 
-	it('should burn 0 when trying to burn synths that do not exist', async () => {
+	it('should revert when trying to burn synths that do not exist', async () => {
 		// Send a price update to guarantee we're not depending on values from outside this test.
 
 		await exchangeRates.updateRates(
@@ -463,12 +463,11 @@ contract('Issuer (via Synthetix)', async accounts => {
 		});
 
 		const debtBefore = await synthetix.debtBalanceOf(account1, sUSD);
+
 		assert.ok(!debtBefore.isNeg());
-		// Burning any amount of sUSD will reduce the amount down to the current supply, which is 0
-		await synthetix.burnSynths('1', { from: account1 });
-		const debtAfter = await synthetix.debtBalanceOf(account1, sUSD);
-		// So assert their debt balabce is unchanged from the burn of 0
-		assert.bnEqual(debtBefore, debtAfter);
+
+		// Burning any amount of sUSD beyond what is owned will cause a revert
+		await assert.revert(synthetix.burnSynths('1', { from: account1 }));
 	});
 
 	it("should only burn up to a user's actual debt level", async () => {

--- a/test/contracts/Synth.js
+++ b/test/contracts/Synth.js
@@ -349,6 +349,7 @@ contract('Synth', async accounts => {
 			const reclaimAmount = toUnit('10');
 			beforeEach(async () => {
 				await exchanger.setReclaim(reclaimAmount);
+				await exchanger.setNumEntries('1');
 			});
 			it('then transferableSynths should be the total amount minus the reclaim', async () => {
 				assert.bnEqual(await sUSDContract.transferableSynths(owner), toUnit('990'));
@@ -432,6 +433,7 @@ contract('Synth', async accounts => {
 			const reclaimAmount = toUnit('600');
 			beforeEach(async () => {
 				await exchanger.setReclaim(reclaimAmount);
+				await exchanger.setNumEntries('1');
 				balanceBefore = await sUSDContract.balanceOf(owner);
 			});
 			describe('when reclaim 600 sUSD and transferring 500 sUSD synths', async () => {


### PR DESCRIPTION
This fix prevents the known side-effect of SIP-37 whereby exchanges with invalid amounts are succeeding with 0 amounts. Instead they should `revert` unless a settlement was required, in which case they should continue to pass (and thereby emptying out the settlement queue).

E.g. https://etherscan.io/tx/0x9a92ca42aa216b1cb406e1b09c50062b90ec2bfb5f10e584cc19978c5eece4a4 

For Exchanger.exchange, Issuer.burnSynths, Synth.transferAndSettle, Synth.transferFromAndSettle we will only reduce the amount down to the user's balance if there was any settlement. This means invalid amounts, instead of quietly succeeding as 0, will revert as they used to 