### PR TITLE
Adding contract size output to compile task for buidler

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: npx buidler compile
+      - run: npx buidler compile --showsize --optimizer
       - run:
           name: Test and output gas used
           command: |

--- a/buidler.config.js
+++ b/buidler.config.js
@@ -16,6 +16,10 @@ const {
 	constants: { inflationStartTimestampInSecs, AST_FILENAME, AST_FOLDER, BUILD_FOLDER },
 } = require('.');
 
+const {
+	DEFAULTS: { optimizerRuns },
+} = require('./publish/src/commands/build');
+
 const log = (...text) => console.log(gray(...['└─> [DEBUG]'].concat(text)));
 
 const GAS_PRICE = 20e9; // 20 GWEI
@@ -118,8 +122,8 @@ task('compile')
 			// Use optimizer (slower) but simulates real contract size limits and gas usage
 			// Note: does not consider actual deployed optimization runs from
 			// publish/src/contract-overrides.js
-			console.log(gray('Adding optimizer, runs', yellow(200)));
-			bre.config.solc.optimizer = { enabled: true, runs: 200 };
+			console.log(gray('Adding optimizer, runs', yellow(optimizerRuns)));
+			bre.config.solc.optimizer = { enabled: true, runs: optimizerRuns };
 			bre.config.networks.buidlerevm.allowUnlimitedContractSize = false;
 		} else {
 			console.log(gray('Optimizer disabled. Unlimited contract sizes allowed.'));

--- a/buidler.config.js
+++ b/buidler.config.js
@@ -144,7 +144,10 @@ module.exports = {
 	GAS_PRICE,
 	solc: {
 		version: '0.5.16',
-		optimizer: { enabled: true, runs: 200 }, // simulate real deployment conditions
+		// Use optimizer (slower) but simulates real contract size limits and gas usage
+		// Note: does not consider actual deployed optimization runs from
+		// publish/src/contract-overrides.js
+		optimizer: { enabled: true, runs: 200 },
 	},
 	paths: {
 		sources: './contracts',

--- a/publish/src/commands/build.js
+++ b/publish/src/commands/build.js
@@ -2,8 +2,8 @@
 
 const path = require('path');
 const fs = require('fs');
-const { table } = require('table');
-const { gray, green, yellow, red, bgRed } = require('chalk');
+const { gray, green, yellow, red } = require('chalk');
+
 const { findSolFiles, flatten, compile } = require('../solidity');
 
 const {
@@ -11,26 +11,18 @@ const {
 } = require('../../..');
 
 const { stringify } = require('../util');
-const { sizeOfContracts } = require('../contract-size');
+const {
+	sizeOfContracts,
+	logContractSizes,
+	pcentToColorFnc,
+	sizeChange,
+} = require('../contract-size');
 
 const DEFAULTS = {
 	buildPath: path.join(__dirname, '..', '..', '..', BUILD_FOLDER),
 	optimizerRuns: 200,
 };
 const overrides = require('../contract-overrides');
-
-const pcentToColorFnc = ({ pcent, content }) => {
-	const percentage = pcent.slice(0, -1);
-	return percentage > 95
-		? bgRed(content)
-		: percentage > 85
-		? red(content)
-		: percentage > 60
-		? yellow(content)
-		: percentage > 25
-		? content
-		: gray(content);
-};
 
 const build = async ({
 	buildPath = DEFAULTS.buildPath,
@@ -98,20 +90,6 @@ const build = async ({
 	const allCompiledFilePaths = [];
 	const previousSizes = [];
 
-	const sizeChange = ({ prevSizeIfAny, length }) => {
-		if (
-			!prevSizeIfAny ||
-			prevSizeIfAny.length === 0 ||
-			length === 0 ||
-			prevSizeIfAny.length === length
-		) {
-			return '';
-		}
-		const amount = length / prevSizeIfAny.length;
-		const pcentChange = ((amount - 1) * 100).toFixed(2);
-		return (pcentChange > 0 ? red : green)(`Change of ${pcentChange}%`);
-	};
-
 	for (const contract of Object.keys(sources)) {
 		const contractName = contract
 			.match(/^.+(?=\.sol$)/)[0]
@@ -119,9 +97,11 @@ const build = async ({
 			.slice(-1)[0];
 		const toWrite = path.join(compiledPath, contractName);
 		const filePath = `${toWrite}.json`;
-		const prevSizeIfAny = await sizeOfContracts({
-			filePaths: [filePath],
-		})[0];
+		const prevSizeIfAny = fs.existsSync(filePath)
+			? await sizeOfContracts({
+					contractToObjectMap: { [filePath]: require(filePath).evm.bytecode.object },
+			  })[0]
+			: undefined;
 		if (prevSizeIfAny) {
 			previousSizes.push(prevSizeIfAny);
 		}
@@ -173,7 +153,9 @@ const build = async ({
 			} catch (e) {}
 			fs.writeFileSync(filePath, stringify(artifacts[contractName]));
 
-			const { pcent, bytes, length } = sizeOfContracts({ filePaths: [filePath] })[0];
+			const { pcent, bytes, length } = sizeOfContracts({
+				contractToObjectMap: { [filePath]: artifacts[contractName].evm.bytecode.object },
+			})[0];
 
 			console.log(
 				green(`${contract}`),
@@ -196,44 +178,14 @@ const build = async ({
 	console.log(green('Build succeeded'));
 
 	if (showContractSize) {
-		const config = {
-			border: Object.entries({
-				topBody: `─`,
-				topJoin: `┬`,
-				topLeft: `┌`,
-				topRight: `┐`,
-
-				bottomBody: `─`,
-				bottomJoin: `┴`,
-				bottomLeft: `└`,
-				bottomRight: `┘`,
-
-				bodyLeft: `│`,
-				bodyRight: `│`,
-				bodyJoin: `│`,
-
-				joinBody: `─`,
-				joinLeft: `├`,
-				joinRight: `┤`,
-				joinJoin: `┼`,
-			}).reduce((memo, [key, val]) => {
-				memo[key] = gray(val);
+		const contractToObjectMap = allCompiledFilePaths
+			.filter(file => fs.existsSync(file))
+			.reduce((memo, file) => {
+				memo[file] = require(file).evm.bytecode.object;
 				return memo;
-			}, {}),
-		};
-		const entries = sizeOfContracts({ filePaths: allCompiledFilePaths });
-		const tableData = [
-			['Contract', 'Size', 'Percent of Limit', 'Increase'].map(x => yellow(x)),
-		].concat(
-			entries.reverse().map(({ file, length, pcent }) => {
-				const prevSizeIfAny = previousSizes.find(candidate => candidate.file === file);
+			}, {});
 
-				return [file, length, pcent, sizeChange({ prevSizeIfAny, length })].map(content =>
-					pcentToColorFnc({ pcent, content })
-				);
-			})
-		);
-		console.log(table(tableData, config));
+		logContractSizes({ previousSizes, contractToObjectMap });
 	}
 };
 

--- a/publish/src/commands/verify.js
+++ b/publish/src/commands/verify.js
@@ -6,7 +6,6 @@ const { gray, green, red } = require('chalk');
 const { table } = require('table');
 const axios = require('axios');
 const qs = require('querystring');
-const solc = require('solc');
 
 const {
 	constants: { BUILD_FOLDER, FLATTENED_FOLDER, CONFIG_FILENAME, DEPLOYMENT_FILENAME },
@@ -23,6 +22,9 @@ const CONTRACT_OVERRIDES = require('../contract-overrides');
 const { optimizerRuns } = require('./build').DEFAULTS;
 
 const verify = async ({ buildPath, network, deploymentPath }) => {
+	// Note: require this here as silent error is detected on require that impacts pretty-error
+	const solc = require('solc');
+
 	ensureNetwork(network);
 
 	const { config, deployment, deploymentFile } = loadAndCheckRequiredSources({

--- a/publish/src/contract-size.js
+++ b/publish/src/contract-size.js
@@ -1,47 +1,120 @@
 'use strict';
 
 const path = require('path');
-const fs = require('fs');
+const { table } = require('table');
+const { gray, green, yellow, red, bgRed } = require('chalk');
 
 function formatBytes(bytes, decimals) {
 	if (bytes === 0) return '0 Bytes';
-	var k = 1024;
-	var dm = decimals <= 0 ? 0 : decimals || 2;
-	var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
-	var i = Math.floor(Math.log(bytes) / Math.log(k));
+	const k = 1024;
+	const dm = decimals <= 0 ? 0 : decimals || 2;
+	const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+	const i = Math.floor(Math.log(bytes) / Math.log(k));
 	return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 }
 
 function hexToBytes(hex) {
 	if (hex.substr(0, 2) === '0x') hex = hex.slice(2);
 
-	for (var bytes = [], c = 0; c < hex.length; c += 2) {
+	const bytes = [];
+	for (let c = 0; c < hex.length; c += 2) {
 		bytes.push(parseInt(hex.substr(c, 2), 16));
 	}
 
 	return bytes;
 }
 
+const pcentToColorFnc = ({ pcent, content }) => {
+	const percentage = pcent.slice(0, -1);
+	return percentage > 95
+		? bgRed(content)
+		: percentage > 85
+		? red(content)
+		: percentage > 60
+		? yellow(content)
+		: percentage > 25
+		? content
+		: gray(content);
+};
+
+const sizeChange = ({ prevSizeIfAny, length }) => {
+	if (
+		!prevSizeIfAny ||
+		prevSizeIfAny.length === 0 ||
+		length === 0 ||
+		prevSizeIfAny.length === length
+	) {
+		return '';
+	}
+	const amount = length / prevSizeIfAny.length;
+	const pcentChange = ((amount - 1) * 100).toFixed(2);
+	return (pcentChange > 0 ? red : green)(`Change of ${pcentChange}%`);
+};
+
+const sizeOfContracts = ({ contractToObjectMap }) => {
+	return Object.entries(contractToObjectMap)
+		.map(([file, object]) => {
+			// Max contract size as defined in EIP-170
+			// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-170.md
+			const max = 0x6000;
+			const decimalsToDisplay = 2;
+
+			const { length } = hexToBytes(object);
+
+			return {
+				file: path.basename(file, '.json'),
+				length,
+				bytes: formatBytes(length, decimalsToDisplay),
+				pcent: `${((length / max) * 100).toFixed(decimalsToDisplay)}%`,
+			};
+		})
+		.sort((left, right) => right.length - left.length);
+};
+
 module.exports = {
-	sizeOfContracts({ filePaths }) {
-		return filePaths
-			.filter(file => fs.existsSync(file))
-			.map(file => {
-				// Max contract size as defined in EIP-170
-				// https://github.com/ethereum/EIPs/blob/master/EIPS/eip-170.md
-				const max = 0x6000;
-				const decimalsToDisplay = 2;
+	logContractSizes({ previousSizes = [], contractToObjectMap }) {
+		const config = {
+			border: Object.entries({
+				topBody: `─`,
+				topJoin: `┬`,
+				topLeft: `┌`,
+				topRight: `┐`,
 
-				const { evm } = JSON.parse(fs.readFileSync(file));
-				const { length } = hexToBytes(evm.bytecode.object);
+				bottomBody: `─`,
+				bottomJoin: `┴`,
+				bottomLeft: `└`,
+				bottomRight: `┘`,
 
-				return {
-					file: path.basename(file, '.json'),
-					length,
-					bytes: formatBytes(length, decimalsToDisplay),
-					pcent: `${((length / max) * 100).toFixed(decimalsToDisplay)}%`,
-				};
+				bodyLeft: `│`,
+				bodyRight: `│`,
+				bodyJoin: `│`,
+
+				joinBody: `─`,
+				joinLeft: `├`,
+				joinRight: `┤`,
+				joinJoin: `┼`,
+			}).reduce((memo, [key, val]) => {
+				memo[key] = gray(val);
+				return memo;
+			}, {}),
+		};
+		const entries = sizeOfContracts({ contractToObjectMap });
+		const tableData = [
+			['Contract', 'Size', 'Percent of Limit', 'Increase'].map(x => yellow(x)),
+		].concat(
+			entries.reverse().map(({ file, length, pcent }) => {
+				const prevSizeIfAny = previousSizes.find(candidate => candidate.file === file);
+
+				return [file, length, pcent, sizeChange({ prevSizeIfAny, length })].map(content =>
+					pcentToColorFnc({ pcent, content })
+				);
 			})
-			.sort((left, right) => right.length - left.length);
+		);
+		console.log(table(tableData, config));
 	},
+	sizeOfContracts,
+
+	pcentToColorFnc,
+
+	sizeChange,
 };

--- a/publish/src/solidity.js
+++ b/publish/src/solidity.js
@@ -3,7 +3,6 @@
 const path = require('path');
 const fs = require('fs');
 const solidifier = require('solidifier');
-const solc = require('solc');
 const {
 	constants: { COMPILED_FOLDER },
 } = require('../..');
@@ -65,6 +64,9 @@ module.exports = {
 	},
 
 	compile({ sources, runs }) {
+		// Note: require this here as silent error is detected on require that impacts pretty-error
+		const solc = require('solc');
+
 		const artifacts = [];
 		const output = JSON.parse(
 			solc.compile(


### PR DESCRIPTION
Ensure the buidler tests uses optimized sources when requested, and output compiled sizes.

Run via `npx buidler compile --showsize --optimizer`

Added both opts to circleci, so it will fail if the contract is oversize (as using `--optimizer` will disable `allowUnlimitedContractSize`)

### Opts

* `--showsize` output file sizes
* `--optimizer` enable the optimizer to run with `200` runs

![sizes-buidler](https://user-images.githubusercontent.com/799038/82610080-bd7bfb80-9b8b-11ea-8afb-9c5cde5b22a0.gif)

