### PR TITLE
Fixing proxy labelling and connections on testnets

### DIFF
--- a/publish/deployed/kovan/deployment.json
+++ b/publish/deployed/kovan/deployment.json
@@ -99,8 +99,8 @@
 			"txn": "",
 			"network": "kovan"
 		},
-		"ProxysUSD": {
-			"name": "ProxysUSD",
+		"ProxyERC20sUSD": {
+			"name": "ProxyERC20sUSD",
 			"address": "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
 			"source": "ProxyERC20",
 			"link": "https://kovan.etherscan.io/address/0x57Ab1ec28D129707052df4dF418D58a2D46d5f51",
@@ -702,8 +702,8 @@
 			"txn": "https://kovan.etherscan.io/tx/0xd13eda66ba28b1c5922041988c2c6818ac7bd77eaa390a35c4c2f05ed5b0510a",
 			"network": "kovan"
 		},
-		"ProxyERC20sUSD": {
-			"name": "ProxyERC20sUSD",
+		"ProxysUSD": {
+			"name": "ProxysUSD",
 			"address": "0xC674ad732Dfd4E1359ec4B18fA5472c0747E480A",
 			"source": "ProxyERC20",
 			"link": "https://kovan.etherscan.io/address/0xC674ad732Dfd4E1359ec4B18fA5472c0747E480A",

--- a/test/deployments/index.js
+++ b/test/deployments/index.js
@@ -36,7 +36,7 @@ describe('deployments', () => {
 					web3 = new Web3(new Web3.providers.HttpProvider(connections.providerUrl));
 
 					contracts = {
-						Synthetix: getContract({ source: 'Synthetix', target: 'ProxySynthetix' }),
+						Synthetix: getContract({ source: 'Synthetix', target: 'ProxyERC20' }),
 						ExchangeRates: getContract({ target: 'ExchangeRates' }),
 					};
 				});

--- a/test/publish/index.js
+++ b/test/publish/index.js
@@ -143,13 +143,13 @@ describe('publish scripts', function() {
 				targets = snx.getTarget({ network });
 				synths = snx.getSynths({ network }).filter(({ name }) => name !== 'sUSD');
 
-				Synthetix = new web3.eth.Contract(
-					sources['Synthetix'].abi,
-					targets['ProxySynthetix'].address
-				);
+				Synthetix = new web3.eth.Contract(sources['Synthetix'].abi, targets['ProxyERC20'].address);
 				FeePool = new web3.eth.Contract(sources['FeePool'].abi, targets['ProxyFeePool'].address);
 				Issuer = new web3.eth.Contract(sources['Issuer'].abi, targets['Issuer'].address);
-				sUSDContract = new web3.eth.Contract(sources['Synth'].abi, targets['ProxysUSD'].address);
+				sUSDContract = new web3.eth.Contract(
+					sources['Synth'].abi,
+					targets['ProxyERC20sUSD'].address
+				);
 				sBTCContract = new web3.eth.Contract(sources['Synth'].abi, targets['ProxysBTC'].address);
 				sETHContract = new web3.eth.Contract(sources['Synth'].abi, targets['ProxysETH'].address);
 				timestamp = (await web3.eth.getBlock('latest')).timestamp;


### PR DESCRIPTION
This PR makes sure all testnet labels match mainnet from Phase 2 (https://docs.synthetix.io/integrations/guide/#proxies)

- `ProxyERC20` on all environments is a `ProxyERC20.sol` and `target` is `Synthetix`
- All `Synthetix` contracts have `proxy` set to `ProxyERC20` and `integrationProxy` set to the old `ProxySynthetix`
- `ProxyERC20sUSD` on all environments is a `ProxyERC20.sol` and `target` is `SynthsUSD`
- All `SynthsUSD` contracts have `proxy` set to `ProxyERC20sUSD` and `integrationProxy` set to the old `ProxysUSD`
