### PR TITLE
Splitting deployments test into an etherscan ABI check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,23 @@ env_defaults: &env_defaults
     - image: circleci/node:10.16
 
 version: 2.1
+commands:
+  testnet_pvt:
+    description: Run testnet PVT
+    parameters:
+      network:
+        type: string
+    steps:
+      - run: npm run test:testnet --  --yes --network << parameters.network >>
+
+  etherscan_check:
+    description: Run etherscan ABI check
+    parameters:
+      network:
+        type: string
+    steps:
+      - run: npm run test:etherscan --  --network << parameters.network >>
+
 jobs:
   prepare:
     <<: *env_defaults
@@ -98,7 +115,10 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: npm run test:testnet --  --yes --network kovan
+      - testnet_pvt:
+          network: kovan
+      - etherscan_check:
+          network: kovan
 
   test-rinkeby:
     <<: *env_defaults
@@ -106,7 +126,10 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: npm run test:testnet --  --yes --network rinkeby
+      - testnet_pvt:
+          network: rinkeby
+      - etherscan_check:
+          network: rinkeby
 
   test-ropsten:
     <<: *env_defaults
@@ -114,7 +137,20 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: npm run test:testnet --  --yes --network ropsten
+      - testnet_pvt:
+          network: ropsten
+      - etherscan_check:
+          network: ropsten
+
+  test-mainnet:
+    <<: *env_defaults
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      # - run: No PVT for mainnet just yet
+      - etherscan_check:
+          network: ropsten
 
 workflows:
   version: 2
@@ -154,3 +190,9 @@ workflows:
           filters:
             branches:
               only: release-candidate
+      - test-mainnet:
+          requires:
+            - prepare
+          filters:
+            branches:
+              only: master

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
 		"test:publish": "concurrently --kill-others --success first \"npm run ganache:int > /dev/null\" \"wait-port 8545 && mocha test/publish\"",
 		"test:deployments": "mocha test/deployments -- --timeout 15000",
 		"test:testnet": "node test/testnet",
+		"test:etherscan": "node test/etherscan",
 		"test:local": "concurrently --kill-others --success first \"npm run ganache:int > /dev/null\" \"wait-port 8545 && node test/testnet --network local --yes\"",
 		"truffle": "truffle"
 	},

--- a/test/etherscan/index.js
+++ b/test/etherscan/index.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const path = require('path');
+const Mocha = require('mocha');
+
+const commander = require('commander');
+const program = new commander.Command();
+
+program
+	.option('-n, --network <value>', 'The network to run off.', x => x.toLowerCase(), 'mainnet')
+	.action(async ({ network }) => {
+		// setup the network as an env variable
+		process.env.ETH_NETWORK = network;
+
+		const mocha = new Mocha({
+			timeout: 10e3, // 10 secs
+		});
+
+		// Add each .js file to the mocha instance
+		mocha.addFile(path.join(__dirname, 'spec.js'));
+
+		// Run the tests, this way we can pass CLI args in as env variables
+		mocha.run(failures => {
+			process.exitCode = failures ? 1 : 0; // exit with non-zero status if there were failures
+		});
+	});
+
+if (require.main === module) {
+	program.parse(process.argv);
+}

--- a/test/etherscan/spec.js
+++ b/test/etherscan/spec.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const Web3 = require('web3');
+const assert = require('assert');
+const axios = require('axios');
+
+require('dotenv').config();
+
+const { loadConnections, stringify } = require('../../publish/src/util');
+
+const { getTarget, getSource } = require('../..');
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const network = process.env.ETH_NETWORK;
+
+describe(`Etherscan on ${network}`, () => {
+	// we need this outside the test runner in order to generate tests per contract name
+	const targets = getTarget({ network });
+	const { providerUrl, etherscanUrl, etherscanLinkPrefix } = loadConnections({
+		network,
+	});
+
+	let sources;
+	let web3;
+
+	beforeEach(() => {
+		// reset this each test to prevent it getting overwritten
+		sources = getSource({ network });
+		web3 = new Web3();
+
+		web3 = new Web3(new Web3.providers.HttpProvider(providerUrl));
+	});
+
+	Object.values(targets).forEach(({ name, source, address }) => {
+		describe(`${name}`, () => {
+			it(`Etherscan has the correct ABI at ${etherscanLinkPrefix}/address/${address}`, async () => {
+				const response = await axios.get(etherscanUrl, {
+					params: {
+						module: 'contract',
+						action: 'getabi',
+						address,
+						apikey: process.env.ETHERSCAN_KEY,
+					},
+				});
+				let result;
+				try {
+					result = JSON.parse(response.data.result);
+				} catch (err) {
+					console.log('Error Etherscan returned the following:', response.data.result);
+					throw err;
+				}
+
+				const sortByName = (a, b) =>
+					(a.name || 'constructor') > (b.name || 'constructor') ? 1 : -1;
+
+				const removeSignaturesAndVariableNames = entry => {
+					delete entry.signature;
+					// Some contracts, such as ProxyERC20 were deployed with different function
+					// input names than currently in the code, so reomve these from the check
+					// specifically balanceOf(address owner) was changed to balanceOf(address account)
+					(entry.inputs || []).forEach(input => {
+						input.name = '';
+					});
+
+					// Special edge-case: TokenStateSynthetix on mainnet has older
+					// method name "nominateOwner" over "nominateNewOwner"
+					if (
+						network === 'mainnet' &&
+						name === 'TokenStateSynthetix' &&
+						entry.name === 'nominateOwner'
+					) {
+						entry.name = 'nominateNewOwner';
+					}
+					return entry;
+				};
+
+				const actual = stringify(result.sort(sortByName).map(removeSignaturesAndVariableNames));
+				const expected = stringify(
+					sources[source].abi.sort(sortByName).map(removeSignaturesAndVariableNames)
+				);
+
+				assert.strictEqual(actual, expected);
+
+				// wait 1.5s in order to prevent Etherscan rate limits (use 1.5s as parallel tests in CI
+				// can trigger the limit)
+				await sleep(1500);
+			});
+
+			it('ABI signature is correct', () => {
+				const { abi } = sources[source];
+
+				const { encodeFunctionSignature, encodeEventSignature } = web3.eth.abi;
+
+				for (const { type, inputs, name, signature } of abi) {
+					if (type === 'function') {
+						assert.strictEqual(
+							encodeFunctionSignature({ name, inputs }),
+							signature,
+							`${source}.${name} signature mismatch`
+						);
+					} else if (type === 'event') {
+						assert.strictEqual(
+							encodeEventSignature({ name, inputs }),
+							signature,
+							`${source}.${name} signature mismatch`
+						);
+					}
+				}
+			});
+		});
+	});
+});


### PR DESCRIPTION
This will stop spurious failures from checking Etherscan ABIs each commit, and only run them on merging into named release branches - `master`, `release-candidate`, `beta` and `alpha`