### PR TITLE
Allow all views to return when rates are stale

### DIFF
--- a/contracts/ExchangeRates.sol
+++ b/contracts/ExchangeRates.sol
@@ -266,7 +266,7 @@ contract ExchangeRates is SelfDestructible {
         bytes32 destinationCurrencyKey,
         uint roundIdForSrc,
         uint roundIdForDest
-    ) external view rateNotStale(sourceCurrencyKey) rateNotStale(destinationCurrencyKey) returns (uint) {
+    ) external view returns (uint) {
         // If there's no change in the currency, then just return the amount they gave us
         if (sourceCurrencyKey == destinationCurrencyKey) return sourceAmount;
 
@@ -311,8 +311,6 @@ contract ExchangeRates is SelfDestructible {
     function effectiveValue(bytes32 sourceCurrencyKey, uint sourceAmount, bytes32 destinationCurrencyKey)
         public
         view
-        rateNotStale(sourceCurrencyKey)
-        rateNotStale(destinationCurrencyKey)
         returns (uint)
     {
         // If there's no change in the currency, then just return the amount they gave us
@@ -564,11 +562,6 @@ contract ExchangeRates is SelfDestructible {
     }
 
     /* ========== MODIFIERS ========== */
-
-    modifier rateNotStale(bytes32 currencyKey) {
-        require(!rateIsStale(currencyKey), "Rate stale or nonexistant currency");
-        _;
-    }
 
     modifier onlyOracle {
         require(msg.sender == oracle, "Only the oracle can perform this action");

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -159,15 +159,13 @@ contract Exchanger is MixinResolver {
         uint sourceAmount,
         bytes32 destinationCurrencyKey,
         address destinationAddress
-    )
-        external
-        // Note: We don't need to insist on non-stale rates because effectiveValue will do it for us.
-        onlySynthetixorSynth
-        returns (uint amountReceived)
-    {
+    ) external onlySynthetixorSynth returns (uint amountReceived) {
         require(sourceCurrencyKey != destinationCurrencyKey, "Can't be same synth");
         require(sourceAmount > 0, "Zero amount");
         require(exchangeEnabled, "Exchanging is disabled");
+
+        require(!exchangeRates().rateIsStale(sourceCurrencyKey), "Source rate stale or not found");
+        require(!exchangeRates().rateIsStale(destinationCurrencyKey), "Dest rate stale or not found");
 
         (, uint refunded, uint numEntriesSettled) = _internalSettle(from, sourceCurrencyKey);
 
@@ -240,6 +238,8 @@ contract Exchanger is MixinResolver {
         returns (uint reclaimed, uint refunded, uint numEntriesSettled)
     {
         // Note: this function can be called by anyone on behalf of anyone else
+
+        require(!exchangeRates().rateIsStale(currencyKey), "Rate stale or not found");
 
         return _internalSettle(from, currencyKey);
     }

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -127,8 +127,7 @@ contract Synthetix is ExternStateToken, MixinResolver {
         uint total = 0;
         uint currencyRate = exRates.rateForCurrency(currencyKey);
 
-        (uint[] memory rates, bool anyRateStale) = exRates.ratesAndStaleForCurrencies(availableCurrencyKeys());
-        require(!anyRateStale, "Rates are stale");
+        (uint[] memory rates, ) = exRates.ratesAndStaleForCurrencies(availableCurrencyKeys());
 
         for (uint i = 0; i < availableSynths.length; i++) {
             // What's the total issued value of that synth in the destination currency?
@@ -311,14 +310,7 @@ contract Synthetix is ExternStateToken, MixinResolver {
      * @notice The maximum synths an issuer can issue against their total synthetix quantity.
      * This ignores any already issued synths, and is purely giving you the maximimum amount the user can issue.
      */
-    function maxIssuableSynths(address _issuer)
-        public
-        view
-        returns (
-            // We don't need to check stale rates here as effectiveValue will do it for us.
-            uint
-        )
-    {
+    function maxIssuableSynths(address _issuer) public view returns (uint) {
         // What is the value of their SNX balance in the destination currency?
         uint destinationValue = exchangeRates().effectiveValue("SNX", collateral(_issuer), sUSD);
 


### PR DESCRIPTION
This will allow all contract views to still return with no reverts, even when rates are stale. The onus is now on the mutative functions to prevent actions during stale rates rather than breaking the entire system for any apps reading state.

**Note:** This requires updating `EtherCollateral` which won't be upgraded until the 3m trial ends.