### PR TITLE
Use deployedBytecode instead of bytecode during build

### DIFF
--- a/publish/src/commands/build.js
+++ b/publish/src/commands/build.js
@@ -99,7 +99,7 @@ const build = async ({
 		const filePath = `${toWrite}.json`;
 		const prevSizeIfAny = fs.existsSync(filePath)
 			? await sizeOfContracts({
-					contractToObjectMap: { [filePath]: require(filePath).evm.bytecode.object },
+					contractToObjectMap: { [filePath]: require(filePath).evm.deployedBytecode.object },
 			  })[0]
 			: undefined;
 		if (prevSizeIfAny) {
@@ -154,7 +154,7 @@ const build = async ({
 			fs.writeFileSync(filePath, stringify(artifacts[contractName]));
 
 			const { pcent, bytes, length } = sizeOfContracts({
-				contractToObjectMap: { [filePath]: artifacts[contractName].evm.bytecode.object },
+				contractToObjectMap: { [filePath]: artifacts[contractName].evm.deployedBytecode.object },
 			})[0];
 
 			console.log(
@@ -181,7 +181,7 @@ const build = async ({
 		const contractToObjectMap = allCompiledFilePaths
 			.filter(file => fs.existsSync(file))
 			.reduce((memo, file) => {
-				memo[file] = require(file).evm.bytecode.object;
+				memo[file] = require(file).evm.deployedBytecode.object;
 				return memo;
 			}, {});
 

--- a/publish/src/solidity.js
+++ b/publish/src/solidity.js
@@ -79,7 +79,7 @@ module.exports = {
 						},
 						outputSelection: {
 							'*': {
-								'*': ['abi', 'evm.bytecode'],
+								'*': ['abi', 'evm.bytecode', 'evm.deployedBytecode'],
 							},
 						},
 					},


### PR DESCRIPTION
The contract size being logged is the size of `bytecode`, or `initcode`, while the size limitation of `24KB` only applies to the `deployedBytecode`.