### PR TITLE
Moving issuance views to issuer (for SIP-48)

### DIFF
--- a/contracts/Issuer.sol
+++ b/contracts/Issuer.sol
@@ -8,13 +8,17 @@ import "./interfaces/IIssuer.sol";
 // Libraries
 import "./SafeDecimalMath.sol";
 
-// Inheritance
+// Internal references
 import "./IssuanceEternalStorage.sol";
 import "./interfaces/ISynthetix.sol";
 import "./interfaces/IFeePool.sol";
 import "./interfaces/ISynthetixState.sol";
 import "./interfaces/IExchanger.sol";
 import "./interfaces/IDelegateApprovals.sol";
+import "./IssuanceEternalStorage.sol";
+import "./interfaces/IExchangeRates.sol";
+import "./interfaces/IEtherCollateral.sol";
+import "./interfaces/IERC20.sol";
 
 
 // https://docs.synthetix.io/contracts/Issuer
@@ -38,6 +42,8 @@ contract Issuer is Owned, MixinResolver, IIssuer {
     bytes32 private constant CONTRACT_FEEPOOL = "FeePool";
     bytes32 private constant CONTRACT_DELEGATEAPPROVALS = "DelegateApprovals";
     bytes32 private constant CONTRACT_ISSUANCEETERNALSTORAGE = "IssuanceEternalStorage";
+    bytes32 private constant CONTRACT_EXRATES = "ExchangeRates";
+    bytes32 private constant CONTRACT_ETHERCOLLATERAL = "EtherCollateral";
 
     bytes32[24] private addressesToCache = [
         CONTRACT_SYNTHETIX,
@@ -45,7 +51,9 @@ contract Issuer is Owned, MixinResolver, IIssuer {
         CONTRACT_SYNTHETIXSTATE,
         CONTRACT_FEEPOOL,
         CONTRACT_DELEGATEAPPROVALS,
-        CONTRACT_ISSUANCEETERNALSTORAGE
+        CONTRACT_ISSUANCEETERNALSTORAGE,
+        CONTRACT_EXRATES,
+        CONTRACT_ETHERCOLLATERAL
     ];
 
     constructor(address _owner, address _resolver) public Owned(_owner) MixinResolver(_resolver, addressesToCache) {}
@@ -78,7 +86,46 @@ contract Issuer is Owned, MixinResolver, IIssuer {
             );
     }
 
+    function exchangeRates() internal view returns (IExchangeRates) {
+        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES, "Missing ExchangeRates address"));
+    }
+
+    function etherCollateral() internal view returns (IEtherCollateral) {
+        return IEtherCollateral(requireAndGetAddress(CONTRACT_ETHERCOLLATERAL, "Missing EtherCollateral address"));
+    }
+
+    function _totalIssuedSynths(bytes32 currencyKey, bool excludeEtherCollateral) internal view returns (uint) {
+        uint total = 0;
+        uint currencyRate = exchangeRates().rateForCurrency(currencyKey);
+
+        bytes32[] memory synths = synthetix().availableCurrencyKeys();
+        uint[] memory rates = exchangeRates().ratesForCurrencies(synths);
+
+        for (uint i = 0; i < synths.length; i++) {
+            // What's the total issued value of that synth in the destination currency?
+            // Note: We're not using exchangeRates().effectiveValue() because we don't want to go get the
+            //       rate for the destination currency and check if it's stale repeatedly on every
+            //       iteration of the loop
+            bytes32 synth = synths[i];
+            uint totalSynths = IERC20(address(synthetix().synths(synth))).totalSupply();
+
+            // minus total issued synths from Ether Collateral from sETH.totalSupply()
+            if (excludeEtherCollateral && synth == "sETH") {
+                totalSynths = totalSynths.sub(etherCollateral().totalIssuedSynths());
+            }
+
+            uint synthValue = totalSynths.multiplyDecimalRound(rates[i]);
+            total = total.add(synthValue);
+        }
+
+        return total.divideDecimalRound(currencyRate);
+    }
+
     /* ========== VIEWS ========== */
+
+    function totalIssuedSynths(bytes32 currencyKey, bool excludeEtherCollateral) external view returns (uint) {
+        return _totalIssuedSynths(currencyKey, excludeEtherCollateral);
+    }
 
     function canBurnSynths(address account) public view returns (bool) {
         return now >= lastIssueEvent(account).add(minimumStakeTime);
@@ -87,6 +134,81 @@ contract Issuer is Owned, MixinResolver, IIssuer {
     function lastIssueEvent(address account) public view returns (uint) {
         //  Get the timestamp of the last issue this account made
         return issuanceEternalStorage().getUIntValue(keccak256(abi.encodePacked(LAST_ISSUE_EVENT, account)));
+    }
+
+    function debtBalanceOf(address _issuer, bytes32 currencyKey) public view returns (uint) {
+        ISynthetixState state = synthetixState();
+
+        // What was their initial debt ownership?
+        (uint initialDebtOwnership, ) = state.issuanceData(_issuer);
+
+        // If it's zero, they haven't issued, and they have no debt.
+        if (initialDebtOwnership == 0) return 0;
+
+        (uint debtBalance, ) = debtBalanceOfAndTotalDebt(_issuer, currencyKey);
+        return debtBalance;
+    }
+
+    function debtBalanceOfAndTotalDebt(address _issuer, bytes32 currencyKey)
+        public
+        view
+        returns (uint debtBalance, uint totalSystemValue)
+    {
+        ISynthetixState state = synthetixState();
+
+        // What was their initial debt ownership?
+        uint initialDebtOwnership;
+        uint debtEntryIndex;
+        (initialDebtOwnership, debtEntryIndex) = state.issuanceData(_issuer);
+
+        // What's the total value of the system excluding ETH backed synths in their requested currency?
+        totalSystemValue = _totalIssuedSynths(currencyKey, true);
+
+        // If it's zero, they haven't issued, and they have no debt.
+        if (initialDebtOwnership == 0) return (0, totalSystemValue);
+
+        // Figure out the global debt percentage delta from when they entered the system.
+        // This is a high precision integer of 27 (1e27) decimals.
+        uint currentDebtOwnership = state
+            .lastDebtLedgerEntry()
+            .divideDecimalRoundPrecise(state.debtLedger(debtEntryIndex))
+            .multiplyDecimalRoundPrecise(initialDebtOwnership);
+
+        // Their debt balance is their portion of the total system value.
+        uint highPrecisionBalance = totalSystemValue.decimalToPreciseDecimal().multiplyDecimalRoundPrecise(
+            currentDebtOwnership
+        );
+
+        // Convert back into 18 decimals (1e18)
+        debtBalance = highPrecisionBalance.preciseDecimalToDecimal();
+    }
+
+    function remainingIssuableSynths(address _issuer)
+        public
+        view
+        returns (
+            // Don't need to check for synth existing or stale rates because maxIssuableSynths will do it for us.
+            uint maxIssuable,
+            uint alreadyIssued,
+            uint totalSystemDebt
+        )
+    {
+        (alreadyIssued, totalSystemDebt) = debtBalanceOfAndTotalDebt(_issuer, sUSD);
+        maxIssuable = maxIssuableSynths(_issuer);
+
+        if (alreadyIssued >= maxIssuable) {
+            maxIssuable = 0;
+        } else {
+            maxIssuable = maxIssuable.sub(alreadyIssued);
+        }
+    }
+
+    function maxIssuableSynths(address _issuer) public view returns (uint) {
+        // What is the value of their SNX balance in the destination currency?
+        uint destinationValue = exchangeRates().effectiveValue("SNX", synthetix().collateral(_issuer), sUSD);
+
+        // They're allowed to issue up to issuanceRatio of that value
+        return destinationValue.multiplyDecimal(synthetixState().issuanceRatio());
     }
 
     /* ========== SETTERS ========== */
@@ -111,7 +233,7 @@ contract Issuer is Owned, MixinResolver, IIssuer {
     ) external onlySynthetix {
         require(delegateApprovals().canIssueFor(issueForAddress, from), "Not approved to act on behalf");
 
-        (uint maxIssuable, uint existingDebt, uint totalSystemDebt) = synthetix().remainingIssuableSynths(issueForAddress);
+        (uint maxIssuable, uint existingDebt, uint totalSystemDebt) = remainingIssuableSynths(issueForAddress);
         require(amount <= maxIssuable, "Amount too large");
         _internalIssueSynths(issueForAddress, amount, existingDebt, totalSystemDebt);
     }
@@ -119,13 +241,13 @@ contract Issuer is Owned, MixinResolver, IIssuer {
     function issueMaxSynthsOnBehalf(address issueForAddress, address from) external onlySynthetix {
         require(delegateApprovals().canIssueFor(issueForAddress, from), "Not approved to act on behalf");
 
-        (uint maxIssuable, uint existingDebt, uint totalSystemDebt) = synthetix().remainingIssuableSynths(issueForAddress);
+        (uint maxIssuable, uint existingDebt, uint totalSystemDebt) = remainingIssuableSynths(issueForAddress);
         _internalIssueSynths(issueForAddress, maxIssuable, existingDebt, totalSystemDebt);
     }
 
     function issueSynths(address from, uint amount) external onlySynthetix {
         // Get remaining issuable in sUSD and existingDebt
-        (uint maxIssuable, uint existingDebt, uint totalSystemDebt) = synthetix().remainingIssuableSynths(from);
+        (uint maxIssuable, uint existingDebt, uint totalSystemDebt) = remainingIssuableSynths(from);
         require(amount <= maxIssuable, "Amount too large");
 
         _internalIssueSynths(from, amount, existingDebt, totalSystemDebt);
@@ -133,7 +255,7 @@ contract Issuer is Owned, MixinResolver, IIssuer {
 
     function issueMaxSynths(address from) external onlySynthetix {
         // Figure out the maximum we can issue in that currency
-        (uint maxIssuable, uint existingDebt, uint totalSystemDebt) = synthetix().remainingIssuableSynths(from);
+        (uint maxIssuable, uint existingDebt, uint totalSystemDebt) = remainingIssuableSynths(from);
 
         _internalIssueSynths(from, maxIssuable, existingDebt, totalSystemDebt);
     }
@@ -179,7 +301,7 @@ contract Issuer is Owned, MixinResolver, IIssuer {
         (, uint refunded, uint numEntriesSettled) = exchanger().settle(from, sUSD);
 
         // How much debt do they have?
-        (uint existingDebt, uint totalSystemValue) = synthetix().debtBalanceOfAndTotalDebt(from, sUSD);
+        (uint existingDebt, uint totalSystemValue) = debtBalanceOfAndTotalDebt(from, sUSD);
 
         require(existingDebt > 0, "No debt to forgive");
 
@@ -201,18 +323,16 @@ contract Issuer is Owned, MixinResolver, IIssuer {
         _burnSynthsToTarget(from);
     }
 
-    /* ========== INTERNAL FUNCTIONS ========== */
-
     // Burns your sUSD to the target c-ratio so you can claim fees
     // Skip settle anything pending into sUSD as user will still have debt remaining after target c-ratio
     function _burnSynthsToTarget(address from) internal {
         // How much debt do they have?
-        (uint existingDebt, uint totalSystemValue) = synthetix().debtBalanceOfAndTotalDebt(from, sUSD);
+        (uint existingDebt, uint totalSystemValue) = debtBalanceOfAndTotalDebt(from, sUSD);
 
         require(existingDebt > 0, "No debt to forgive");
 
         // The maximum amount issuable against their total SNX balance.
-        uint maxIssuable = synthetix().maxIssuableSynths(from);
+        uint maxIssuable = maxIssuableSynths(from);
 
         // The amount of sUSD to burn to fix c-ratio. The safe sub will revert if its < 0
         uint amountToBurnToTarget = existingDebt.sub(maxIssuable);
@@ -244,11 +364,8 @@ contract Issuer is Owned, MixinResolver, IIssuer {
         _appendAccountIssuanceRecord(from);
     }
 
-    /**
-     * @notice Store in the FeePool the users current debt value in the system.
-     * @dev debtBalanceOf(messageSender, "sUSD") to be used with totalIssuedSynthsExcludeEtherCollateral("sUSD") to get
-     *  users % of the system within a feePeriod.
-     */
+    /* ========== INTERNAL FUNCTIONS ========== */
+
     function _appendAccountIssuanceRecord(address from) internal {
         uint initialDebtOwnership;
         uint debtEntryIndex;
@@ -257,11 +374,6 @@ contract Issuer is Owned, MixinResolver, IIssuer {
         feePool().appendAccountIssuanceRecord(from, initialDebtOwnership, debtEntryIndex);
     }
 
-    /**
-     * @notice Function that registers new synth as they are issued. Calculate delta to append to synthetixState.
-     * @dev Only internal calls from synthetix address.
-     * @param amount The amount of synths to register with a base of UNIT
-     */
     function _addToDebtRegister(
         address from,
         uint amount,
@@ -304,12 +416,6 @@ contract Issuer is Owned, MixinResolver, IIssuer {
         }
     }
 
-    /**
-     * @notice Remove a debt position from the register
-     * @param amount The amount (in UNIT base) being presented in sUSDs
-     * @param existingDebt The existing debt (in UNIT base) of address presented in sUSDs
-     * @param totalDebtIssued The existing system debt (in UNIT base) presented in sUSDs
-     */
     function _removeFromDebtRegister(
         address from,
         uint amount,

--- a/contracts/PurgeableSynth.sol
+++ b/contracts/PurgeableSynth.sol
@@ -42,10 +42,6 @@ contract PurgeableSynth is Synth {
 
     /* ========== MUTATIVE FUNCTIONS ========== */
 
-    /**
-     * @notice Function that allows owner to exchange any number of holders back to sUSD (for frozen or deprecated synths)
-     * @param addresses The list of holders to purge
-     */
     function purge(address[] calldata addresses) external optionalProxy_onlyOwner {
         IExchangeRates exRates = exchangeRates();
 

--- a/contracts/interfaces/IIssuer.sol
+++ b/contracts/interfaces/IIssuer.sol
@@ -5,7 +5,27 @@ interface IIssuer {
     // Views
     function canBurnSynths(address account) external view returns (bool);
 
+    function debtBalanceOf(address issuer, bytes32 currencyKey) external view returns (uint);
+
+    function debtBalanceOfAndTotalDebt(address issuer, bytes32 currencyKey)
+        external
+        view
+        returns (uint debtBalance, uint totalSystemValue);
+
     function lastIssueEvent(address account) external view returns (uint);
+
+    function maxIssuableSynths(address issuer) external view returns (uint maxIssuable);
+
+    function remainingIssuableSynths(address issuer)
+        external
+        view
+        returns (
+            uint maxIssuable,
+            uint alreadyIssued,
+            uint totalSystemDebt
+        );
+
+    function totalIssuedSynths(bytes32 currencyKey, bool excludeEtherCollateral) external view returns (uint);
 
     // Restricted: used internally to Synthetix
     function issueSynths(address from, uint amount) external;

--- a/contracts/interfaces/IIssuer.sol
+++ b/contracts/interfaces/IIssuer.sol
@@ -7,11 +7,6 @@ interface IIssuer {
 
     function debtBalanceOf(address issuer, bytes32 currencyKey) external view returns (uint);
 
-    function debtBalanceOfAndTotalDebt(address issuer, bytes32 currencyKey)
-        external
-        view
-        returns (uint debtBalance, uint totalSystemValue);
-
     function lastIssueEvent(address account) external view returns (uint);
 
     function maxIssuableSynths(address issuer) external view returns (uint maxIssuable);

--- a/contracts/interfaces/ISynthetix.sol
+++ b/contracts/interfaces/ISynthetix.sol
@@ -17,11 +17,6 @@ interface ISynthetix {
 
     function debtBalanceOf(address issuer, bytes32 currencyKey) external view returns (uint);
 
-    function debtBalanceOfAndTotalDebt(address issuer, bytes32 currencyKey)
-        external
-        view
-        returns (uint debtBalance, uint totalSystemValue);
-
     function isWaitingPeriod(bytes32 currencyKey) external view returns (bool);
 
     function maxIssuableSynths(address issuer) external view returns (uint maxIssuable);

--- a/test/contracts/Depot.js
+++ b/test/contracts/Depot.js
@@ -64,7 +64,14 @@ contract('Depot', async accounts => {
 				// mocks necessary for address resolver imports
 				SynthsUSD: synth,
 			},
-			contracts: ['Depot', 'AddressResolver', 'ExchangeRates', 'SystemStatus', 'Synthetix'],
+			contracts: [
+				'Depot',
+				'AddressResolver',
+				'ExchangeRates',
+				'SystemStatus',
+				'Synthetix',
+				'Issuer',
+			],
 		}));
 	});
 

--- a/test/contracts/Exchanger.js
+++ b/test/contracts/Exchanger.js
@@ -73,6 +73,7 @@ contract('Exchanger (via Synthetix)', async accounts => {
 				'Exchanger',
 				'ExchangeState',
 				'ExchangeRates',
+				'Issuer', // necessary for synthetix transfers to succeed
 				'FeePool',
 				'Synthetix',
 				'SystemStatus',

--- a/test/contracts/Issuer.js
+++ b/test/contracts/Issuer.js
@@ -853,6 +853,7 @@ contract('Issuer (via Synthetix)', async accounts => {
 			assert.bnClose(balanceOfAccount1AfterBurn, amountTransferred, '1000');
 		});
 
+		// TEST CONDITION - TEMP
 		it("should successfully burn all user's synths", async () => {
 			// Give some SNX to account1
 			await synthetix.transfer(account1, toUnit('10000'), {

--- a/test/contracts/Issuer.js
+++ b/test/contracts/Issuer.js
@@ -1,10 +1,12 @@
 'use strict';
 
-const { contract, web3, legacy } = require('@nomiclabs/buidler');
+const { artifacts, contract, web3, legacy } = require('@nomiclabs/buidler');
 
 const { assert, addSnapshotBeforeRestoreAfterEach } = require('./common');
 
 const { setupAllContracts } = require('./setup');
+
+const MockEtherCollateral = artifacts.require('MockEtherCollateral');
 
 const { currentTime, multiplyDecimal, divideDecimal, toUnit, fastForward } = require('../utils')();
 
@@ -21,7 +23,7 @@ const {
 const { toBytes32 } = require('../..');
 
 contract('Issuer (via Synthetix)', async accounts => {
-	const [sUSD, sAUD, sEUR, SNX] = ['sUSD', 'sAUD', 'sEUR', 'SNX'].map(toBytes32);
+	const [sUSD, sAUD, sEUR, SNX, sETH] = ['sUSD', 'sAUD', 'sEUR', 'SNX', 'sETH'].map(toBytes32);
 
 	const [, owner, oracle, account1, account2, account3, account6] = accounts;
 
@@ -32,12 +34,16 @@ contract('Issuer (via Synthetix)', async accounts => {
 		exchangeRates,
 		feePool,
 		sUSDContract,
+		sETHContract,
+		sEURContract,
+		sAUDContract,
 		escrow,
 		rewardEscrow,
 		exchanger,
 		timestamp,
 		issuer,
-		synths;
+		synths,
+		addressResolver;
 
 	const getRemainingIssuableSynths = async account =>
 		(await synthetix.remainingIssuableSynths(account))[0];
@@ -45,7 +51,7 @@ contract('Issuer (via Synthetix)', async accounts => {
 	// run this once before all tests to prepare our environment, snapshots on beforeEach will take
 	// care of resetting to this state
 	before(async () => {
-		synths = ['sUSD', 'sAUD', 'sEUR'];
+		synths = ['sUSD', 'sAUD', 'sEUR', 'sETH'];
 		({
 			Synthetix: synthetix,
 			SynthetixState: synthetixState,
@@ -54,10 +60,14 @@ contract('Issuer (via Synthetix)', async accounts => {
 			SynthetixEscrow: escrow,
 			RewardEscrow: rewardEscrow,
 			SynthsUSD: sUSDContract,
+			SynthsETH: sETHContract,
+			SynthsAUD: sAUDContract,
+			SynthsEUR: sEURContract,
 			Issuer: issuer,
 			FeePool: feePool,
 			Exchanger: exchanger,
 			DelegateApprovals: delegateApprovals,
+			AddressResolver: addressResolver,
 		} = await setupAllContracts({
 			accounts,
 			synths,
@@ -89,8 +99,8 @@ contract('Issuer (via Synthetix)', async accounts => {
 		timestamp = await currentTime();
 
 		await exchangeRates.updateRates(
-			[sAUD, sEUR, SNX],
-			['0.5', '1.25', '0.1'].map(toUnit),
+			[sAUD, sEUR, SNX, sETH],
+			['0.5', '1.25', '0.1', '200'].map(toUnit),
 			timestamp,
 			{ from: oracle }
 		);
@@ -256,6 +266,209 @@ contract('Issuer (via Synthetix)', async accounts => {
 				// burn synths
 				await synthetix.burnSynths(web3.utils.toBN('5'), { from: account1 });
 			});
+		});
+	});
+
+	describe('totalIssuedSynths()', () => {
+		it('should correctly calculate the total issued synths in a single currency', async () => {
+			// Send a price update to give the synth rates
+			await exchangeRates.updateRates(
+				[sAUD, sEUR, sETH],
+				['0.5', '1.25', '100'].map(toUnit),
+				timestamp,
+				{ from: oracle }
+			);
+			// as our synths are mocks, let's issue some amount to users
+			await sUSDContract.issue(account1, toUnit('1000'));
+			await sUSDContract.issue(account2, toUnit('100'));
+			await sUSDContract.issue(account3, toUnit('10'));
+			await sUSDContract.issue(account1, toUnit('1'));
+
+			assert.bnEqual(await synthetix.totalIssuedSynths(sUSD), toUnit('1111'));
+		});
+
+		it('should correctly calculate the total issued synths in multiple currencies', async () => {
+			// Send a price update to give the synth rates
+			await exchangeRates.updateRates(
+				[sAUD, sEUR, sETH],
+				['0.5', '1.25', '100'].map(toUnit),
+				timestamp,
+				{ from: oracle }
+			);
+
+			// as our synths are mocks, let's issue some amount to users
+
+			await sUSDContract.issue(account1, toUnit('1000'));
+
+			await sAUDContract.issue(account1, toUnit('1000')); // 500 sUSD worth
+			await sAUDContract.issue(account2, toUnit('1000')); // 500 sUSD worth
+
+			await sEURContract.issue(account3, toUnit('80')); // 100 sUSD worth
+
+			await sETHContract.issue(account1, toUnit('1')); // 100 sUSD worth
+
+			assert.bnEqual(await synthetix.totalIssuedSynths(sUSD), toUnit('2200'));
+		});
+	});
+
+	describe('debtBalance()', () => {
+		it('should not change debt balance % if exchange rates change', async () => {
+			let newAUDRate = toUnit('0.5');
+			let timestamp = await currentTime();
+			await exchangeRates.updateRates([sAUD], [newAUDRate], timestamp, { from: oracle });
+
+			await synthetix.transfer(account1, toUnit('20000'), {
+				from: owner,
+			});
+			await synthetix.transfer(account2, toUnit('20000'), {
+				from: owner,
+			});
+
+			const amountIssuedAcc1 = toUnit('30');
+			const amountIssuedAcc2 = toUnit('50');
+			await synthetix.issueSynths(amountIssuedAcc1, { from: account1 });
+			await synthetix.issueSynths(amountIssuedAcc2, { from: account2 });
+			await synthetix.exchange(sUSD, amountIssuedAcc2, sAUD, { from: account2 });
+
+			const PRECISE_UNIT = web3.utils.toWei(web3.utils.toBN('1'), 'gether');
+			let totalIssuedSynthsUSD = await synthetix.totalIssuedSynths(sUSD);
+			const account1DebtRatio = divideDecimal(amountIssuedAcc1, totalIssuedSynthsUSD, PRECISE_UNIT);
+			const account2DebtRatio = divideDecimal(amountIssuedAcc2, totalIssuedSynthsUSD, PRECISE_UNIT);
+
+			timestamp = await currentTime();
+			newAUDRate = toUnit('1.85');
+			await exchangeRates.updateRates([sAUD], [newAUDRate], timestamp, { from: oracle });
+
+			totalIssuedSynthsUSD = await synthetix.totalIssuedSynths(sUSD);
+			const conversionFactor = web3.utils.toBN(1000000000);
+			const expectedDebtAccount1 = multiplyDecimal(
+				account1DebtRatio,
+				totalIssuedSynthsUSD.mul(conversionFactor),
+				PRECISE_UNIT
+			).div(conversionFactor);
+			const expectedDebtAccount2 = multiplyDecimal(
+				account2DebtRatio,
+				totalIssuedSynthsUSD.mul(conversionFactor),
+				PRECISE_UNIT
+			).div(conversionFactor);
+
+			assert.bnClose(await synthetix.debtBalanceOf(account1, sUSD), expectedDebtAccount1);
+			assert.bnClose(await synthetix.debtBalanceOf(account2, sUSD), expectedDebtAccount2);
+		});
+
+		it("should correctly calculate a user's debt balance without prior issuance", async () => {
+			await synthetix.transfer(account1, toUnit('200000'), {
+				from: owner,
+			});
+			await synthetix.transfer(account2, toUnit('10000'), {
+				from: owner,
+			});
+
+			const debt1 = await synthetix.debtBalanceOf(account1, toBytes32('sUSD'));
+			const debt2 = await synthetix.debtBalanceOf(account2, toBytes32('sUSD'));
+			assert.bnEqual(debt1, 0);
+			assert.bnEqual(debt2, 0);
+		});
+
+		it("should correctly calculate a user's debt balance with prior issuance", async () => {
+			// Give some SNX to account1
+			await synthetix.transfer(account1, toUnit('200000'), {
+				from: owner,
+			});
+
+			// Issue
+			const issuedSynths = toUnit('1001');
+			await synthetix.issueSynths(issuedSynths, { from: account1 });
+
+			const debt = await synthetix.debtBalanceOf(account1, toBytes32('sUSD'));
+			assert.bnEqual(debt, issuedSynths);
+		});
+	});
+
+	describe('remainingIssuableSynths()', () => {
+		it("should correctly calculate a user's remaining issuable synths with prior issuance", async () => {
+			const snx2usdRate = await exchangeRates.rateForCurrency(SNX);
+			const issuanceRatio = await synthetixState.issuanceRatio();
+
+			const issuedSynthetixs = web3.utils.toBN('200012');
+			await synthetix.transfer(account1, toUnit(issuedSynthetixs), {
+				from: owner,
+			});
+
+			// Issue
+			const amountIssued = toUnit('2011');
+			await synthetix.issueSynths(amountIssued, { from: account1 });
+
+			const expectedIssuableSynths = multiplyDecimal(
+				toUnit(issuedSynthetixs),
+				multiplyDecimal(snx2usdRate, issuanceRatio)
+			).sub(amountIssued);
+
+			const remainingIssuable = await getRemainingIssuableSynths(account1);
+			assert.bnEqual(remainingIssuable, expectedIssuableSynths);
+		});
+
+		it("should correctly calculate a user's remaining issuable synths without prior issuance", async () => {
+			const snx2usdRate = await exchangeRates.rateForCurrency(SNX);
+			const issuanceRatio = await synthetixState.issuanceRatio();
+
+			const issuedSynthetixs = web3.utils.toBN('20');
+			await synthetix.transfer(account1, toUnit(issuedSynthetixs), {
+				from: owner,
+			});
+
+			const expectedIssuableSynths = multiplyDecimal(
+				toUnit(issuedSynthetixs),
+				multiplyDecimal(snx2usdRate, issuanceRatio)
+			);
+
+			const remainingIssuable = await getRemainingIssuableSynths(account1);
+			assert.bnEqual(remainingIssuable, expectedIssuableSynths);
+		});
+	});
+
+	describe('maxIssuableSynths()', () => {
+		it("should correctly calculate a user's maximum issuable synths without prior issuance", async () => {
+			const rate = await exchangeRates.rateForCurrency(toBytes32('SNX'));
+			const issuedSynthetixs = web3.utils.toBN('200000');
+			await synthetix.transfer(account1, toUnit(issuedSynthetixs), {
+				from: owner,
+			});
+			const issuanceRatio = await synthetixState.issuanceRatio();
+
+			const expectedIssuableSynths = multiplyDecimal(
+				toUnit(issuedSynthetixs),
+				multiplyDecimal(rate, issuanceRatio)
+			);
+			const maxIssuableSynths = await synthetix.maxIssuableSynths(account1);
+
+			assert.bnEqual(expectedIssuableSynths, maxIssuableSynths);
+		});
+
+		it("should correctly calculate a user's maximum issuable synths without any SNX", async () => {
+			const maxIssuableSynths = await synthetix.maxIssuableSynths(account1);
+			assert.bnEqual(0, maxIssuableSynths);
+		});
+
+		it("should correctly calculate a user's maximum issuable synths with prior issuance", async () => {
+			const snx2usdRate = await exchangeRates.rateForCurrency(SNX);
+
+			const issuedSynthetixs = web3.utils.toBN('320001');
+			await synthetix.transfer(account1, toUnit(issuedSynthetixs), {
+				from: owner,
+			});
+
+			const issuanceRatio = await synthetixState.issuanceRatio();
+			const amountIssued = web3.utils.toBN('1234');
+			await synthetix.issueSynths(toUnit(amountIssued), { from: account1 });
+
+			const expectedIssuableSynths = multiplyDecimal(
+				toUnit(issuedSynthetixs),
+				multiplyDecimal(snx2usdRate, issuanceRatio)
+			);
+
+			const maxIssuableSynths = await synthetix.maxIssuableSynths(account1);
+			assert.bnEqual(expectedIssuableSynths, maxIssuableSynths);
 		});
 	});
 
@@ -1779,6 +1992,81 @@ contract('Issuer (via Synthetix)', async accounts => {
 
 			const sUSDBalanceAfter = await sUSDContract.balanceOf(account1);
 			assert.bnEqual(sUSDBalanceAfter, toUnit('40'));
+		});
+	});
+
+	describe('when etherCollateral is set', async () => {
+		const collateralKey = 'EtherCollateral';
+
+		it('should have zero totalIssuedSynths', async () => {
+			// totalIssuedSynthsExcludeEtherCollateral equal totalIssuedSynths
+			assert.bnEqual(
+				await synthetix.totalIssuedSynths(sUSD),
+				await synthetix.totalIssuedSynthsExcludeEtherCollateral(sUSD)
+			);
+		});
+		describe('creating a loan on etherCollateral to issue sETH', async () => {
+			let etherCollateral;
+			beforeEach(async () => {
+				// mock etherCollateral
+				etherCollateral = await MockEtherCollateral.new({ from: owner });
+				// have the owner simulate being MultiCollateral so we can invoke issue and burn
+				await addressResolver.importAddresses(
+					[toBytes32(collateralKey)],
+					[etherCollateral.address],
+					{ from: owner }
+				);
+
+				// ensure Issuer has the latest EtherCollateral
+				await issuer.setResolverAndSyncCache(addressResolver.address, { from: owner });
+
+				// Give some SNX to account1
+				await synthetix.transfer(account1, toUnit('1000'), { from: owner });
+
+				// account1 should be able to issue
+				await synthetix.issueSynths(toUnit('10'), { from: account1 });
+
+				// set owner as Synthetix on resolver to allow issuing by owner
+				await addressResolver.importAddresses([toBytes32('Synthetix')], [owner], { from: owner });
+			});
+
+			it('should be able to exclude sETH issued by ether Collateral from totalIssuedSynths', async () => {
+				const totalSupplyBefore = await synthetix.totalIssuedSynths(sETH);
+
+				// issue sETH
+				const amountToIssue = toUnit('10');
+				await sETHContract.issue(account1, amountToIssue, { from: owner });
+
+				// openLoan of same amount on Ether Collateral
+				await etherCollateral.openLoan(amountToIssue, { from: owner });
+
+				// totalSupply of synths should exclude Ether Collateral issued synths
+				assert.bnEqual(
+					totalSupplyBefore,
+					await synthetix.totalIssuedSynthsExcludeEtherCollateral(sETH)
+				);
+
+				// totalIssuedSynths after includes amount issued
+				assert.bnEqual(
+					await synthetix.totalIssuedSynths(sETH),
+					totalSupplyBefore.add(amountToIssue)
+				);
+			});
+
+			it('should exclude sETH issued by ether Collateral from debtBalanceOf', async () => {
+				// account1 should own 100% of the debt.
+				const debtBefore = await synthetix.debtBalanceOf(account1, sUSD);
+				assert.bnEqual(debtBefore, toUnit('10'));
+
+				// issue sETH to mimic loan
+				const amountToIssue = toUnit('10');
+				await sETHContract.issue(account1, amountToIssue, { from: owner });
+				await etherCollateral.openLoan(amountToIssue, { from: owner });
+
+				// After account1 owns 100% of sUSD debt.
+				assert.bnEqual(await synthetix.totalIssuedSynthsExcludeEtherCollateral(sUSD), toUnit('10'));
+				assert.bnEqual(await synthetix.debtBalanceOf(account1, sUSD), debtBefore);
+			});
 		});
 	});
 });

--- a/test/contracts/MultiCollateralSynth.js
+++ b/test/contracts/MultiCollateralSynth.js
@@ -24,7 +24,7 @@ contract('MultiCollateralSynth', accounts => {
 		({ AddressResolver: resolver, Synthetix: synthetix } = await setupAllContracts({
 			accounts,
 			mocks: { FeePool: true },
-			contracts: ['AddressResolver', 'Synthetix'],
+			contracts: ['AddressResolver', 'Synthetix', 'Issuer'],
 		}));
 	});
 

--- a/test/contracts/RewardsDistribution.js
+++ b/test/contracts/RewardsDistribution.js
@@ -37,7 +37,7 @@ contract('RewardsDistribution', async accounts => {
 			Synthetix: synthetix,
 		} = await setupAllContracts({
 			accounts,
-			contracts: ['RewardsDistribution', 'Synthetix', 'FeePool'],
+			contracts: ['RewardsDistribution', 'Synthetix', 'FeePool', 'Issuer'],
 		}));
 
 		mockRewardsRecipient = await MockRewardsRecipient.new(owner, { from: owner });

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -443,6 +443,7 @@ const setupAllContracts = async ({
 		{
 			contract: 'Issuer',
 			mocks: [
+				'EtherCollateral',
 				'Synthetix',
 				'SynthetixState',
 				'Exchanger',
@@ -467,7 +468,6 @@ const setupAllContracts = async ({
 			mocks: [
 				'Issuer',
 				'Exchanger',
-				'EtherCollateral',
 				'SupplySchedule',
 				'RewardEscrow',
 				'SynthetixEscrow',


### PR DESCRIPTION
Here is a proposal for how to reduce size of Synthetix, by moving issuance-specific views over and keeping.

This is a PR into the SIP-48 branch of #451.

These are the contract size of `develop` (not rates stale)
![image](https://user-images.githubusercontent.com/799038/82741306-cb15ba80-9d1e-11ea-9450-a96abf29d09e.png)

And these are the contract size of this:
![image](https://user-images.githubusercontent.com/799038/82741290-ade0ec00-9d1e-11ea-91f3-9ad76257cd79.png)

I'm going to add average gas prices for issuance actions here shortly to compare
