### PR TITLE
set default min stake time

### DIFF
--- a/contracts/Issuer.sol
+++ b/contracts/Issuer.sol
@@ -22,7 +22,7 @@ contract Issuer is MixinResolver {
     // Minimum Stake time may not exceed 1 weeks.
     uint public constant MAX_MINIMUM_STAKING_TIME = 1 weeks;
 
-    uint public minimumStakeTime = 8 hours; // default minimum waiting period after issuing synths
+    uint public minimumStakeTime = 24 hours; // default minimum waiting period after issuing synths
 
     /* ========== ADDRESS RESOLVER CONFIGURATION ========== */
 

--- a/test/contracts/Issuer.js
+++ b/test/contracts/Issuer.js
@@ -77,6 +77,10 @@ contract('Issuer (via Synthetix)', async accounts => {
 			],
 		}));
 
+		// check default min stake time is set 24hrs
+		const defaultMinStakeTime = 86400;
+		assert.bnEqual(defaultMinStakeTime, await issuer.minimumStakeTime());
+
 		// set minimumStakeTime on issue and burning to 0
 		await issuer.setMinimumStakeTime(0, { from: owner });
 	});
@@ -175,7 +179,7 @@ contract('Issuer (via Synthetix)', async accounts => {
 				reason: 'Only the synthetix contract can perform this action',
 			});
 		});
-		it('setMinimumStakeTime() can onlt be invoked by owner', async () => {
+		it('setMinimumStakeTime() can only be invoked by owner', async () => {
 			await onlyGivenAddressCanInvoke({
 				fnc: issuer.setMinimumStakeTime,
 				args: [1],


### PR DESCRIPTION
set default min stake time

- can be updated to go into develop after migrating-to-buiilder is merged into develop