### PR TITLE
Added script to catch function hash collisions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,14 @@ jobs:
           at: .
       - run: npm run lint
 
+  clash-check:
+    <<: *env_defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: npm run test:collisions
+
   test-contracts:
     <<: *env_defaults
     parallelism: 4
@@ -122,6 +130,9 @@ workflows:
     jobs:
       - prepare
       - lint:
+          requires:
+            - prepare
+      - clash-check:
           requires:
             - prepare
       - test-contracts:

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"test:publish": "concurrently --kill-others --success first \"npm run ganache:int > /dev/null\" \"wait-port 8545 && mocha test/publish\"",
 		"test:deployments": "mocha test/deployments -- --timeout 15000",
 		"test:testnet": "node test/testnet",
+		"test:collisions": "mocha test/collisions",
 		"test:local": "concurrently --kill-others --success first \"npm run ganache:int > /dev/null\" \"wait-port 8545 && node test/testnet --network local --yes\"",
 		"truffle": "truffle"
 	},

--- a/test/collisions/index.js
+++ b/test/collisions/index.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 
 const { getTarget, getSource } = require('../..');
 
-// The functions are allowed to be duplicated between proxy and target
+// These functions are allowed to be duplicated between proxy and target
 const exemptList = [
 	'nominateNewOwner',
 	'balanceOf',

--- a/test/collisions/index.js
+++ b/test/collisions/index.js
@@ -1,0 +1,82 @@
+'use strict';
+
+const assert = require('assert');
+
+const { getTarget, getSource } = require('../..');
+
+// The functions are allowed to be duplicated between proxy and target
+const exemptList = [
+	'nominateNewOwner',
+	'balanceOf',
+	'acceptOwnership',
+	'owner',
+	'symbol',
+	'allowance',
+	'name',
+	'totalSupply',
+	'nominatedOwner',
+	'transfer',
+	'decimals',
+	'transferFrom',
+	'approve',
+];
+
+describe('proxy clash check', () => {
+	// Add local?
+	['kovan', 'rinkeby', 'ropsten', 'mainnet'].forEach(network => {
+		describe(network, () => {
+			const targets = getTarget({ network });
+			const sources = getSource({ network });
+			const contractPairs = new Map(); // proxy -> implementation
+
+			it('Proxy contracts should not have any function hash collisions', () => {
+				// 1) Map all proxy contracts with their target contracts
+				for (const target in targets) {
+					if (target.startsWith('Proxy')) {
+						// console.log(targets[target].name);
+						// console.log(targets[target].name.substring(5));
+						if (targets[target].name === 'ProxyFeePool') {
+							contractPairs.set(targets[target].name, 'FeePool');
+						} else if (targets[target].name === 'ProxyERC20sUSD') {
+							contractPairs.set(targets[target].name, 'SynthsUSD');
+						} else if (targets[target].name === 'ProxySynthetix') {
+							contractPairs.set(targets[target].name, 'Synthetix');
+						} else if (targets[target].name === 'ProxyERC20') {
+							contractPairs.set(targets[target].name, 'Synthetix');
+						} else if (targets['Synth' + targets[target].name.substring(5)] !== undefined) {
+							contractPairs.set(
+								targets[target].name,
+								targets['Synth' + targets[target].name.substring(5)].name
+							);
+						} else {
+							assert(false, 'A proxy contract was detected but not matched against implementation');
+						}
+					}
+				}
+
+				// 2) Check for collisions in proxy functions and target functions
+				for (const [proxy, target] of contractPairs.entries()) {
+					const proxyABI = sources[targets[proxy].source].abi;
+					const targetABI = sources[targets[target].source].abi;
+					const functionSelectors = new Map(); // FunctionHash -> name
+					for (const { type, name, signature } of proxyABI) {
+						if (type === 'function') {
+							functionSelectors.set(signature, name);
+						}
+					}
+					for (const { type, name, signature } of targetABI) {
+						if (type === 'function') {
+							assert(
+								!functionSelectors.has(signature) ||
+									(exemptList.includes(name) && name === functionSelectors.get(signature)),
+								`Function hash collision detected between function ${functionSelectors.get(
+									signature
+								)} of ${proxy} and function ${name} of ${target}`
+							);
+						}
+					}
+				}
+			});
+		});
+	});
+});


### PR DESCRIPTION
The script will run as part of CI and will catch collisions between function selectors in proxy and target contracts.

The script currently runs on testnet and mainnet deployments. 

Ideally, it should also run on local deployments but I'm not sure how to generate the local deployment file.