### PR TITLE
[WIP] Added slither to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -152,6 +152,15 @@ jobs:
       - etherscan_check:
           network: ropsten
 
+  slither:
+    docker:
+    - image: trailofbits/eth-security-toolbox
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: slither .
+
 workflows:
   version: 2
   dev:
@@ -199,3 +208,6 @@ workflows:
           filters:
             branches:
               only: master
+      - slither:
+          requires:
+            - prepare

--- a/slither.config.json
+++ b/slither.config.json
@@ -1,0 +1,3 @@
+{
+    "buidler_cache_directory": "build/cache"
+}


### PR DESCRIPTION
It might take a couple of tries to get the CI config right but you can run slither locally with this dockerfile
```
FROM trailofbits/eth-security-toolbox
USER ethsec
ENV DEBIAN_FRONTEND noninteractive

RUN sudo apt update
RUN sudo apt install wget curl gnupg software-properties-common apt-utils git-core unzip python2.7 -y

RUN git clone https://github.com/Synthetixio/synthetix.git
WORKDIR /home/ethsec/synthetix

RUN git checkout develop
RUN npm i
RUN echo '{"buidler_cache_directory": "build/cache"}' >> slither.config.json
RUN slither .
```