### PR TITLE
Fixing main interfaces

### DIFF
--- a/contracts/AddressResolver.sol
+++ b/contracts/AddressResolver.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 
 

--- a/contracts/DelegateApprovals.sol
+++ b/contracts/DelegateApprovals.sol
@@ -1,11 +1,12 @@
 pragma solidity ^0.5.16;
 
-import "./EternalStorage.sol";
 import "./Owned.sol";
+import "./interfaces/IDelegateApprovals.sol";
+import "./EternalStorage.sol";
 
 
 // https://docs.synthetix.io/contracts/DelegateApprovals
-contract DelegateApprovals is Owned {
+contract DelegateApprovals is Owned, IDelegateApprovals {
     bytes32 public constant BURN_FOR_ADDRESS = "BurnForAddress";
     bytes32 public constant ISSUE_FOR_ADDRESS = "IssueForAddress";
     bytes32 public constant CLAIM_FOR_ADDRESS = "ClaimForAddress";

--- a/contracts/DelegateApprovals.sol
+++ b/contracts/DelegateApprovals.sol
@@ -1,7 +1,10 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./interfaces/IDelegateApprovals.sol";
+
+// Internal references
 import "./EternalStorage.sol";
 
 

--- a/contracts/Depot.sol
+++ b/contracts/Depot.sol
@@ -12,7 +12,6 @@ import "./interfaces/IDepot.sol";
 import "./SafeDecimalMath.sol";
 
 // Internal references
-import "./interfaces/ISynth.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/IExchangeRates.sol";
 
@@ -502,8 +501,8 @@ contract Depot is Owned, SelfDestructible, Pausable, ReentrancyGuard, MixinResol
 
     /* ========== INTERNAL VIEWS ========== */
 
-    function synthsUSD() internal view returns (ISynth) {
-        return ISynth(requireAndGetAddress(CONTRACT_SYNTHSUSD, "Missing SynthsUSD address"));
+    function synthsUSD() internal view returns (IERC20) {
+        return IERC20(requireAndGetAddress(CONTRACT_SYNTHSUSD, "Missing SynthsUSD address"));
     }
 
     function synthetix() internal view returns (IERC20) {

--- a/contracts/Depot.sol
+++ b/contracts/Depot.sol
@@ -1,12 +1,17 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./SelfDestructible.sol";
 import "./Pausable.sol";
 import "openzeppelin-solidity-2.3.0/contracts/utils/ReentrancyGuard.sol";
 import "./MixinResolver.sol";
 import "./interfaces/IDepot.sol";
+
+// Libraries
 import "./SafeDecimalMath.sol";
+
+// Internal references
 import "./interfaces/ISynth.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/IExchangeRates.sol";

--- a/contracts/EscrowChecker.sol
+++ b/contracts/EscrowChecker.sol
@@ -1,18 +1,18 @@
 pragma solidity ^0.5.16;
 
 
-contract SynthetixEscrow {
-    function numVestingEntries(address account) public view returns (uint);
+interface ISynthetixEscrow {
+    function numVestingEntries(address account) external view returns (uint);
 
-    function getVestingScheduleEntry(address account, uint index) public view returns (uint[2] memory);
+    function getVestingScheduleEntry(address account, uint index) external view returns (uint[2] memory);
 }
 
 
 // https://docs.synthetix.io/contracts/EscrowChecker
 contract EscrowChecker {
-    SynthetixEscrow public synthetix_escrow;
+    ISynthetixEscrow public synthetix_escrow;
 
-    constructor(SynthetixEscrow _esc) public {
+    constructor(ISynthetixEscrow _esc) public {
         synthetix_escrow = _esc;
     }
 

--- a/contracts/EternalStorage.sol
+++ b/contracts/EternalStorage.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./State.sol";
 

--- a/contracts/EtherCollateral.sol
+++ b/contracts/EtherCollateral.sol
@@ -377,7 +377,7 @@ contract EtherCollateral is Owned, Pausable, ReentrancyGuard, MixinResolver, IEt
         depot().exchangeEtherForSynths.value(totalFees)();
 
         // Transfer the sUSD to distribute to SNX holders.
-        synthsUSD().transfer(FEE_ADDRESS, IERC20(address(synthsUSD())).balanceOf(address(this)));
+        IERC20(address(synthsUSD())).transfer(FEE_ADDRESS, IERC20(address(synthsUSD())).balanceOf(address(this)));
 
         // Send remainder ETH to caller
         address(msg.sender).transfer(synthLoan.collateralAmount.sub(totalFees));

--- a/contracts/EtherCollateral.sol
+++ b/contracts/EtherCollateral.sol
@@ -9,11 +9,12 @@ import "./interfaces/IFeePool.sol";
 import "./interfaces/ISynth.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/IDepot.sol";
+import "./interfaces/IEtherCollateral.sol";
 import "./MixinResolver.sol";
 
 
 // https://docs.synthetix.io/contracts/EtherCollateral
-contract EtherCollateral is Owned, Pausable, ReentrancyGuard, MixinResolver {
+contract EtherCollateral is Owned, Pausable, ReentrancyGuard, MixinResolver, IEtherCollateral {
     using SafeMath for uint256;
     using SafeDecimalMath for uint256;
 

--- a/contracts/EtherCollateral.sol
+++ b/contracts/EtherCollateral.sol
@@ -346,7 +346,7 @@ contract EtherCollateral is Owned, Pausable, ReentrancyGuard, MixinResolver, IEt
         require(synthLoan.loanID > 0, "Loan does not exist");
         require(synthLoan.timeClosed == 0, "Loan already closed");
         require(
-            synthsETH().balanceOf(msg.sender) >= synthLoan.loanAmount,
+            IERC20(address(synthsETH())).balanceOf(msg.sender) >= synthLoan.loanAmount,
             "You do not have the required Synth balance to close this loan."
         );
 
@@ -366,13 +366,13 @@ contract EtherCollateral is Owned, Pausable, ReentrancyGuard, MixinResolver, IEt
 
         // Fee Distribution. Purchase sUSD with ETH from Depot
         require(
-            synthsUSD().balanceOf(address(depot())) >= totalFees,
+            IERC20(address(synthsUSD())).balanceOf(address(depot())) >= totalFees,
             "The sUSD Depot does not have enough sUSD to buy for fees"
         );
         depot().exchangeEtherForSynths.value(totalFees)();
 
         // Transfer the sUSD to distribute to SNX holders.
-        synthsUSD().transfer(FEE_ADDRESS, synthsUSD().balanceOf(address(this)));
+        synthsUSD().transfer(FEE_ADDRESS, IERC20(address(synthsUSD())).balanceOf(address(this)));
 
         // Send remainder ETH to caller
         address(msg.sender).transfer(synthLoan.collateralAmount.sub(totalFees));

--- a/contracts/EtherCollateral.sol
+++ b/contracts/EtherCollateral.sol
@@ -1,16 +1,21 @@
 pragma solidity ^0.5.16;
 
-import "openzeppelin-solidity-2.3.0/contracts/utils/ReentrancyGuard.sol";
+// Inheritance
 import "./Owned.sol";
 import "./Pausable.sol";
+import "openzeppelin-solidity-2.3.0/contracts/utils/ReentrancyGuard.sol";
+import "./MixinResolver.sol";
+import "./interfaces/IEtherCollateral.sol";
+
+// Libraries
 import "./SafeDecimalMath.sol";
+
+// Internal references
 import "./interfaces/ISystemStatus.sol";
 import "./interfaces/IFeePool.sol";
 import "./interfaces/ISynth.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/IDepot.sol";
-import "./interfaces/IEtherCollateral.sol";
-import "./MixinResolver.sol";
 
 
 // https://docs.synthetix.io/contracts/EtherCollateral

--- a/contracts/ExchangeRates.sol
+++ b/contracts/ExchangeRates.sol
@@ -1,8 +1,9 @@
 pragma solidity ^0.5.16;
 
-import "openzeppelin-solidity-2.3.0/contracts/math/SafeMath.sol";
 import "./Owned.sol";
 import "./SelfDestructible.sol";
+import "./interfaces/IExchangeRates.sol";
+import "openzeppelin-solidity-2.3.0/contracts/math/SafeMath.sol";
 import "./SafeDecimalMath.sol";
 
 // AggregatorInterface from Chainlink represents a decentralized pricing network for a single currency key
@@ -10,7 +11,7 @@ import "@chainlink/contracts-0.0.3/src/v0.5/dev/AggregatorInterface.sol";
 
 
 // https://docs.synthetix.io/contracts/ExchangeRates
-contract ExchangeRates is Owned, SelfDestructible {
+contract ExchangeRates is Owned, SelfDestructible, IExchangeRates {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
 

--- a/contracts/ExchangeRates.sol
+++ b/contracts/ExchangeRates.sol
@@ -1,11 +1,14 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./SelfDestructible.sol";
 import "./interfaces/IExchangeRates.sol";
-import "openzeppelin-solidity-2.3.0/contracts/math/SafeMath.sol";
+
+// Libraries
 import "./SafeDecimalMath.sol";
 
+// Internal references
 // AggregatorInterface from Chainlink represents a decentralized pricing network for a single currency key
 import "@chainlink/contracts-0.0.3/src/v0.5/dev/AggregatorInterface.sol";
 

--- a/contracts/ExchangeState.sol
+++ b/contracts/ExchangeState.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./State.sol";
 import "./interfaces/IExchangeState.sol";

--- a/contracts/ExchangeState.sol
+++ b/contracts/ExchangeState.sol
@@ -2,10 +2,11 @@ pragma solidity ^0.5.16;
 
 import "./Owned.sol";
 import "./State.sol";
+import "./interfaces/IExchangeState.sol";
 
 
 // https://docs.synthetix.io/contracts/ExchangeState
-contract ExchangeState is Owned, State {
+contract ExchangeState is Owned, State, IExchangeState {
     struct ExchangeEntry {
         bytes32 src;
         uint amount;

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -1,19 +1,25 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./MixinResolver.sol";
 import "./interfaces/IExchanger.sol";
+
+// Libraries
 import "openzeppelin-solidity-2.3.0/contracts/math/SafeMath.sol";
 import "./SafeDecimalMath.sol";
+
+// Internal references
 import "./interfaces/IERC20.sol";
+import "./interfaces/ISystemStatus.sol";
 import "./interfaces/IExchangeState.sol";
 import "./interfaces/IExchangeRates.sol";
-import "./interfaces/ISystemStatus.sol";
 import "./interfaces/ISynthetix.sol";
 import "./interfaces/IFeePool.sol";
 import "./interfaces/IDelegateApprovals.sol";
 
 
+// Used to have strongly-typed access to internal mutative functions in Synthetix
 interface ISynthetixInternal {
     function emitSynthExchange(
         address account,

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.5.16;
 import "openzeppelin-solidity-2.3.0/contracts/math/SafeMath.sol";
 import "./Owned.sol";
 import "./MixinResolver.sol";
+import "./interfaces/IExchanger.sol";
 import "./SafeDecimalMath.sol";
 import "./interfaces/IExchangeState.sol";
 import "./interfaces/IExchangeRates.sol";
@@ -13,7 +14,7 @@ import "./interfaces/IDelegateApprovals.sol";
 
 
 // https://docs.synthetix.io/contracts/Exchanger
-contract Exchanger is Owned, MixinResolver {
+contract Exchanger is Owned, MixinResolver, IExchanger {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
 

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -6,7 +6,6 @@ import "./MixinResolver.sol";
 import "./interfaces/IExchanger.sol";
 
 // Libraries
-import "openzeppelin-solidity-2.3.0/contracts/math/SafeMath.sol";
 import "./SafeDecimalMath.sol";
 
 // Internal references

--- a/contracts/ExternStateToken.sol
+++ b/contracts/ExternStateToken.sol
@@ -3,14 +3,13 @@ pragma solidity ^0.5.16;
 import "./Owned.sol";
 import "./SelfDestructible.sol";
 import "./Proxyable.sol";
-import "./interfaces/IERC20.sol";
 import "openzeppelin-solidity-2.3.0/contracts/math/SafeMath.sol";
 import "./SafeDecimalMath.sol";
 import "./TokenState.sol";
 
 
 // https://docs.synthetix.io/contracts/ExternStateToken
-contract ExternStateToken is Owned, SelfDestructible, Proxyable, IERC20 {
+contract ExternStateToken is Owned, SelfDestructible, Proxyable {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
 

--- a/contracts/ExternStateToken.sol
+++ b/contracts/ExternStateToken.sol
@@ -3,13 +3,14 @@ pragma solidity ^0.5.16;
 import "./Owned.sol";
 import "./SelfDestructible.sol";
 import "./Proxyable.sol";
+import "./interfaces/IERC20.sol";
 import "openzeppelin-solidity-2.3.0/contracts/math/SafeMath.sol";
 import "./SafeDecimalMath.sol";
 import "./TokenState.sol";
 
 
 // https://docs.synthetix.io/contracts/ExternStateToken
-contract ExternStateToken is Owned, SelfDestructible, Proxyable {
+contract ExternStateToken is Owned, SelfDestructible, Proxyable, IERC20 {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
 
@@ -55,7 +56,7 @@ contract ExternStateToken is Owned, SelfDestructible, Proxyable {
     /**
      * @notice Returns the ERC20 token balance of a given account.
      */
-    function balanceOf(address account) public view returns (uint) {
+    function balanceOf(address account) external view returns (uint) {
         return tokenState.balanceOf(account);
     }
 

--- a/contracts/ExternStateToken.sol
+++ b/contracts/ExternStateToken.sol
@@ -1,10 +1,14 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./SelfDestructible.sol";
 import "./Proxyable.sol";
-import "openzeppelin-solidity-2.3.0/contracts/math/SafeMath.sol";
+
+// Libraries
 import "./SafeDecimalMath.sol";
+
+// Internal references
 import "./TokenState.sol";
 
 

--- a/contracts/FeePool.sol
+++ b/contracts/FeePool.sol
@@ -5,6 +5,8 @@ import "./Proxyable.sol";
 import "./SelfDestructible.sol";
 import "./LimitedSetup.sol";
 import "./MixinResolver.sol";
+import "./interfaces/IFeePool.sol";
+
 import "./SafeDecimalMath.sol";
 import "./interfaces/ISystemStatus.sol";
 import "./interfaces/ISynthetixEscrow.sol";
@@ -21,7 +23,7 @@ import "./DelegateApprovals.sol";
 
 
 // https://docs.synthetix.io/contracts/FeePool
-contract FeePool is Owned, Proxyable, SelfDestructible, LimitedSetup, MixinResolver {
+contract FeePool is Owned, Proxyable, SelfDestructible, LimitedSetup, MixinResolver, IFeePool {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
 

--- a/contracts/FeePool.sol
+++ b/contracts/FeePool.sol
@@ -9,7 +9,7 @@ import "./interfaces/IFeePool.sol";
 
 import "./SafeDecimalMath.sol";
 import "./interfaces/ISystemStatus.sol";
-import "./interfaces/ISynthetixEscrow.sol";
+import "./interfaces/IRewardEscrow.sol";
 import "./interfaces/IExchangeRates.sol";
 import "./interfaces/ISynthetixState.sol";
 import "./interfaces/ISynthetix.sol";
@@ -158,8 +158,8 @@ contract FeePool is Owned, Proxyable, SelfDestructible, LimitedSetup, MixinResol
         return ISynthetixState(requireAndGetAddress(CONTRACT_SYNTHETIXSTATE, "Missing SynthetixState address"));
     }
 
-    function rewardEscrow() internal view returns (ISynthetixEscrow) {
-        return ISynthetixEscrow(requireAndGetAddress(CONTRACT_REWARDESCROW, "Missing RewardEscrow address"));
+    function rewardEscrow() internal view returns (IRewardEscrow) {
+        return IRewardEscrow(requireAndGetAddress(CONTRACT_REWARDESCROW, "Missing RewardEscrow address"));
     }
 
     function delegateApprovals() internal view returns (DelegateApprovals) {

--- a/contracts/FeePool.sol
+++ b/contracts/FeePool.sol
@@ -543,15 +543,6 @@ contract FeePool is Owned, Proxyable, SelfDestructible, LimitedSetup, MixinResol
     }
 
     /**
-     * @notice The amount the recipient will receive if you send a certain number of tokens.
-     * function used by Depot and stub will return value amount inputted.
-     * @param value The amount of tokens you intend to send.
-     */
-    function amountReceivedFromTransfer(uint value) external pure returns (uint) {
-        return value;
-    }
-
-    /**
      * @notice Calculate the fee charged on top of a value being sent via an exchange
      * @return Return the fee charged
      */

--- a/contracts/FeePoolEternalStorage.sol
+++ b/contracts/FeePoolEternalStorage.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./EternalStorage.sol";
 import "./LimitedSetup.sol";
 

--- a/contracts/FeePoolState.sol
+++ b/contracts/FeePoolState.sol
@@ -1,9 +1,14 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./SelfDestructible.sol";
 import "./LimitedSetup.sol";
+
+// Libraries
 import "./SafeDecimalMath.sol";
+
+// Internal references
 import "./interfaces/IFeePool.sol";
 
 

--- a/contracts/IssuanceEternalStorage.sol
+++ b/contracts/IssuanceEternalStorage.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./EternalStorage.sol";
 
 

--- a/contracts/Issuer.sol
+++ b/contracts/Issuer.sol
@@ -1,10 +1,14 @@
 pragma solidity ^0.5.16;
 
-import "openzeppelin-solidity-2.3.0/contracts/math/SafeMath.sol";
+// Inheritance
 import "./Owned.sol";
 import "./MixinResolver.sol";
 import "./interfaces/IIssuer.sol";
+
+// Libraries
 import "./SafeDecimalMath.sol";
+
+// Inheritance
 import "./IssuanceEternalStorage.sol";
 import "./interfaces/ISynthetix.sol";
 import "./interfaces/IFeePool.sol";

--- a/contracts/Issuer.sol
+++ b/contracts/Issuer.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.5.16;
 import "openzeppelin-solidity-2.3.0/contracts/math/SafeMath.sol";
 import "./Owned.sol";
 import "./MixinResolver.sol";
+import "./interfaces/IIssuer.sol";
 import "./SafeDecimalMath.sol";
 import "./IssuanceEternalStorage.sol";
 import "./interfaces/ISynthetix.sol";
@@ -13,7 +14,7 @@ import "./interfaces/IDelegateApprovals.sol";
 
 
 // https://docs.synthetix.io/contracts/Issuer
-contract Issuer is Owned, MixinResolver {
+contract Issuer is Owned, MixinResolver, IIssuer {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
 

--- a/contracts/Math.sol
+++ b/contracts/Math.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Libraries
 import "./SafeDecimalMath.sol";
 
 

--- a/contracts/MixinResolver.sol
+++ b/contracts/MixinResolver.sol
@@ -1,6 +1,9 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
+
+// Internal references
 import "./AddressResolver.sol";
 
 

--- a/contracts/MultiCollateralSynth.sol
+++ b/contracts/MultiCollateralSynth.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Synth.sol";
 
 

--- a/contracts/Pausable.sol
+++ b/contracts/Pausable.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 
 

--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -1,6 +1,9 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
+
+// Internal references
 import "./Proxyable.sol";
 
 

--- a/contracts/ProxyERC20.sol
+++ b/contracts/ProxyERC20.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Proxy.sol";
 import "./interfaces/IERC20.sol";
 

--- a/contracts/Proxyable.sol
+++ b/contracts/Proxyable.sol
@@ -1,6 +1,9 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
+
+// Internal references
 import "./Proxy.sol";
 
 

--- a/contracts/PurgeableSynth.sol
+++ b/contracts/PurgeableSynth.sol
@@ -1,9 +1,13 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Synth.sol";
+
+// Libraries
 import "./SafeDecimalMath.sol";
+
+// Internal References
 import "./interfaces/IExchangeRates.sol";
-import "./interfaces/ISynthetix.sol";
 
 
 // https://docs.synthetix.io/contracts/PurgeableSynth

--- a/contracts/PurgeableSynth.sol
+++ b/contracts/PurgeableSynth.sol
@@ -56,7 +56,7 @@ contract PurgeableSynth is Synth {
         for (uint i = 0; i < addresses.length; i++) {
             address holder = addresses[i];
 
-            uint amountHeld = balanceOf(holder);
+            uint amountHeld = tokenState.balanceOf(holder);
 
             if (amountHeld > 0) {
                 exchanger().exchange(holder, currencyKey, amountHeld, "sUSD", holder);

--- a/contracts/RewardEscrow.sol
+++ b/contracts/RewardEscrow.sol
@@ -4,10 +4,11 @@ import "./Owned.sol";
 import "./SafeDecimalMath.sol";
 import "./interfaces/IFeePool.sol";
 import "./interfaces/ISynthetix.sol";
+import "./interfaces/IRewardEscrow.sol";
 
 
 // https://docs.synthetix.io/contracts/RewardEscrow
-contract RewardEscrow is Owned {
+contract RewardEscrow is Owned, IRewardEscrow {
     using SafeMath for uint;
 
     /* The corresponding Synthetix contract. */
@@ -74,10 +75,14 @@ contract RewardEscrow is Owned {
         return totalEscrowedAccountBalance[account];
     }
 
+    function _numVestingEntries(address account) internal view returns (uint) {
+        return vestingSchedules[account].length;
+    }
+
     /**
      * @notice The number of vesting dates in an account's schedule.
      */
-    function numVestingEntries(address account) public view returns (uint) {
+    function numVestingEntries(address account) external view returns (uint) {
         return vestingSchedules[account].length;
     }
 
@@ -107,7 +112,7 @@ contract RewardEscrow is Owned {
      * @notice Obtain the index of the next schedule entry that will vest for a given user.
      */
     function getNextVestingIndex(address account) public view returns (uint) {
-        uint len = numVestingEntries(account);
+        uint len = _numVestingEntries(account);
         for (uint i = 0; i < len; i++) {
             if (getVestingTime(account, i) != 0) {
                 return i;
@@ -121,7 +126,7 @@ contract RewardEscrow is Owned {
      * @return A pair of uints: (timestamp, synthetix quantity). */
     function getNextVestingEntry(address account) public view returns (uint[2] memory) {
         uint index = getNextVestingIndex(account);
-        if (index == numVestingEntries(account)) {
+        if (index == _numVestingEntries(account)) {
             return [uint(0), 0];
         }
         return getVestingScheduleEntry(account, index);
@@ -149,7 +154,7 @@ contract RewardEscrow is Owned {
      */
     function checkAccountSchedule(address account) public view returns (uint[520] memory) {
         uint[520] memory _result;
-        uint schedules = numVestingEntries(account);
+        uint schedules = _numVestingEntries(account);
         for (uint i = 0; i < schedules; i++) {
             uint[2] memory pair = getVestingScheduleEntry(account, i);
             _result[i * 2] = pair[0];
@@ -160,16 +165,7 @@ contract RewardEscrow is Owned {
 
     /* ========== MUTATIVE FUNCTIONS ========== */
 
-    /**
-     * @notice Add a new vesting entry at a given time and quantity to an account's schedule.
-     * @dev A call to this should accompany a previous successful call to synthetix.transfer(rewardEscrow, amount),
-     * to ensure that when the funds are withdrawn, there is enough balance.
-     * Note; although this function could technically be used to produce unbounded
-     * arrays, it's only withinn the 4 year period of the weekly inflation schedule.
-     * @param account The account to append a new vesting entry to.
-     * @param quantity The quantity of SNX that will be escrowed.
-     */
-    function appendVestingEntry(address account, uint quantity) public onlyFeePool {
+    function _appendVestingEntry(address account, uint quantity) internal {
         /* No empty or already-passed vesting entries allowed. */
         require(quantity != 0, "Quantity cannot be zero");
 
@@ -205,10 +201,23 @@ contract RewardEscrow is Owned {
     }
 
     /**
+     * @notice Add a new vesting entry at a given time and quantity to an account's schedule.
+     * @dev A call to this should accompany a previous successful call to synthetix.transfer(rewardEscrow, amount),
+     * to ensure that when the funds are withdrawn, there is enough balance.
+     * Note; although this function could technically be used to produce unbounded
+     * arrays, it's only withinn the 4 year period of the weekly inflation schedule.
+     * @param account The account to append a new vesting entry to.
+     * @param quantity The quantity of SNX that will be escrowed.
+     */
+    function appendVestingEntry(address account, uint quantity) external onlyFeePool {
+        _appendVestingEntry(account, quantity);
+    }
+
+    /**
      * @notice Allow a user to withdraw any SNX in their schedule that have vested.
      */
     function vest() external {
-        uint numEntries = numVestingEntries(msg.sender);
+        uint numEntries = _numVestingEntries(msg.sender);
         uint total;
         for (uint i = 0; i < numEntries; i++) {
             uint time = getVestingTime(msg.sender, i);

--- a/contracts/RewardEscrow.sol
+++ b/contracts/RewardEscrow.sol
@@ -1,11 +1,16 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
+import "./interfaces/IRewardEscrow.sol";
+
+// Libraries
 import "./SafeDecimalMath.sol";
+
+// Internal references
 import "./interfaces/IERC20.sol";
 import "./interfaces/IFeePool.sol";
 import "./interfaces/ISynthetix.sol";
-import "./interfaces/IRewardEscrow.sol";
 
 
 // https://docs.synthetix.io/contracts/RewardEscrow

--- a/contracts/RewardEscrow.sol
+++ b/contracts/RewardEscrow.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.16;
 
 import "./Owned.sol";
 import "./SafeDecimalMath.sol";
+import "./interfaces/IERC20.sol";
 import "./interfaces/IFeePool.sol";
 import "./interfaces/ISynthetix.sol";
 import "./interfaces/IRewardEscrow.sol";
@@ -172,7 +173,7 @@ contract RewardEscrow is Owned, IRewardEscrow {
         /* There must be enough balance in the contract to provide for the vesting entry. */
         totalEscrowedBalance = totalEscrowedBalance.add(quantity);
         require(
-            totalEscrowedBalance <= synthetix.balanceOf(address(this)),
+            totalEscrowedBalance <= IERC20(address(synthetix)).balanceOf(address(this)),
             "Must be enough balance in the contract to provide for the vesting entry"
         );
 
@@ -238,7 +239,7 @@ contract RewardEscrow is Owned, IRewardEscrow {
             totalEscrowedBalance = totalEscrowedBalance.sub(total);
             totalEscrowedAccountBalance[msg.sender] = totalEscrowedAccountBalance[msg.sender].sub(total);
             totalVestedAccountBalance[msg.sender] = totalVestedAccountBalance[msg.sender].add(total);
-            synthetix.transfer(msg.sender, total);
+            IERC20(address(synthetix)).transfer(msg.sender, total);
             emit Vested(msg.sender, now, total);
         }
     }

--- a/contracts/RewardsDistribution.sol
+++ b/contracts/RewardsDistribution.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.16;
 
 import "./Owned.sol";
+import "./interfaces/IRewardsDistribution.sol";
 import "./SafeDecimalMath.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/IFeePool.sol";
@@ -8,7 +9,7 @@ import "./interfaces/ISynthetix.sol";
 
 
 // https://docs.synthetix.io/contracts/RewardsDistribution
-contract RewardsDistribution is Owned {
+contract RewardsDistribution is Owned, IRewardsDistribution {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
 

--- a/contracts/RewardsDistribution.sol
+++ b/contracts/RewardsDistribution.sol
@@ -146,13 +146,6 @@ contract RewardsDistribution is Owned, IRewardsDistribution {
         return true;
     }
 
-    /**
-     * @notice Iterates the distributions sending set out amounts of
-     * tokens to the specified address. The remainder is then sent to the RewardEscrow Contract
-     * and applied to the FeePools staking rewards.
-     * @param amount The total number of tokens being distributed
-
-     */
     function distributeRewards(uint amount) external returns (bool) {
         require(msg.sender == authority, "Caller is not authorised");
         require(rewardEscrow != address(0), "RewardEscrow is not set");

--- a/contracts/RewardsDistribution.sol
+++ b/contracts/RewardsDistribution.sol
@@ -1,11 +1,15 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./interfaces/IRewardsDistribution.sol";
+
+// Libraires
 import "./SafeDecimalMath.sol";
+
+// Internal references
 import "./interfaces/IERC20.sol";
 import "./interfaces/IFeePool.sol";
-import "./interfaces/ISynthetix.sol";
 
 
 // https://docs.synthetix.io/contracts/RewardsDistribution

--- a/contracts/RewardsDistributionRecipient.sol
+++ b/contracts/RewardsDistributionRecipient.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 
 

--- a/contracts/SafeDecimalMath.sol
+++ b/contracts/SafeDecimalMath.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Libraries
 import "openzeppelin-solidity-2.3.0/contracts/math/SafeMath.sol";
 
 

--- a/contracts/SelfDestructible.sol
+++ b/contracts/SelfDestructible.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 
 

--- a/contracts/State.sol
+++ b/contracts/State.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 
 

--- a/contracts/SupplySchedule.sol
+++ b/contracts/SupplySchedule.sol
@@ -1,9 +1,13 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
-import "openzeppelin-solidity-2.3.0/contracts/math/SafeMath.sol";
+
+// Libraries
 import "./SafeDecimalMath.sol";
 import "./Math.sol";
+
+// Internal references
 import "./Proxy.sol";
 import "./interfaces/ISynthetix.sol";
 import "./interfaces/IERC20.sol";

--- a/contracts/SupplySchedule.sol
+++ b/contracts/SupplySchedule.sol
@@ -6,6 +6,7 @@ import "./SafeDecimalMath.sol";
 import "./Math.sol";
 import "./Proxy.sol";
 import "./interfaces/ISynthetix.sol";
+import "./interfaces/IERC20.sol";
 
 
 // https://docs.synthetix.io/contracts/SupplySchedule
@@ -91,7 +92,7 @@ contract SupplySchedule is Owned {
             } else {
                 // Terminal supply is calculated on the total supply of Synthetix including any new supply
                 // We can compound the remaining week's supply at the fixed terminal rate
-                uint totalSupply = ISynthetix(synthetixProxy).totalSupply();
+                uint totalSupply = IERC20(synthetixProxy).totalSupply();
                 uint currentTotalSupply = totalSupply.add(totalAmount);
 
                 totalAmount = totalAmount.add(terminalInflationSupply(currentTotalSupply, remainingWeeksToMint));

--- a/contracts/Synth.sol
+++ b/contracts/Synth.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.5.16;
 import "./Owned.sol";
 import "./ExternStateToken.sol";
 import "./MixinResolver.sol";
+import "./interfaces/ISynth.sol";
 import "./interfaces/ISystemStatus.sol";
 import "./interfaces/IFeePool.sol";
 import "./interfaces/ISynthetix.sol";
@@ -10,7 +11,7 @@ import "./interfaces/IExchanger.sol";
 import "./interfaces/IIssuer.sol";
 
 
-contract Synth is Owned, ExternStateToken, MixinResolver {
+contract Synth is Owned, ExternStateToken, MixinResolver, ISynth {
     /* ========== STATE VARIABLES ========== */
 
     // Currency key which identifies this Synth to the Synthetix system

--- a/contracts/Synth.sol
+++ b/contracts/Synth.sol
@@ -1,9 +1,12 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./ExternStateToken.sol";
 import "./MixinResolver.sol";
 import "./interfaces/ISynth.sol";
+
+// Internal references
 import "./interfaces/ISystemStatus.sol";
 import "./interfaces/IFeePool.sol";
 import "./interfaces/ISynthetix.sol";

--- a/contracts/Synth.sol
+++ b/contracts/Synth.sol
@@ -5,6 +5,7 @@ import "./Owned.sol";
 import "./ExternStateToken.sol";
 import "./MixinResolver.sol";
 import "./interfaces/ISynth.sol";
+import "./interfaces/IERC20.sol";
 
 // Internal references
 import "./interfaces/ISystemStatus.sol";
@@ -14,7 +15,7 @@ import "./interfaces/IExchanger.sol";
 import "./interfaces/IIssuer.sol";
 
 
-contract Synth is Owned, ExternStateToken, MixinResolver, ISynth {
+contract Synth is Owned, IERC20, ExternStateToken, MixinResolver, ISynth {
     /* ========== STATE VARIABLES ========== */
 
     // Currency key which identifies this Synth to the Synthetix system

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -8,7 +8,8 @@ import "./Synth.sol";
 import "./interfaces/ISystemStatus.sol";
 import "./interfaces/ISynthetixState.sol";
 import "./interfaces/IExchangeRates.sol";
-import "./interfaces/ISynthetixEscrow.sol";
+import "./interfaces/IRewardEscrow.sol";
+import "./interfaces/IHasBalance.sol";
 import "./interfaces/IFeePool.sol";
 import "./interfaces/IRewardsDistribution.sol";
 import "./interfaces/IExchanger.sol";
@@ -106,12 +107,12 @@ contract Synthetix is ExternStateToken, MixinResolver {
         return SupplySchedule(requireAndGetAddress(CONTRACT_SUPPLYSCHEDULE, "Missing SupplySchedule address"));
     }
 
-    function rewardEscrow() internal view returns (ISynthetixEscrow) {
-        return ISynthetixEscrow(requireAndGetAddress(CONTRACT_REWARDESCROW, "Missing RewardEscrow address"));
+    function rewardEscrow() internal view returns (IRewardEscrow) {
+        return IRewardEscrow(requireAndGetAddress(CONTRACT_REWARDESCROW, "Missing RewardEscrow address"));
     }
 
-    function synthetixEscrow() internal view returns (ISynthetixEscrow) {
-        return ISynthetixEscrow(requireAndGetAddress(CONTRACT_SYNTHETIXESCROW, "Missing SynthetixEscrow address"));
+    function synthetixEscrow() internal view returns (IHasBalance) {
+        return IHasBalance(requireAndGetAddress(CONTRACT_SYNTHETIXESCROW, "Missing SynthetixEscrow address"));
     }
 
     function rewardsDistribution() internal view returns (IRewardsDistribution) {

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -23,7 +23,7 @@ import "./interfaces/IRewardsDistribution.sol";
 
 
 // https://docs.synthetix.io/contracts/Synthetix
-contract Synthetix is ExternStateToken, MixinResolver, ISynthetix {
+contract Synthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
     // ========== STATE VARIABLES ==========
 
     // Available Synths which can be used with the system

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -1,25 +1,29 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./ExternStateToken.sol";
 import "./MixinResolver.sol";
+import "./interfaces/ISynthetix.sol";
+
+// Internal references
 import "./TokenState.sol";
-import "./SupplySchedule.sol";
 import "./interfaces/ISynth.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/ISystemStatus.sol";
+import "./interfaces/IExchanger.sol";
+import "./interfaces/IEtherCollateral.sol";
+import "./interfaces/IIssuer.sol";
 import "./interfaces/ISynthetixState.sol";
 import "./interfaces/IExchangeRates.sol";
+import "./interfaces/IFeePool.sol";
+import "./SupplySchedule.sol";
 import "./interfaces/IRewardEscrow.sol";
 import "./interfaces/IHasBalance.sol";
-import "./interfaces/IFeePool.sol";
 import "./interfaces/IRewardsDistribution.sol";
-import "./interfaces/IExchanger.sol";
-import "./interfaces/IIssuer.sol";
-import "./interfaces/IEtherCollateral.sol";
 
 
 // https://docs.synthetix.io/contracts/Synthetix
-contract Synthetix is ExternStateToken, MixinResolver {
+contract Synthetix is ExternStateToken, MixinResolver, ISynthetix {
     // ========== STATE VARIABLES ==========
 
     // Available Synths which can be used with the system

--- a/contracts/SynthetixEscrow.sol
+++ b/contracts/SynthetixEscrow.sol
@@ -2,13 +2,13 @@ pragma solidity ^0.5.16;
 
 import "./Owned.sol";
 import "./LimitedSetup.sol";
-import "./interfaces/ISynthetixEscrow.sol";
+import "./interfaces/IHasBalance.sol";
 import "./SafeDecimalMath.sol";
 import "./interfaces/ISynthetix.sol";
 
 
 // https://docs.synthetix.io/contracts/SynthetixEscrow
-contract SynthetixEscrow is Owned, LimitedSetup(8 weeks), ISynthetixEscrow {
+contract SynthetixEscrow is Owned, LimitedSetup(8 weeks), IHasBalance {
     using SafeMath for uint;
 
     /* The corresponding Synthetix contract. */

--- a/contracts/SynthetixEscrow.sol
+++ b/contracts/SynthetixEscrow.sol
@@ -2,12 +2,13 @@ pragma solidity ^0.5.16;
 
 import "./Owned.sol";
 import "./LimitedSetup.sol";
+import "./interfaces/ISynthetixEscrow.sol";
 import "./SafeDecimalMath.sol";
 import "./interfaces/ISynthetix.sol";
 
 
 // https://docs.synthetix.io/contracts/SynthetixEscrow
-contract SynthetixEscrow is Owned, LimitedSetup(8 weeks) {
+contract SynthetixEscrow is Owned, LimitedSetup(8 weeks), ISynthetixEscrow {
     using SafeMath for uint;
 
     /* The corresponding Synthetix contract. */

--- a/contracts/SynthetixEscrow.sol
+++ b/contracts/SynthetixEscrow.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.5.16;
 import "./Owned.sol";
 import "./LimitedSetup.sol";
 import "./interfaces/IHasBalance.sol";
+import "./interfaces/IERC20.sol";
 import "./SafeDecimalMath.sol";
 import "./interfaces/ISynthetix.sol";
 
@@ -126,7 +127,7 @@ contract SynthetixEscrow is Owned, LimitedSetup(8 weeks), IHasBalance {
      * @dev This may only be called by the owner during the contract's setup period.
      */
     function withdrawSynthetix(uint quantity) external onlyOwner onlyDuringSetup {
-        synthetix.transfer(address(synthetix), quantity);
+        IERC20(address(synthetix)).transfer(address(synthetix), quantity);
     }
 
     /**
@@ -163,7 +164,7 @@ contract SynthetixEscrow is Owned, LimitedSetup(8 weeks), IHasBalance {
         /* There must be enough balance in the contract to provide for the vesting entry. */
         totalVestedBalance = totalVestedBalance.add(quantity);
         require(
-            totalVestedBalance <= synthetix.balanceOf(address(this)),
+            totalVestedBalance <= IERC20(address(synthetix)).balanceOf(address(this)),
             "Must be enough balance in the contract to provide for the vesting entry"
         );
 
@@ -227,7 +228,7 @@ contract SynthetixEscrow is Owned, LimitedSetup(8 weeks), IHasBalance {
         if (total != 0) {
             totalVestedBalance = totalVestedBalance.sub(total);
             totalVestedAccountBalance[msg.sender] = totalVestedAccountBalance[msg.sender].sub(total);
-            synthetix.transfer(msg.sender, total);
+            IERC20(address(synthetix)).transfer(msg.sender, total);
             emit Vested(msg.sender, now, total);
         }
     }

--- a/contracts/SynthetixEscrow.sol
+++ b/contracts/SynthetixEscrow.sol
@@ -1,10 +1,15 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./LimitedSetup.sol";
 import "./interfaces/IHasBalance.sol";
-import "./interfaces/IERC20.sol";
+
+// Libraires
 import "./SafeDecimalMath.sol";
+
+// Internal references
+import "./interfaces/IERC20.sol";
 import "./interfaces/ISynthetix.sol";
 
 

--- a/contracts/SynthetixState.sol
+++ b/contracts/SynthetixState.sol
@@ -1,14 +1,17 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./State.sol";
 import "./LimitedSetup.sol";
+import "./interfaces/ISynthetixState.sol";
+
+// Libraries
 import "./SafeDecimalMath.sol";
-import "./Synthetix.sol";
 
 
 // https://docs.synthetix.io/contracts/SynthetixState
-contract SynthetixState is Owned, State, LimitedSetup {
+contract SynthetixState is Owned, State, LimitedSetup, ISynthetixState {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
 

--- a/contracts/SystemStatus.sol
+++ b/contracts/SystemStatus.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./interfaces/ISystemStatus.sol";
 

--- a/contracts/SystemStatus.sol
+++ b/contracts/SystemStatus.sol
@@ -1,10 +1,11 @@
 pragma solidity ^0.5.16;
 
 import "./Owned.sol";
+import "./interfaces/ISystemStatus.sol";
 
 
 // https://docs.synthetix.io/contracts/SystemStatus
-contract SystemStatus is Owned {
+contract SystemStatus is Owned, ISystemStatus {
     struct Status {
         bool canSuspend;
         bool canResume;

--- a/contracts/TokenState.sol
+++ b/contracts/TokenState.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./State.sol";
 

--- a/contracts/interfaces/IDelegateApprovals.sol
+++ b/contracts/interfaces/IDelegateApprovals.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.16;
 
 
 interface IDelegateApprovals {
+    // Views
     function canBurnFor(address authoriser, address delegate) external view returns (bool);
 
     function canIssueFor(address authoriser, address delegate) external view returns (bool);
@@ -9,4 +10,25 @@ interface IDelegateApprovals {
     function canClaimFor(address authoriser, address delegate) external view returns (bool);
 
     function canExchangeFor(address authoriser, address delegate) external view returns (bool);
+
+    // Mutative
+    function approveAllDelegatePowers(address delegate) external;
+
+    function removeAllDelegatePowers(address delegate) external;
+
+    function approveBurnOnBehalf(address delegate) external;
+
+    function removeBurnOnBehalf(address delegate) external;
+
+    function approveIssueOnBehalf(address delegate) external;
+
+    function removeIssueOnBehalf(address delegate) external;
+
+    function approveClaimOnBehalf(address delegate) external;
+
+    function removeClaimOnBehalf(address delegate) external;
+
+    function approveExchangeOnBehalf(address delegate) external;
+
+    function removeExchangeOnBehalf(address delegate) external;
 }

--- a/contracts/interfaces/IDepot.sol
+++ b/contracts/interfaces/IDepot.sol
@@ -13,7 +13,9 @@ interface IDepot {
     // Deprecated ABI for MAINNET. Only used on Testnets
     function exchangeEtherForSNX() external payable returns (uint);
 
-    function exchangeEtherForSNXAtRate(uint guaranteedRate) external payable returns (uint);
+    function exchangeEtherForSNXAtRate(uint guaranteedRate, uint guaranteedSynthetixRate) external payable returns (uint);
 
-    function exchangeSynthsForSNX() external payable returns (uint);
+    function exchangeSynthsForSNX(uint synthAmount) external returns (uint);
+
+    function exchangeSynthsForSNXAtRate(uint synthAmount, uint guaranteedRate) external returns (uint);
 }

--- a/contracts/interfaces/IDepot.sol
+++ b/contracts/interfaces/IDepot.sol
@@ -1,11 +1,8 @@
 pragma solidity ^0.5.16;
 
 
-/**
- * @title Synthetix Depot interface
- */
-contract IDepot {
-    function exchangeEtherForSynths() public payable returns (uint);
+interface IDepot {
+    function exchangeEtherForSynths() external payable returns (uint);
 
     function exchangeEtherForSynthsAtRate(uint guaranteedRate) external payable returns (uint);
 

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -2,12 +2,21 @@ pragma solidity ^0.5.16;
 
 
 interface IERC20 {
+    // ERC20 Optional Views
+    function name() external view returns (string memory);
+
+    function symbol() external view returns (string memory);
+
+    function decimals() external view returns (uint8);
+
+    // Views
     function totalSupply() external view returns (uint);
 
     function balanceOf(address owner) external view returns (uint);
 
     function allowance(address owner, address spender) external view returns (uint);
 
+    // Mutative functions
     function transfer(address to, uint value) external returns (bool);
 
     function approve(address spender, uint value) external returns (bool);
@@ -18,13 +27,7 @@ interface IERC20 {
         uint value
     ) external returns (bool);
 
-    // ERC20 Optional
-    function name() external view returns (string memory);
-
-    function symbol() external view returns (string memory);
-
-    function decimals() external view returns (uint8);
-
+    // Events
     event Transfer(address indexed from, address indexed to, uint value);
 
     event Approval(address indexed owner, address indexed spender, uint value);

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,33 +1,29 @@
 pragma solidity ^0.5.16;
 
 
-/**
- * @title ERC20 interface
- * @dev see https://github.com/ethereum/EIPs/issues/20
- */
-contract IERC20 {
-    function totalSupply() public view returns (uint);
+interface IERC20 {
+    function totalSupply() external view returns (uint);
 
-    function balanceOf(address owner) public view returns (uint);
+    function balanceOf(address owner) external view returns (uint);
 
-    function allowance(address owner, address spender) public view returns (uint);
+    function allowance(address owner, address spender) external view returns (uint);
 
-    function transfer(address to, uint value) public returns (bool);
+    function transfer(address to, uint value) external returns (bool);
 
-    function approve(address spender, uint value) public returns (bool);
+    function approve(address spender, uint value) external returns (bool);
 
     function transferFrom(
         address from,
         address to,
         uint value
-    ) public returns (bool);
+    ) external returns (bool);
 
     // ERC20 Optional
-    function name() public view returns (string memory);
+    function name() external view returns (string memory);
 
-    function symbol() public view returns (string memory);
+    function symbol() external view returns (string memory);
 
-    function decimals() public view returns (uint8);
+    function decimals() external view returns (uint8);
 
     event Transfer(address indexed from, address indexed to, uint value);
 

--- a/contracts/interfaces/IEtherCollateral.sol
+++ b/contracts/interfaces/IEtherCollateral.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.16;
 
 
-contract IEtherCollateral {
-    uint256 public totalIssuedSynths;
+interface IEtherCollateral {
+    function totalIssuedSynths() external view returns (uint256);
 }

--- a/contracts/interfaces/IEtherCollateral.sol
+++ b/contracts/interfaces/IEtherCollateral.sol
@@ -2,5 +2,17 @@ pragma solidity ^0.5.16;
 
 
 interface IEtherCollateral {
+    // Views
     function totalIssuedSynths() external view returns (uint256);
+
+    function totalLoansCreated() external view returns (uint256);
+
+    function totalOpenLoanCount() external view returns (uint256);
+
+    // Mutative functions
+    function openLoan() external payable returns (uint256 loanID);
+
+    function closeLoan(uint256 loanID) external;
+
+    function liquidateUnclosedLoan(address _loanCreatorsAddress, uint256 _loanID) external;
 }

--- a/contracts/interfaces/IExchangeRates.sol
+++ b/contracts/interfaces/IExchangeRates.sol
@@ -1,9 +1,6 @@
 pragma solidity ^0.5.16;
 
 
-/**
- * @title ExchangeRates interface
- */
 interface IExchangeRates {
     function effectiveValue(
         bytes32 sourceCurrencyKey,

--- a/contracts/interfaces/IExchangeRates.sol
+++ b/contracts/interfaces/IExchangeRates.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.16;
 
 
 interface IExchangeRates {
+    // Views
     function effectiveValue(
         bytes32 sourceCurrencyKey,
         uint sourceAmount,

--- a/contracts/interfaces/IExchangeState.sol
+++ b/contracts/interfaces/IExchangeState.sol
@@ -2,20 +2,7 @@ pragma solidity ^0.5.16;
 
 
 interface IExchangeState {
-    function appendExchangeEntry(
-        address account,
-        bytes32 src,
-        uint amount,
-        bytes32 dest,
-        uint amountReceived,
-        uint exchangeFeeRate,
-        uint timestamp,
-        uint roundIdForSrc,
-        uint roundIdForDest
-    ) external;
-
-    function removeEntries(address account, bytes32 currencyKey) external;
-
+    // Views
     function getLengthOfEntries(address account, bytes32 currencyKey) external view returns (uint);
 
     function getEntryAt(
@@ -37,4 +24,19 @@ interface IExchangeState {
         );
 
     function getMaxTimestamp(address account, bytes32 currencyKey) external view returns (uint);
+
+    // Mutative functions
+    function appendExchangeEntry(
+        address account,
+        bytes32 src,
+        uint amount,
+        bytes32 dest,
+        uint amountReceived,
+        uint exchangeFeeRate,
+        uint timestamp,
+        uint roundIdForSrc,
+        uint roundIdForDest
+    ) external;
+
+    function removeEntries(address account, bytes32 currencyKey) external;
 }

--- a/contracts/interfaces/IExchanger.sol
+++ b/contracts/interfaces/IExchanger.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.16;
 
 
 interface IExchanger {
+    // Views
     function maxSecsLeftInWaitingPeriod(address account, bytes32 currencyKey) external view returns (uint);
 
     function feeRateForExchange(bytes32 sourceCurrencyKey, bytes32 destinationCurrencyKey) external view returns (uint);
@@ -15,6 +16,14 @@ interface IExchanger {
             uint numEntries
         );
 
+    function calculateAmountAfterSettlement(
+        address from,
+        bytes32 currencyKey,
+        uint amount,
+        uint refunded
+    ) external view returns (uint amountAfterSettlement);
+
+    // Mutative functions
     function settle(address from, bytes32 currencyKey)
         external
         returns (
@@ -38,11 +47,4 @@ interface IExchanger {
         uint sourceAmount,
         bytes32 destinationCurrencyKey
     ) external returns (uint amountReceived);
-
-    function calculateAmountAfterSettlement(
-        address from,
-        bytes32 currencyKey,
-        uint amount,
-        uint refunded
-    ) external view returns (uint amountAfterSettlement);
 }

--- a/contracts/interfaces/IFeePool.sol
+++ b/contracts/interfaces/IFeePool.sol
@@ -9,7 +9,7 @@ interface IFeePool {
 
     function amountReceivedFromExchange(uint value) external view returns (uint);
 
-    function amountReceivedFromTransfer(uint value) external view returns (uint);
+    function amountReceivedFromTransfer(uint value) external pure returns (uint);
 
     function recordFeePaid(uint sUSDAmount) external;
 

--- a/contracts/interfaces/IFeePool.sol
+++ b/contracts/interfaces/IFeePool.sol
@@ -11,8 +11,6 @@ interface IFeePool {
 
     function amountReceivedFromExchange(uint value) external view returns (uint);
 
-    function amountReceivedFromTransfer(uint value) external pure returns (uint);
-
     // Mutative Functions
     function recordFeePaid(uint sUSDAmount) external;
 

--- a/contracts/interfaces/IFeePool.sol
+++ b/contracts/interfaces/IFeePool.sol
@@ -2,6 +2,8 @@ pragma solidity ^0.5.16;
 
 
 interface IFeePool {
+    // Views
+
     // solhint-disable func-name-mixedcase
     function FEE_ADDRESS() external view returns (address);
 
@@ -11,6 +13,7 @@ interface IFeePool {
 
     function amountReceivedFromTransfer(uint value) external pure returns (uint);
 
+    // Mutative Functions
     function recordFeePaid(uint sUSDAmount) external;
 
     function appendAccountIssuanceRecord(

--- a/contracts/interfaces/IFeePool.sol
+++ b/contracts/interfaces/IFeePool.sol
@@ -1,13 +1,11 @@
 pragma solidity ^0.5.16;
 
 
-/**
- * @title FeePool Interface
- * @notice Abstract contract to hold public getters
- */
-contract IFeePool {
-    address public FEE_ADDRESS;
-    uint public exchangeFeeRate;
+interface IFeePool {
+    // solhint-disable func-name-mixedcase
+    function FEE_ADDRESS() external view returns (address);
+
+    function exchangeFeeRate() external view returns (uint);
 
     function amountReceivedFromExchange(uint value) external view returns (uint);
 

--- a/contracts/interfaces/IHasBalance.sol
+++ b/contracts/interfaces/IHasBalance.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.5.16;
+
+
+interface IHasBalance {
+    // Views
+    function balanceOf(address account) external view returns (uint);
+}

--- a/contracts/interfaces/IIssuer.sol
+++ b/contracts/interfaces/IIssuer.sol
@@ -2,6 +2,12 @@ pragma solidity ^0.5.16;
 
 
 interface IIssuer {
+    // Views
+    function canBurnSynths(address account) external view returns (bool);
+
+    function lastIssueEvent(address account) external view returns (uint);
+
+    // Mutative functions
     function issueSynths(address from, uint amount) external;
 
     function issueSynthsOnBehalf(
@@ -25,8 +31,4 @@ interface IIssuer {
     function burnSynthsToTarget(address from) external;
 
     function burnSynthsToTargetOnBehalf(address burnForAddress, address from) external;
-
-    function canBurnSynths(address account) external view returns (bool);
-
-    function lastIssueEvent(address account) external view returns (uint);
 }

--- a/contracts/interfaces/IRewardEscrow.sol
+++ b/contracts/interfaces/IRewardEscrow.sol
@@ -11,7 +11,4 @@ interface IRewardEscrow {
     function appendVestingEntry(address account, uint quantity) external;
 
     function vest() external;
-
-    // Events
-    event Vested(address indexed beneficiary, uint time, uint value);
 }

--- a/contracts/interfaces/IRewardEscrow.sol
+++ b/contracts/interfaces/IRewardEscrow.sol
@@ -1,0 +1,17 @@
+pragma solidity ^0.5.16;
+
+
+interface IRewardEscrow {
+    // Views
+    function balanceOf(address account) external view returns (uint);
+
+    function numVestingEntries(address account) external view returns (uint);
+
+    // Mutative functions
+    function appendVestingEntry(address account, uint quantity) external;
+
+    function vest() external;
+
+    // Events
+    event Vested(address indexed beneficiary, uint time, uint value);
+}

--- a/contracts/interfaces/IRewardsDistribution.sol
+++ b/contracts/interfaces/IRewardsDistribution.sol
@@ -2,5 +2,5 @@ pragma solidity ^0.5.16;
 
 
 interface IRewardsDistribution {
-    function distributeRewards(uint amount) external;
+    function distributeRewards(uint amount) external returns (bool);
 }

--- a/contracts/interfaces/IRewardsDistribution.sol
+++ b/contracts/interfaces/IRewardsDistribution.sol
@@ -1,9 +1,6 @@
 pragma solidity ^0.5.16;
 
 
-/**
- * @title RewardsDistribution interface
- */
 interface IRewardsDistribution {
     function distributeRewards(uint amount) external;
 }

--- a/contracts/interfaces/IRewardsDistribution.sol
+++ b/contracts/interfaces/IRewardsDistribution.sol
@@ -2,5 +2,6 @@ pragma solidity ^0.5.16;
 
 
 interface IRewardsDistribution {
+    // Mutative functions
     function distributeRewards(uint amount) external returns (bool);
 }

--- a/contracts/interfaces/ISynth.sol
+++ b/contracts/interfaces/ISynth.sol
@@ -2,19 +2,13 @@ pragma solidity ^0.5.16;
 
 
 interface ISynth {
+    // Views
+    function currencyKey() external view returns (bytes32);
+
+    // Mutative functions
     function burn(address account, uint amount) external;
 
     function issue(address account, uint amount) external;
-
-    function transfer(address to, uint value) external returns (bool);
-
-    function transferAndSettle(address to, uint value) external returns (bool);
-
-    function transferFrom(
-        address from,
-        address to,
-        uint value
-    ) external returns (bool);
 
     function transferFromAndSettle(
         address from,
@@ -22,23 +16,14 @@ interface ISynth {
         uint value
     ) external returns (bool);
 
-    // IERC20
-    // function totalSupply() external view returns (uint);
+    function transferFrom(
+        address from,
+        address to,
+        uint value
+    ) external returns (bool);
 
-    // function balanceOf(address owner) external view returns (uint);
+    // IERC20 implementations
+    function transferAndSettle(address to, uint value) external returns (bool);
 
-    // function allowance(address owner, address spender) external view returns (uint);
-
-    // function approve(address spender, uint value) external returns (bool);
-
-    // // ERC20 Optional
-    // function name() external view returns (string memory);
-
-    // function symbol() external view returns (string memory);
-
-    // function decimals() external view returns (uint8);
-
-    // event Transfer(address indexed from, address indexed to, uint value);
-
-    // event Approval(address indexed owner, address indexed spender, uint value);
+    function transfer(address to, uint value) external returns (bool);
 }

--- a/contracts/interfaces/ISynth.sol
+++ b/contracts/interfaces/ISynth.sol
@@ -8,6 +8,8 @@ interface ISynth {
 
     function transfer(address to, uint value) external returns (bool);
 
+    function transferAndSettle(address to, uint value) external returns (bool);
+
     function transferFrom(
         address from,
         address to,
@@ -20,5 +22,23 @@ interface ISynth {
         uint value
     ) external returns (bool);
 
-    function balanceOf(address owner) external view returns (uint);
+    // IERC20
+    // function totalSupply() external view returns (uint);
+
+    // function balanceOf(address owner) external view returns (uint);
+
+    // function allowance(address owner, address spender) external view returns (uint);
+
+    // function approve(address spender, uint value) external returns (bool);
+
+    // // ERC20 Optional
+    // function name() external view returns (string memory);
+
+    // function symbol() external view returns (string memory);
+
+    // function decimals() external view returns (uint8);
+
+    // event Transfer(address indexed from, address indexed to, uint value);
+
+    // event Approval(address indexed owner, address indexed spender, uint value);
 }

--- a/contracts/interfaces/ISynth.sol
+++ b/contracts/interfaces/ISynth.sol
@@ -17,14 +17,4 @@ interface ISynth {
         address to,
         uint value
     ) external returns (bool);
-
-    // IERC20 implementations
-
-    function transferFrom(
-        address from,
-        address to,
-        uint value
-    ) external returns (bool);
-
-    function transfer(address to, uint value) external returns (bool);
 }

--- a/contracts/interfaces/ISynth.sol
+++ b/contracts/interfaces/ISynth.sol
@@ -10,20 +10,21 @@ interface ISynth {
 
     function issue(address account, uint amount) external;
 
+    function transferAndSettle(address to, uint value) external returns (bool);
+
     function transferFromAndSettle(
         address from,
         address to,
         uint value
     ) external returns (bool);
 
+    // IERC20 implementations
+
     function transferFrom(
         address from,
         address to,
         uint value
     ) external returns (bool);
-
-    // IERC20 implementations
-    function transferAndSettle(address to, uint value) external returns (bool);
 
     function transfer(address to, uint value) external returns (bool);
 }

--- a/contracts/interfaces/ISynthetix.sol
+++ b/contracts/interfaces/ISynthetix.sol
@@ -1,38 +1,41 @@
 pragma solidity ^0.5.16;
 
-/**
- * @title Synthetix interface contract
- * @notice Abstract contract to hold public getters
- * @dev pseudo interface, actually declared as contract to hold the public getters
- */
-import "../interfaces/ISynthetixState.sol";
 import "../interfaces/ISynth.sol";
-import "../interfaces/IFeePool.sol";
-import "../interfaces/IExchangeRates.sol";
-import "../Synth.sol";
 
 
-contract ISynthetix {
-    // ========== PUBLIC STATE VARIABLES ==========
+interface ISynthetix {
+    // Views
+    function synths(bytes32 currencyKey) external view returns (ISynth);
 
-    uint public totalSupply;
+    function synthsByAddress(address synthAddress) external view returns (bytes32);
 
-    mapping(bytes32 => Synth) public synths;
+    function collateralisationRatio(address issuer) external view returns (uint);
 
-    mapping(address => bytes32) public synthsByAddress;
+    function totalIssuedSynths(bytes32 currencyKey) external view returns (uint);
 
-    // ========== PUBLIC FUNCTIONS ==========
+    function totalIssuedSynthsExcludeEtherCollateral(bytes32 currencyKey) external view returns (uint);
 
-    function balanceOf(address account) public view returns (uint);
+    function debtBalanceOf(address issuer, bytes32 currencyKey) external view returns (uint);
 
-    function transfer(address to, uint value) public returns (bool);
+    function debtBalanceOfAndTotalDebt(address issuer, bytes32 currencyKey)
+        external
+        view
+        returns (uint debtBalance, uint totalSystemValue);
 
-    function transferFrom(
-        address from,
-        address to,
-        uint value
-    ) public returns (bool);
+    function remainingIssuableSynths(address issuer)
+        external
+        view
+        returns (
+            uint maxIssuable,
+            uint alreadyIssued,
+            uint totalSystemDebt
+        );
 
+    function maxIssuableSynths(address issuer) external view returns (uint maxIssuable);
+
+    function isWaitingPeriod(bytes32 currencyKey) external view returns (bool);
+
+    // Mutative Functions
     function exchange(
         bytes32 sourceCurrencyKey,
         uint sourceAmount,
@@ -54,51 +57,4 @@ contract ISynthetix {
             uint refunded,
             uint numEntries
         );
-
-    function collateralisationRatio(address issuer) public view returns (uint);
-
-    function totalIssuedSynths(bytes32 currencyKey) public view returns (uint);
-
-    function totalIssuedSynthsExcludeEtherCollateral(bytes32 currencyKey) public view returns (uint);
-
-    function debtBalanceOf(address issuer, bytes32 currencyKey) public view returns (uint);
-
-    function debtBalanceOfAndTotalDebt(address issuer, bytes32 currencyKey)
-        public
-        view
-        returns (uint debtBalance, uint totalSystemValue);
-
-    function remainingIssuableSynths(address issuer)
-        public
-        view
-        returns (
-            uint maxIssuable,
-            uint alreadyIssued,
-            uint totalSystemDebt
-        );
-
-    function maxIssuableSynths(address issuer) public view returns (uint maxIssuable);
-
-    function isWaitingPeriod(bytes32 currencyKey) external view returns (bool);
-
-    function emitSynthExchange(
-        address account,
-        bytes32 fromCurrencyKey,
-        uint fromAmount,
-        bytes32 toCurrencyKey,
-        uint toAmount,
-        address toAddress
-    ) external;
-
-    function emitExchangeReclaim(
-        address account,
-        bytes32 currencyKey,
-        uint amount
-    ) external;
-
-    function emitExchangeRebate(
-        address account,
-        bytes32 currencyKey,
-        uint amount
-    ) external;
 }

--- a/contracts/interfaces/ISynthetix.sol
+++ b/contracts/interfaces/ISynthetix.sol
@@ -7,7 +7,6 @@ pragma solidity ^0.5.16;
  */
 import "../interfaces/ISynthetixState.sol";
 import "../interfaces/ISynth.sol";
-import "../interfaces/ISynthetixEscrow.sol";
 import "../interfaces/IFeePool.sol";
 import "../interfaces/IExchangeRates.sol";
 import "../Synth.sol";

--- a/contracts/interfaces/ISynthetixEscrow.sol
+++ b/contracts/interfaces/ISynthetixEscrow.sol
@@ -1,9 +1,6 @@
 pragma solidity ^0.5.16;
 
 
-/**
- * @title SynthetixEscrow interface
- */
 interface ISynthetixEscrow {
     function balanceOf(address account) external view returns (uint);
 

--- a/contracts/interfaces/ISynthetixEscrow.sol
+++ b/contracts/interfaces/ISynthetixEscrow.sol
@@ -1,8 +1,0 @@
-pragma solidity ^0.5.16;
-
-
-interface ISynthetixEscrow {
-    function balanceOf(address account) external view returns (uint);
-
-    function appendVestingEntry(address account, uint quantity) external;
-}

--- a/contracts/interfaces/ISynthetixState.sol
+++ b/contracts/interfaces/ISynthetixState.sol
@@ -13,14 +13,14 @@ interface ISynthetixState {
 
     function hasIssued(address account) external view returns (bool);
 
+    function lastDebtLedgerEntry() external view returns (uint);
+
     // Mutative functions
     function incrementTotalIssuerCount() external;
 
     function decrementTotalIssuerCount() external;
 
     function setCurrentIssuanceData(address account, uint initialDebtOwnership) external;
-
-    function lastDebtLedgerEntry() external view returns (uint);
 
     function appendDebtLedgerValue(uint value) external;
 

--- a/contracts/interfaces/ISynthetixState.sol
+++ b/contracts/interfaces/ISynthetixState.sol
@@ -1,33 +1,19 @@
 pragma solidity ^0.5.16;
 
 
-/**
- * @title SynthetixState interface contract
- * @notice Abstract contract to hold public getters
- */
-contract ISynthetixState {
-    // A struct for handing values associated with an individual user's debt position
-    struct IssuanceData {
-        // Percentage of the total debt owned at the time
-        // of issuance. This number is modified by the global debt
-        // delta array. You can figure out a user's exit price and
-        // collateralisation ratio using a combination of their initial
-        // debt and the slice of global debt delta which applies to them.
-        uint initialDebtOwnership;
-        // This lets us know when (in relative terms) the user entered
-        // the debt pool so we can calculate their exit price and
-        // collateralistion ratio
-        uint debtEntryIndex;
-    }
+interface ISynthetixState {
+    // Views
+    function debtLedger(uint index) external view returns (uint);
 
-    uint[] public debtLedger;
-    uint public issuanceRatio;
-    mapping(address => IssuanceData) public issuanceData;
+    function issuanceRatio() external view returns (uint);
+
+    function issuanceData(address account) external view returns (uint initialDebtOwnership, uint debtEntryIndex);
 
     function debtLedgerLength() external view returns (uint);
 
     function hasIssued(address account) external view returns (bool);
 
+    // Mutative functions
     function incrementTotalIssuerCount() external;
 
     function decrementTotalIssuerCount() external;

--- a/contracts/interfaces/ISystemStatus.sol
+++ b/contracts/interfaces/ISystemStatus.sol
@@ -2,6 +2,7 @@ pragma solidity ^0.5.16;
 
 
 interface ISystemStatus {
+    // Views
     function requireSystemActive() external view;
 
     function requireIssuanceActive() external view;

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
 	"files": [
 		"index.js",
 		"bin.js",
+		"contracts/*.sol",
+		"contracts/interfaces/*.sol",
 		"publish/deployed/*/synths.json",
 		"publish/deployed/*/deployment.json"
 	],

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
 	"files": [
 		"index.js",
 		"bin.js",
-		"contracts/*.sol",
-		"contracts/interfaces/*.sol",
+		"contracts/**/*.sol",
 		"publish/deployed/*/synths.json",
 		"publish/deployed/*/deployment.json"
 	],

--- a/test/contracts/ExternStateToken.js
+++ b/test/contracts/ExternStateToken.js
@@ -2,7 +2,7 @@ const { artifacts, contract } = require('@nomiclabs/buidler');
 
 const { assert } = require('./common');
 
-const ExternStateToken = artifacts.require('ExternStateToken');
+// const ExternStateToken = artifacts.require('ExternStateToken');
 const PublicEST = artifacts.require('PublicEST');
 
 const { ZERO_ADDRESS, toUnit } = require('../utils')();
@@ -26,13 +26,12 @@ contract('ExternStateToken', async accounts => {
 		});
 		tokenState = await TokenState.new(owner, ZERO_ADDRESS, { from: deployerAccount });
 
-		instance = await ExternStateToken.new(
+		instance = await PublicEST.new(
 			proxy.address,
 			tokenState.address,
 			'Some Token',
 			'TOKEN',
 			toUnit('1000'),
-			'18',
 			owner,
 			{
 				from: deployerAccount,
@@ -53,9 +52,15 @@ contract('ExternStateToken', async accounts => {
 	});
 	it('ensure only known functions are mutative', () => {
 		ensureOnlyExpectedMutativeFunctions({
-			abi: instance.abi,
+			abi: artifacts.require('ExternStateToken').abi,
 			ignoreParents: ['SelfDestructible', 'Proxyable'],
-			expected: ['setTokenState', 'approve'],
+			expected: [
+				'setTokenState',
+				'approve',
+				// Note: these functions are abstract in ExternStateToken so get picked up here
+				'transfer',
+				'transferFrom',
+			],
 		});
 	});
 	describe('setTokenState', () => {
@@ -96,71 +101,71 @@ contract('ExternStateToken', async accounts => {
 		});
 	});
 
-	describe('when extended into a test class', () => {
-		let subInstance;
+	// describe('when extended into a test class', () => {
+	// 	let instance;
+	// 	beforeEach(async () => {
+	// 		instance = await PublicEST.new(
+	// 			proxy.address,
+	// 			tokenState.address,
+	// 			'Some Token',
+	// 			'TOKEN',
+	// 			toUnit('1000'),
+	// 			owner,
+	// 			{
+	// 				from: deployerAccount,
+	// 			}
+	// 		);
+	// 		await proxy.setTarget(instance.address, { from: owner });
+	// 	});
+	describe('when account1 has 100 units', () => {
 		beforeEach(async () => {
-			subInstance = await PublicEST.new(
-				proxy.address,
-				tokenState.address,
-				'Some Token',
-				'TOKEN',
-				toUnit('1000'),
-				owner,
-				{
-					from: deployerAccount,
-				}
-			);
-			await proxy.setTarget(subInstance.address, { from: owner });
+			await tokenState.setAssociatedContract(owner, { from: owner });
+			await tokenState.setBalanceOf(account1, toUnit('100'), { from: owner });
+			await tokenState.setAssociatedContract(instance.address, { from: owner });
 		});
-		describe('when account1 has 100 units', () => {
+		it('when account1 transfers to account2, it works as expected', async () => {
+			assert.bnEqual(await instance.balanceOf(account1), toUnit('100'));
+			assert.bnEqual(await instance.balanceOf(account2), toUnit('0'));
+			await instance.transfer(account2, toUnit('25'), { from: account1 });
+			assert.bnEqual(await instance.balanceOf(account1), toUnit('75'));
+			assert.bnEqual(await instance.balanceOf(account2), toUnit('25'));
+		});
+		it('when account1 transfers to account2, it works as expected', async () => {
+			assert.bnEqual(await instance.balanceOf(account1), toUnit('100'));
+			assert.bnEqual(await instance.balanceOf(account2), toUnit('0'));
+			await proxy.transfer(account2, toUnit('25'), { from: account1 });
+			assert.bnEqual(await instance.balanceOf(account1), toUnit('75'));
+			assert.bnEqual(await instance.balanceOf(account2), toUnit('25'));
+		});
+		describe('when account1 approves account2 to transfer from', () => {
 			beforeEach(async () => {
-				await tokenState.setAssociatedContract(owner, { from: owner });
-				await tokenState.setBalanceOf(account1, toUnit('100'), { from: owner });
-				await tokenState.setAssociatedContract(subInstance.address, { from: owner });
+				await instance.approve(account2, toUnit('50'), { from: account1 });
 			});
-			it('when account1 transfers to account2, it works as expected', async () => {
-				assert.bnEqual(await subInstance.balanceOf(account1), toUnit('100'));
-				assert.bnEqual(await subInstance.balanceOf(account2), toUnit('0'));
-				await subInstance.transfer(account2, toUnit('25'), { from: account1 });
-				assert.bnEqual(await subInstance.balanceOf(account1), toUnit('75'));
-				assert.bnEqual(await subInstance.balanceOf(account2), toUnit('25'));
-			});
-			it('when account1 transfers to account2, it works as expected', async () => {
-				assert.bnEqual(await subInstance.balanceOf(account1), toUnit('100'));
-				assert.bnEqual(await subInstance.balanceOf(account2), toUnit('0'));
-				await proxy.transfer(account2, toUnit('25'), { from: account1 });
-				assert.bnEqual(await subInstance.balanceOf(account1), toUnit('75'));
-				assert.bnEqual(await subInstance.balanceOf(account2), toUnit('25'));
-			});
-			describe('when account1 approves account2 to transfer from', () => {
-				beforeEach(async () => {
-					await subInstance.approve(account2, toUnit('50'), { from: account1 });
-				});
-				describe('when account 2 transferFrom the approved amount', () => {
-					it('then it works as expected', async () => {
-						assert.bnEqual(await subInstance.balanceOf(account1), toUnit('100'));
-						assert.bnEqual(await subInstance.balanceOf(account2), toUnit('0'));
-						assert.bnEqual(await subInstance.balanceOf(account3), toUnit('0'));
-						await subInstance.transferFrom(account1, account3, toUnit('50'), {
-							from: account2,
-						});
-						assert.bnEqual(await subInstance.balanceOf(account1), toUnit('50'));
-						assert.bnEqual(await subInstance.balanceOf(account2), toUnit('0'));
-						assert.bnEqual(await subInstance.balanceOf(account3), toUnit('50'));
+			describe('when account 2 transferFrom the approved amount', () => {
+				it('then it works as expected', async () => {
+					assert.bnEqual(await instance.balanceOf(account1), toUnit('100'));
+					assert.bnEqual(await instance.balanceOf(account2), toUnit('0'));
+					assert.bnEqual(await instance.balanceOf(account3), toUnit('0'));
+					await instance.transferFrom(account1, account3, toUnit('50'), {
+						from: account2,
 					});
+					assert.bnEqual(await instance.balanceOf(account1), toUnit('50'));
+					assert.bnEqual(await instance.balanceOf(account2), toUnit('0'));
+					assert.bnEqual(await instance.balanceOf(account3), toUnit('50'));
 				});
-				describe('when account 2 transferFrom via the proxy of the approved amount', () => {
-					it('then it works as expected', async () => {
-						assert.bnEqual(await subInstance.balanceOf(account1), toUnit('100'));
-						assert.bnEqual(await subInstance.balanceOf(account2), toUnit('0'));
-						assert.bnEqual(await subInstance.balanceOf(account3), toUnit('0'));
-						await proxy.transferFrom(account1, account3, toUnit('50'), { from: account2 });
-						assert.bnEqual(await subInstance.balanceOf(account1), toUnit('50'));
-						assert.bnEqual(await subInstance.balanceOf(account2), toUnit('0'));
-						assert.bnEqual(await subInstance.balanceOf(account3), toUnit('50'));
-					});
+			});
+			describe('when account 2 transferFrom via the proxy of the approved amount', () => {
+				it('then it works as expected', async () => {
+					assert.bnEqual(await instance.balanceOf(account1), toUnit('100'));
+					assert.bnEqual(await instance.balanceOf(account2), toUnit('0'));
+					assert.bnEqual(await instance.balanceOf(account3), toUnit('0'));
+					await proxy.transferFrom(account1, account3, toUnit('50'), { from: account2 });
+					assert.bnEqual(await instance.balanceOf(account1), toUnit('50'));
+					assert.bnEqual(await instance.balanceOf(account2), toUnit('0'));
+					assert.bnEqual(await instance.balanceOf(account3), toUnit('50'));
 				});
 			});
 		});
+		// });
 	});
 });

--- a/test/contracts/Synth.js
+++ b/test/contracts/Synth.js
@@ -100,7 +100,15 @@ contract('Synth', async accounts => {
 			ensureOnlyExpectedMutativeFunctions({
 				abi: sUSDContract.abi,
 				ignoreParents: ['ExternStateToken', 'MixinResolver'],
-				expected: ['issue', 'burn', 'setTotalSupply', 'transferAndSettle', 'transferFromAndSettle'],
+				expected: [
+					'issue',
+					'burn',
+					'setTotalSupply',
+					'transfer',
+					'transferAndSettle',
+					'transferFrom',
+					'transferFromAndSettle',
+				],
 			});
 		});
 

--- a/test/contracts/Synth.js
+++ b/test/contracts/Synth.js
@@ -100,15 +100,7 @@ contract('Synth', async accounts => {
 			ensureOnlyExpectedMutativeFunctions({
 				abi: sUSDContract.abi,
 				ignoreParents: ['ExternStateToken', 'MixinResolver'],
-				expected: [
-					'issue',
-					'burn',
-					'setTotalSupply',
-					'transfer',
-					'transferAndSettle',
-					'transferFrom',
-					'transferFromAndSettle',
-				],
+				expected: ['issue', 'burn', 'setTotalSupply', 'transferAndSettle', 'transferFromAndSettle'],
 			});
 		});
 

--- a/test/contracts/Synthetix.js
+++ b/test/contracts/Synthetix.js
@@ -119,8 +119,6 @@ contract('Synthetix', async accounts => {
 				'mint',
 				'removeSynth',
 				'settle',
-				'transfer',
-				'transferFrom',
 			],
 		});
 	});

--- a/test/contracts/Synthetix.js
+++ b/test/contracts/Synthetix.js
@@ -119,6 +119,8 @@ contract('Synthetix', async accounts => {
 				'mint',
 				'removeSynth',
 				'settle',
+				'transfer',
+				'transferFrom',
 			],
 		});
 	});


### PR DESCRIPTION
- This PR consolidates all of our interfaces in one main area. 
- Export all contracts and interfaces in our `npm` module 

> Note that `ISynthetix` and `ISynth` both extend from `ExternStateToken` and also implement `IERC20`. EST doesn't implement `IERC20` because it doesn't have `transfer` and `transferFrom` so would be partial or abstract. As such, either cast a synthetix or synth address to `ISynthetix`/`ISynth` or `IERC20`, depending on your need (see how it's done in the code)