### PR TITLE
Adding --gasprofile to tests

### DIFF
--- a/buidler.config.js
+++ b/buidler.config.js
@@ -146,7 +146,7 @@ task('compile')
 	.setAction(async (taskArguments, bre, runSuper) => {
 		optimizeIfRequired({ bre, taskArguments });
 
-		await runSuper({ taskArguments });
+		await runSuper(taskArguments);
 
 		if (taskArguments.showsize) {
 			const compiled = require(path.resolve(
@@ -198,7 +198,7 @@ task('test')
 				yellow(Math.round(Number(gasUsed) / 1e3) + 'k')
 			);
 		};
-		await runSuper({ taskArguments });
+		await runSuper(taskArguments);
 	});
 
 module.exports = {

--- a/buidler.config.js
+++ b/buidler.config.js
@@ -117,22 +117,34 @@ task('test:legacy', 'run the tests with legacy components')
 		await bre.run('test', taskArguments);
 	});
 
+const optimizeIfRequired = ({ bre, taskArguments: { optimizer } }) => {
+	if (optimizer || bre.optimizer) {
+		// only show message once if re-run
+		if (bre.optimizer === undefined) {
+			console.log(gray('Adding optimizer, runs', yellow(optimizerRuns)));
+		}
+		// Use optimizer (slower) but simulates real contract size limits and gas usage
+		// Note: does not consider actual deployed optimization runs from
+		// publish/src/contract-overrides.js
+		bre.config.solc.optimizer = { enabled: true, runs: optimizerRuns };
+		bre.config.networks.buidlerevm.allowUnlimitedContractSize = false;
+	} else {
+		if (bre.optimizer === undefined) {
+			console.log(gray('Optimizer disabled. Unlimited contract sizes allowed.'));
+		}
+		bre.config.solc.optimizer = { enabled: false };
+		bre.config.networks.buidlerevm.allowUnlimitedContractSize = true;
+	}
+
+	// flag here so that if invoked via "buidler test" the argument will persist to the compile stage
+	bre.optimizer = !!optimizer;
+};
+
 task('compile')
 	.addFlag('showsize', 'Show size of compiled contracts')
 	.addFlag('optimizer', 'Compile with the optimizer')
 	.setAction(async (taskArguments, bre, runSuper) => {
-		if (taskArguments.optimizer) {
-			// Use optimizer (slower) but simulates real contract size limits and gas usage
-			// Note: does not consider actual deployed optimization runs from
-			// publish/src/contract-overrides.js
-			console.log(gray('Adding optimizer, runs', yellow(optimizerRuns)));
-			bre.config.solc.optimizer = { enabled: true, runs: optimizerRuns };
-			bre.config.networks.buidlerevm.allowUnlimitedContractSize = false;
-		} else {
-			console.log(gray('Optimizer disabled. Unlimited contract sizes allowed.'));
-			bre.config.solc.optimizer = { enabled: false };
-			bre.config.networks.buidlerevm.allowUnlimitedContractSize = true;
-		}
+		optimizeIfRequired({ bre, taskArguments });
 
 		await runSuper({ taskArguments });
 
@@ -166,8 +178,11 @@ task('compile')
 	});
 
 task('test')
+	.addFlag('optimizer', 'Compile with the optimizer')
 	.addFlag('gasprofile', 'Filter tests to only those with gas profile results')
 	.setAction(async (taskArguments, bre, runSuper) => {
+		optimizeIfRequired({ bre, taskArguments });
+
 		if (taskArguments.gasprofile) {
 			console.log(gray('Filtering tests to those containing'), yellow('@gasprofile'));
 			bre.config.mocha.grep = '@gasprofile';

--- a/buidler.config.js
+++ b/buidler.config.js
@@ -165,6 +165,27 @@ task('compile')
 		}
 	});
 
+task('test')
+	.addFlag('gasprofile', 'Filter tests to only those with gas profile results')
+	.setAction(async (taskArguments, bre, runSuper) => {
+		if (taskArguments.gasprofile) {
+			console.log(gray('Filtering tests to those containing'), yellow('@gasprofile'));
+			bre.config.mocha.grep = '@gasprofile';
+		}
+		// add a helper function to output gas in tests
+		bre.gasProfile = ({ receipt: { gasUsed }, fnc = '' }) => {
+			if (!taskArguments.gasprofile) {
+				return;
+			}
+
+			console.log(
+				gray(`\tGas used ${fnc ? 'by ' + fnc : ''}`),
+				yellow(Math.round(Number(gasUsed) / 1e3) + 'k')
+			);
+		};
+		await runSuper({ taskArguments });
+	});
+
 module.exports = {
 	GAS_PRICE,
 	solc: {

--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -54,7 +54,8 @@ contract Proxy is Owned {
         }
     }
 
-    function() external payable {        
+    // solhint-disable no-complex-fallback
+    function() external payable {
         // Mutable call setting Proxyable.messageSender as this is using call not delegatecall
         target.setMessageSender(msg.sender);
 

--- a/legacy/buidler.legacy.js
+++ b/legacy/buidler.legacy.js
@@ -10,7 +10,7 @@ const legacyArtifactsFolder = '../build/legacy/artifacts';
 const latestArtifactsFolder = '../build/artifacts';
 
 task('compile', 'compilation step', async (taskArguments, bre, runSuper) => {
-	await runSuper();
+	await runSuper(taskArguments);
 
 	const sourcePath = path.join(__dirname, sourceFolder);
 	const legacyArtifactsPath = path.join(__dirname, legacyArtifactsFolder);

--- a/test/contracts/Exchanger.js
+++ b/test/contracts/Exchanger.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { contract, web3 } = require('@nomiclabs/buidler');
+const { contract, web3, gasProfile } = require('@nomiclabs/buidler');
 
 const { assert, addSnapshotBeforeRestoreAfterEach } = require('./common');
 
@@ -974,13 +974,15 @@ contract('Exchanger (via Synthetix)', async accounts => {
 													await fastForward(60);
 												});
 												describe('when settle() is invoked for sBTC', () => {
-													it('then it settles with a rebate', async () => {
-														const { tx: hash } = await synthetix.settle(sBTC, {
+													it('then it settles with a rebate @gasprofile', async () => {
+														const txn = await synthetix.settle(sBTC, {
 															from: account1,
 														});
 
+														gasProfile(Object.assign({ fnc: 'Synthetix.settle()' }, txn));
+
 														await ensureTxnEmitsSettlementEvents({
-															hash,
+															hash: txn.tx,
 															synth: sBTCContract,
 															expected: {
 																reclaimAmount: new web3.utils.BN(0),
@@ -1177,11 +1179,13 @@ contract('Exchanger (via Synthetix)', async accounts => {
 				assert.bnEqual(exchangeFeeUSD, feePeriodZero.feesToDistribute);
 			});
 
-			it('should emit a SynthExchange event', async () => {
+			it('should emit a SynthExchange event @gasprofile', async () => {
 				// Exchange sUSD to sAUD
 				const txn = await synthetix.exchange(sUSD, amountIssued, sAUD, {
 					from: account1,
 				});
+
+				gasProfile(Object.assign({ fnc: 'Synthetix.exchange' }, txn));
 
 				const sAUDBalance = await sAUDContract.balanceOf(account1);
 

--- a/test/contracts/FeePool.js
+++ b/test/contracts/FeePool.js
@@ -1,4 +1,6 @@
-const { artifacts, contract, web3 } = require('@nomiclabs/buidler');
+'use strict';
+
+const { artifacts, contract, web3, gasProfile } = require('@nomiclabs/buidler');
 
 const { assert, addSnapshotBeforeRestoreAfterEach } = require('./common');
 
@@ -583,7 +585,7 @@ contract('FeePool', async accounts => {
 			});
 		});
 
-		it('should allow a user to claim their fees in sUSD', async () => {
+		it('should allow a user to claim their fees in sUSD @gasprofile', async () => {
 			const length = (await feePool.FEE_PERIOD_LENGTH()).toNumber();
 
 			// Issue 10,000 sUSD for two different accounts.
@@ -611,6 +613,9 @@ contract('FeePool', async accounts => {
 
 			// Now we should be able to claim them.
 			const claimFeesTx = await feePool.claimFees({ from: owner });
+
+			gasProfile(Object.assign({ fnc: 'FeePool.claimFees()' }, claimFeesTx));
+
 			assert.eventEqual(claimFeesTx, 'FeesClaimed', {
 				sUSDAmount: feesAvailableUSD[0],
 				snxRewards: feesAvailableUSD[1],

--- a/test/contracts/Issuer.js
+++ b/test/contracts/Issuer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { contract, web3, legacy, gasProfile } = require('@nomiclabs/buidler');
+const { contract, web3, gasProfile } = require('@nomiclabs/buidler');
 
 const { assert, addSnapshotBeforeRestoreAfterEach } = require('./common');
 

--- a/test/contracts/Issuer.js
+++ b/test/contracts/Issuer.js
@@ -622,7 +622,7 @@ contract('Issuer (via Synthetix)', async accounts => {
 	});
 
 	describe('debt calculation in multi-issuance scenarios', () => {
-		it('should correctly calculate debt in a multi-issuance multi-burn scenario', async () => {
+		it('should correctly calculate debt in a multi-issuance multi-burn scenario @gasprofile', async () => {
 			// Give some SNX to account1
 			await synthetix.transfer(account1, toUnit('500000'), {
 				from: owner,
@@ -639,11 +639,13 @@ contract('Issuer (via Synthetix)', async accounts => {
 
 			await synthetix.issueSynths(issuedSynthsPt1, { from: account1 });
 			await synthetix.burnSynths(burntSynthsPt1, { from: account1 });
-			await synthetix.issueSynths(issuedSynthsPt2, { from: account1 });
+			const issueTxn = await synthetix.issueSynths(issuedSynthsPt2, { from: account1 });
+			gasProfile(Object.assign({ fnc: 'Synthetix.issueSynths() (3rd of 3)' }, issueTxn));
 
 			await synthetix.issueSynths(toUnit('100'), { from: account2 });
 			await synthetix.issueSynths(toUnit('51'), { from: account2 });
-			await synthetix.burnSynths(burntSynthsPt2, { from: account1 });
+			const burnTxn = await synthetix.burnSynths(burntSynthsPt2, { from: account1 });
+			gasProfile(Object.assign({ fnc: 'Synthetix.burnSynths() (3rd of 3)' }, burnTxn));
 
 			const debt = await synthetix.debtBalanceOf(account1, toBytes32('sUSD'));
 			const expectedDebt = issuedSynthsPt1

--- a/test/contracts/Synth.js
+++ b/test/contracts/Synth.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { artifacts, contract, web3 } = require('@nomiclabs/buidler');
+const { artifacts, contract, web3, gasProfile } = require('@nomiclabs/buidler');
 
 const { assert, addSnapshotBeforeRestoreAfterEach } = require('./common');
 
@@ -205,7 +205,7 @@ contract('Synth', async accounts => {
 		});
 	});
 
-	it('should transfer (ERC20) without error', async () => {
+	it('should transfer (ERC20) without error @gasprofile', async () => {
 		// Issue 10,000 sUSD.
 		const amount = toUnit('10000');
 		await synthetix.issueSynths(amount, { from: owner });
@@ -214,6 +214,7 @@ contract('Synth', async accounts => {
 		const transaction = await sUSDContract.transfer(account1, amount, {
 			from: owner,
 		});
+		gasProfile(Object.assign({ fnc: 'Synth.transfer()' }, transaction));
 
 		// Events should be a fee exchange and a transfer to account1
 		assert.eventEqual(
@@ -241,7 +242,7 @@ contract('Synth', async accounts => {
 		);
 	});
 
-	it('should transferFrom (ERC20) without error', async () => {
+	it('should transferFrom (ERC20) without error @gasprofile', async () => {
 		// Issue 10,000 sUSD.
 		const amount = toUnit('10000');
 		await synthetix.issueSynths(amount, { from: owner });
@@ -253,6 +254,8 @@ contract('Synth', async accounts => {
 		const transaction = await sUSDContract.transferFrom(owner, account1, amount, {
 			from: account1,
 		});
+
+		gasProfile(Object.assign({ fnc: 'Synth.transferFrom()' }, transaction));
 
 		// Events should be a transfer to account1
 		assert.eventEqual(

--- a/test/contracts/Synthetix.js
+++ b/test/contracts/Synthetix.js
@@ -653,6 +653,47 @@ contract('Synthetix', async accounts => {
 			const transferable2 = await synthetix.transferableSynthetix(account1);
 			assert.equal(transferable2.gt(toUnit('1000')), true);
 		});
+
+		describe('when the user has issued some sUSD and exchanged for other synths', () => {
+			beforeEach(async () => {
+				await synthetix.issueSynths(toUnit('100'), { from: owner });
+				await synthetix.exchange(sUSD, toUnit('10'), sETH, { from: owner });
+				await synthetix.exchange(sUSD, toUnit('10'), sAUD, { from: owner });
+				await synthetix.exchange(sUSD, toUnit('10'), sEUR, { from: owner });
+			});
+			it('should transfer using the ERC20 transfer function @gasprofile', async () => {
+				const transaction = await synthetix.transfer(account1, toUnit('10'), { from: owner });
+
+				gasProfile(Object.assign({ fnc: 'Synthetix.transfer()' }, transaction));
+
+				assert.bnEqual(await synthetix.balanceOf(account1), toUnit('10'));
+			});
+
+			it('should transfer using the ERC20 transferFrom function @gasprofile', async () => {
+				const previousOwnerBalance = await synthetix.balanceOf(owner);
+
+				// Approve account1 to act on our behalf for 10 SNX.
+				let transaction = await synthetix.approve(account1, toUnit('10'), { from: owner });
+
+				// Assert that transferFrom works.
+				transaction = await synthetix.transferFrom(owner, account2, toUnit('10'), {
+					from: account1,
+				});
+
+				gasProfile(Object.assign({ fnc: 'Synthetix.transferFrom()' }, transaction));
+
+				// Assert that account2 has 10 SNX and owner has 10 less SNX
+				assert.bnEqual(await synthetix.balanceOf(account2), toUnit('10'));
+				assert.bnEqual(await synthetix.balanceOf(owner), previousOwnerBalance.sub(toUnit('10')));
+
+				// Assert that we can't transfer more even though there's a balance for owner.
+				await assert.revert(
+					synthetix.transferFrom(owner, account2, '1', {
+						from: account1,
+					})
+				);
+			});
+		});
 	});
 
 	describe('debtBalance()', () => {

--- a/test/contracts/Synthetix.js
+++ b/test/contracts/Synthetix.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { artifacts, contract, web3 } = require('@nomiclabs/buidler');
+const { artifacts, contract, web3, gasProfile } = require('@nomiclabs/buidler');
 
 const { assert, addSnapshotBeforeRestoreAfterEach } = require('./common');
 
@@ -414,13 +414,16 @@ contract('Synthetix', async accounts => {
 			await updateRatesWithDefaults({ exchangeRates, oracle });
 		});
 
-		it('should transfer using the ERC20 transfer function', async () => {
+		it('should transfer using the ERC20 transfer function @gasprofile', async () => {
 			// Ensure our environment is set up correctly for our assumptions
 			// e.g. owner owns all SNX.
 
 			assert.bnEqual(await synthetix.totalSupply(), await synthetix.balanceOf(owner));
 
 			const transaction = await synthetix.transfer(account1, toUnit('10'), { from: owner });
+
+			gasProfile(Object.assign({ fnc: 'Synthetix.transfer' }, transaction));
+
 			assert.eventEqual(transaction, 'Transfer', {
 				from: owner,
 				to: account1,
@@ -445,7 +448,7 @@ contract('Synthetix', async accounts => {
 			);
 		});
 
-		it('should transfer using the ERC20 transferFrom function', async () => {
+		it('should transfer using the ERC20 transferFrom function @gasprofile', async () => {
 			// Ensure our environment is set up correctly for our assumptions
 			// e.g. owner owns all SNX.
 			const previousOwnerBalance = await synthetix.balanceOf(owner);
@@ -461,6 +464,9 @@ contract('Synthetix', async accounts => {
 
 			// Assert that transferFrom works.
 			transaction = await synthetix.transferFrom(owner, account2, toUnit('10'), { from: account1 });
+
+			gasProfile(Object.assign({ fnc: 'Synthetix.transferFrom' }, transaction));
+
 			assert.eventEqual(transaction, 'Transfer', {
 				from: owner,
 				to: account2,


### PR DESCRIPTION
Provides a new flag `--gasprofile` to `buidler test` that only runs a handful of tests and outputs their gas usage. (Once #503 is merged, this can simply use that to show gas and this just becomes a small filter of tests to run to profile gas)

![image](https://user-images.githubusercontent.com/799038/83043857-62298d80-a011-11ea-8a82-6a4c9c561623.png)
