### PR TITLE
SIP-48 audit remediations

### DIFF
--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -228,15 +228,14 @@ contract Exchanger is Owned, MixinResolver, IExchanger {
         uint sourceAmount,
         bytes32 destinationCurrencyKey,
         address destinationAddress
-    )
-        internal
-        returns (
-            // Note: We don't need to insist on non-stale rates because effectiveValue will do it for us.
-            uint amountReceived
-        )
-    {
+    ) internal returns (uint amountReceived) {
         require(sourceCurrencyKey != destinationCurrencyKey, "Can't be same synth");
         require(sourceAmount > 0, "Zero amount");
+
+        bytes32[] memory synthKeys = new bytes32[](2);
+        synthKeys[0] = sourceCurrencyKey;
+        synthKeys[1] = destinationCurrencyKey;
+        require(!exchangeRates().anyRateIsStale(synthKeys), "Src/dest rate stale or not found");
 
         (, uint refunded, uint numEntriesSettled) = _internalSettle(from, sourceCurrencyKey);
 

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -274,7 +274,7 @@ contract Exchanger is Owned, MixinResolver, IExchanger {
 
         // Remit the fee if required
         if (fee > 0) {
-            remitFee(exchangeRates(), issuer(), fee, destinationCurrencyKey);
+            remitFee(fee, destinationCurrencyKey);
         }
 
         // Nothing changes as far as issuance data goes because the total value in the system hasn't changed.
@@ -314,15 +314,10 @@ contract Exchanger is Owned, MixinResolver, IExchanger {
     }
 
     /* ========== INTERNAL FUNCTIONS ========== */
-    function remitFee(
-        IExchangeRates _exRates,
-        IIssuer _issuer,
-        uint fee,
-        bytes32 currencyKey
-    ) internal {
+    function remitFee(uint fee, bytes32 currencyKey) internal {
         // Remit the fee in sUSDs
-        uint usdFeeAmount = _exRates.effectiveValue(currencyKey, fee, sUSD);
-        _issuer.synths(sUSD).issue(feePool().FEE_ADDRESS(), usdFeeAmount);
+        uint usdFeeAmount = exchangeRates().effectiveValue(currencyKey, fee, sUSD);
+        issuer().synths(sUSD).issue(feePool().FEE_ADDRESS(), usdFeeAmount);
         // Tell the fee pool about this.
         feePool().recordFeePaid(usdFeeAmount);
     }

--- a/contracts/Issuer.sol
+++ b/contracts/Issuer.sol
@@ -590,7 +590,6 @@ contract Issuer is Owned, MixinResolver, IIssuer {
         _internalBurnSynths(from, amountToBurnToTarget, existingDebt, totalSystemValue, maxIssuableSynthsForAccount);
     }
 
-    // No need to check for stale rates as effectiveValue checks rates
     function _internalBurnSynths(
         address from,
         uint amount,

--- a/contracts/PurgeableSynth.sol
+++ b/contracts/PurgeableSynth.sol
@@ -45,8 +45,6 @@ contract PurgeableSynth is Synth {
     function purge(address[] calldata addresses) external optionalProxy_onlyOwner {
         IExchangeRates exRates = exchangeRates();
 
-        require(!exchangeRates().rateIsStale(currencyKey), "Cannot purge stale synth");
-
         uint maxSupplyToPurge = exRates.effectiveValue("sUSD", maxSupplyToPurgeInUSD, currencyKey);
 
         // Only allow purge when total supply is lte the max or the rate is frozen in ExchangeRates

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -12,7 +12,6 @@ import "./TokenState.sol";
 import "./interfaces/ISystemStatus.sol";
 import "./interfaces/IExchanger.sol";
 import "./interfaces/IIssuer.sol";
-import "./interfaces/IExchangeRates.sol";
 import "./SupplySchedule.sol";
 import "./interfaces/IRewardsDistribution.sol";
 
@@ -32,7 +31,6 @@ contract Synthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
     bytes32 private constant CONTRACT_SYSTEMSTATUS = "SystemStatus";
     bytes32 private constant CONTRACT_EXCHANGER = "Exchanger";
     bytes32 private constant CONTRACT_ISSUER = "Issuer";
-    bytes32 private constant CONTRACT_EXRATES = "ExchangeRates";
     bytes32 private constant CONTRACT_SUPPLYSCHEDULE = "SupplySchedule";
     bytes32 private constant CONTRACT_REWARDSDISTRIBUTION = "RewardsDistribution";
 
@@ -40,7 +38,6 @@ contract Synthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         CONTRACT_SYSTEMSTATUS,
         CONTRACT_EXCHANGER,
         CONTRACT_ISSUER,
-        CONTRACT_EXRATES,
         CONTRACT_SUPPLYSCHEDULE,
         CONTRACT_REWARDSDISTRIBUTION
     ];
@@ -71,10 +68,6 @@ contract Synthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
 
     function issuer() internal view returns (IIssuer) {
         return IIssuer(requireAndGetAddress(CONTRACT_ISSUER, "Missing Issuer address"));
-    }
-
-    function exchangeRates() internal view returns (IExchangeRates) {
-        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES, "Missing ExchangeRates address"));
     }
 
     function supplySchedule() internal view returns (SupplySchedule) {
@@ -336,12 +329,7 @@ contract Synthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
 
     modifier exchangeActive(bytes32 src, bytes32 dest) {
         systemStatus().requireExchangeActive();
-
         systemStatus().requireSynthsActive(src, dest);
-
-        require(!exchangeRates().rateIsStale(src), "Source rate stale or not found");
-        require(!exchangeRates().rateIsStale(dest), "Dest rate stale or not found");
-
         _;
     }
 

--- a/test/contracts/Exchanger.js
+++ b/test/contracts/Exchanger.js
@@ -1402,7 +1402,7 @@ contract('Exchanger (via Synthetix)', async accounts => {
 						it(`attempting to ${type} from sUSD into sAUD reverts with dest stale`, async () => {
 							await assert.revert(
 								exchange({ from: sUSD, amount: amountIssued, to: sAUD }),
-								'Dest rate stale or not found'
+								'Src/dest rate stale or not found'
 							);
 						});
 						it('settling still works ', async () => {
@@ -1429,7 +1429,7 @@ contract('Exchanger (via Synthetix)', async accounts => {
 									it(`${type} back to sUSD fails as the source has no rate`, async () => {
 										await assert.revert(
 											exchange({ from: sAUD, amount: amountIssued, to: sUSD }),
-											'Source rate stale or not found'
+											'Src/dest rate stale or not found'
 										);
 									});
 								});

--- a/test/contracts/PurgeableSynth.js
+++ b/test/contracts/PurgeableSynth.js
@@ -205,7 +205,7 @@ contract('PurgeableSynth', accounts => {
 					it('then purge() reverts', async () => {
 						await assert.revert(
 							iETHContract.purge([account1], { from: owner }),
-							'Cannot purge stale synth'
+							'Src/dest rate stale or not found'
 						);
 					});
 					describe('when rates are received', () => {


### PR DESCRIPTION
- `Exchanger.remitFee` - removed redundant functions
- Added missing test coverage for `totalIssuedSynths` in `SNX` and in `ETH`
- Removed old comments from `Issuer` and `Exchanger`
- Staleness check on `src` and `dest` of `exchange()`
    - Moved stale check of `src` and `dest` from `Synthetix` to `Exchanger` so `Synth._transferToFeeAddress` checks staleness no
    - Removed specific check in `PurgeableSynth.purge` as staleness is now checked in `Exchanger`