### PR TITLE
New settlement command

### DIFF
--- a/publish/index.js
+++ b/publish/index.js
@@ -15,6 +15,7 @@ require('./src/commands/purge-synths').cmd(program);
 require('./src/commands/release').cmd(program);
 require('./src/commands/remove-synths').cmd(program);
 require('./src/commands/replace-synths').cmd(program);
+require('./src/commands/settle').cmd(program);
 require('./src/commands/verify').cmd(program);
 require('./src/commands/versions-history').cmd(program);
 require('./src/commands/versions-update').cmd(program);

--- a/publish/src/commands/.gitignore
+++ b/publish/src/commands/.gitignore
@@ -1,1 +1,2 @@
 recent-feePeriods-*.json
+exchanges-*.json

--- a/publish/src/commands/import-fee-periods.js
+++ b/publish/src/commands/import-fee-periods.js
@@ -28,8 +28,8 @@ const {
 
 const pathToLocal = name => path.join(__dirname, `${name}.json`);
 
-const saveFeePeriodsToFile = async ({ network, feePeriods, sourceContractAddress }) => {
-	await fs.writeFileSync(
+const saveFeePeriodsToFile = ({ network, feePeriods, sourceContractAddress }) => {
+	fs.writeFileSync(
 		pathToLocal(`recent-feePeriods-${network}-${sourceContractAddress}`),
 		stringify(feePeriods)
 	);
@@ -161,7 +161,7 @@ const importFeePeriods = async ({
 	console.log(gray(`Gas Price: ${gasPrice} gwei`));
 
 	if (network !== 'local') {
-		await saveFeePeriodsToFile({ network, feePeriods, sourceContractAddress });
+		saveFeePeriodsToFile({ network, feePeriods, sourceContractAddress });
 	}
 
 	let index = 0;

--- a/publish/src/commands/settle.js
+++ b/publish/src/commands/settle.js
@@ -5,12 +5,7 @@ const fs = require('fs');
 const path = require('path');
 const Web3 = require('web3');
 
-const {
-	getTarget,
-	getSource,
-	toBytes32,
-	// constants: { CONFIG_FILENAME, DEPLOYMENT_FILENAME },
-} = require('../../..');
+const { getTarget, getSource, toBytes32 } = require('../../..');
 
 const { ensureNetwork, loadConnections, stringify } = require('../util');
 
@@ -48,6 +43,7 @@ const settle = async ({
 	gasLimit,
 	privateKey,
 	oldProxy,
+	ethToSeed,
 }) => {
 	ensureNetwork(network);
 
@@ -74,10 +70,9 @@ const settle = async ({
 	let nonce = await web3.eth.getTransactionCount(user.address);
 	console.log(gray('Starting at nonce'), yellow(nonce));
 
-	if (balance === '0') {
-		const ethToSeed = '1';
+	if (balance < '0.1') {
 		if (dryRun) {
-			console.log(green('[DRY RUN] Sending ETH to address'));
+			console.log(green('[DRY RUN] Sending'), yellow(ethToSeed), green('ETH to address'));
 		} else {
 			console.log(
 				green(`Sending ${yellow(ethToSeed)} ETH to address from`),
@@ -247,7 +242,8 @@ module.exports = {
 		program
 			.command('settle')
 			.description('Settle all exchanges')
-			.option('-f, --from-block <value>', `Starting block number to listen to events from`)
+			.option('-e, --eth-to-seed <value>', 'Amount of ETH to seed', '1')
+			.option('-f, --from-block <value>', 'Starting block number to listen to events from')
 			.option('-g, --gas-price <value>', 'Gas price in GWEI', '1')
 			.option('-l, --gas-limit <value>', 'Gas limit', parseInt, 150e3)
 			.option('-v, --private-key <value>', 'Provide private key to settle from given account')

--- a/publish/src/commands/settle.js
+++ b/publish/src/commands/settle.js
@@ -107,14 +107,14 @@ const settle = async ({
 
 	const fetchAllEvents = ({ pageSize = 10e3, startingBlock = fromBlock, target }) => {
 		const innerFnc = async () => {
+			if (startingBlock > currentBlock) {
+				return [];
+			}
 			console.log(gray('-> Fetching page of results from target', yellow(target.options.address)));
 			const pageOfResults = await target.getPastEvents('SynthExchange', {
 				fromBlock: startingBlock,
 				toBlock: startingBlock + pageSize - 1,
 			});
-			if (startingBlock + pageSize - 1 > currentBlock) {
-				return [];
-			}
 			startingBlock += pageSize;
 			return [].concat(pageOfResults).concat(await innerFnc());
 		};

--- a/publish/src/commands/settle.js
+++ b/publish/src/commands/settle.js
@@ -214,7 +214,7 @@ const settle = async ({
 					.settle(account, toCurrencyKey)
 					.send({
 						from: user.address,
-						gas: Math.max(gas * numEntries, 300e3),
+						gas: Math.max(gas * numEntries, 500e3),
 						gasPrice,
 						nonce: nonce++,
 					})

--- a/publish/src/commands/settle.js
+++ b/publish/src/commands/settle.js
@@ -1,0 +1,187 @@
+'use strict';
+
+const { gray, yellow, red, cyan, green } = require('chalk');
+const fs = require('fs');
+const path = require('path');
+const Web3 = require('web3');
+
+const {
+	getTarget,
+	getSource,
+	toBytes32,
+	constants: { CONFIG_FILENAME, DEPLOYMENT_FILENAME },
+} = require('../../..');
+
+const { ensureNetwork, loadConnections, stringify } = require('../util');
+
+// The block where Synthetix first had SIP-37 added (when ExchangeState was added)
+const fromBlockMap = {
+	kovan: 16814289,
+	mainnet: 9518299,
+};
+
+const pathToLocal = name => path.join(__dirname, `${name}.json`);
+
+const saveExchangesToFile = ({ network, label = '', exchanges, fromBlock }) => {
+	fs.writeFileSync(
+		pathToLocal(`exchanges-${label ? label + '-' : ''}${network}-${fromBlock}`),
+		stringify(exchanges)
+	);
+};
+
+const loadExchangesFromFile = ({ network, fromBlock, label = '' }) => {
+	return JSON.parse(
+		fs
+			.readFileSync(pathToLocal(`exchanges-${label ? label + '-' : ''}${network}-${fromBlock}`))
+			.toString()
+	);
+};
+
+const settle = async ({
+	network,
+	fromBlock = fromBlockMap[network],
+	dryRun,
+	deploymentPath,
+	gasPrice,
+	gasLimit,
+}) => {
+	ensureNetwork(network);
+
+	console.log(gray('Using network:', yellow(network)));
+
+	const { providerUrl, privateKey: envPrivateKey } = loadConnections({
+		network,
+	});
+
+	const privateKey = envPrivateKey;
+
+	const web3 = new Web3(new Web3.providers.HttpProvider(providerUrl));
+
+	const user = web3.eth.accounts.wallet.add(privateKey);
+
+	console.log(gray('Using wallet', cyan(user.address)));
+
+	const getContract = ({ label, source }) =>
+		new web3.eth.Contract(
+			getSource({ network, contract: source }).abi,
+			getTarget({ network, contract: label }).address
+		);
+
+	const SynthetixOld = getContract({ label: 'ProxySynthetix', source: 'Synthetix' });
+	// const Synthetix = getContract({ label: 'ProxyERC20', source: 'Synthetix'})
+
+	const Exchanger = getContract({ label: 'Exchanger', source: 'Exchanger' });
+	const ExchangeRates = getContract({ label: 'ExchangeRates', source: 'ExchangeRates' });
+
+	const fetchAllEvents = ({ pageSize = 10e3, startingBlock = fromBlock, target }) => {
+		const innerFnc = async () => {
+			console.log(gray('-> Fetching page of results'));
+			const pageOfResults = await target.getPastEvents('SynthExchange', {
+				fromBlock: startingBlock,
+				toBlock: startingBlock + pageSize - 1,
+			});
+			if (pageOfResults.length < 1) {
+				return [];
+			}
+			startingBlock += pageSize;
+			return [].concat(pageOfResults).concat(await innerFnc());
+		};
+		return innerFnc();
+	};
+
+	const label = 'oldproxy';
+	let methodology = gray('Loaded');
+	let oldProxyExchanges;
+	try {
+		oldProxyExchanges = loadExchangesFromFile({ network, fromBlock, label });
+	} catch (err) {
+		oldProxyExchanges = await fetchAllEvents({ target: SynthetixOld });
+		saveExchangesToFile({ network, fromBlock, label, exchanges: oldProxyExchanges });
+		methodology = yellow('Fetched');
+	}
+
+	console.log(
+		gray(methodology, yellow(oldProxyExchanges.length), 'old proxy exchanges since SIP-37 deployed')
+	);
+
+	// this would be faster in parallel, but let's do it in serial so we know where we got up to
+	// if we have to restart
+	const cache = {};
+	let debtTally = 0;
+
+	for (const {
+		blockNumber,
+		returnValues: { account, toCurrencyKey },
+	} of oldProxyExchanges) {
+		if (cache[account + toCurrencyKey]) continue;
+		cache[account + toCurrencyKey] = true;
+		process.stdout.write(
+			gray(
+				'Block',
+				cyan(blockNumber),
+				'processing',
+				yellow(account),
+				'into',
+				yellow(web3.utils.hexToAscii(toCurrencyKey))
+			)
+		);
+		const { reclaimAmount, rebateAmount, numEntries } = await Exchanger.methods
+			.settlementOwing(account, toCurrencyKey)
+			.call();
+
+		if (+numEntries > 0) {
+			const wasReclaimOrRebate = reclaimAmount > 0 || rebateAmount > 0;
+
+			const valueInUSD = wasReclaimOrRebate
+				? web3.utils.fromWei(
+						await ExchangeRates.methods
+							.effectiveValue(
+								toCurrencyKey,
+								reclaimAmount > rebateAmount ? reclaimAmount.toString() : rebateAmount.toString(),
+								toBytes32('sUSD')
+							)
+							.call(blockNumber)
+				  )
+				: 0;
+
+			debtTally += Math.round(reclaimAmount > rebateAmount ? -valueInUSD : +valueInUSD);
+
+			console.log(
+				gray(
+					' > Found',
+					yellow(numEntries),
+					'entries.',
+					wasReclaimOrRebate
+						? (reclaimAmount > rebateAmount ? green : red)('USD $' + Math.round(valueInUSD))
+						: '($0)',
+					wasReclaimOrRebate ? 'Tally: ' + debtTally : '',
+					'Settling...'
+				)
+			);
+			// await snxjs.Exchanger.settle(addy, currencyKey, { nonce: nonce++ });
+		} else {
+			console.log(gray(' > No entries found. Moving on.'));
+		}
+	}
+};
+
+module.exports = {
+	settle,
+	cmd: program =>
+		program
+			.command('settle')
+			.description('Settle all exchanges')
+			.option('-f, --from-block <value>', `Starting block number to listen to events from`)
+			.option(
+				'-d, --deployment-path <value>',
+				`Path to a folder that has your input configuration file ${CONFIG_FILENAME} and where your ${DEPLOYMENT_FILENAME} files will go`
+			)
+			.option('-g, --gas-price <value>', 'Gas price in GWEI', '1')
+			.option('-l, --gas-limit <value>', 'Gas limit', parseInt, 15e4)
+			.option('-n, --network <value>', 'The network to run off.', x => x.toLowerCase(), 'kovan')
+			.option(
+				'-r, --dry-run',
+				'If enabled, will not run any transactions but merely report on them.'
+			)
+			.action(settle),
+};

--- a/test/publish/index.js
+++ b/test/publish/index.js
@@ -28,6 +28,8 @@ const {
 	constants: { CONFIG_FILENAME, DEPLOYMENT_FILENAME, SYNTHS_FILENAME },
 } = snx;
 
+const TIMEOUT = 180e3;
+
 describe('publish scripts', function() {
 	this.timeout(30e3);
 	const network = 'local';
@@ -103,7 +105,7 @@ describe('publish scripts', function() {
 
 		if (isCompileRequired()) {
 			console.log('Found source file modified after build. Rebuilding...');
-			this.timeout(60000);
+			this.timeout(TIMEOUT);
 			await commands.build({ showContractSize: true, testHelpers: true });
 		} else {
 			console.log('Skipping build as everything up to date');
@@ -179,7 +181,7 @@ describe('publish scripts', function() {
 
 					fs.writeFileSync(configJSONPath, JSON.stringify(configForExrates));
 
-					this.timeout(60000);
+					this.timeout(TIMEOUT);
 
 					await commands.deploy({
 						network,
@@ -642,7 +644,7 @@ describe('publish scripts', function() {
 
 												fs.writeFileSync(configJSONPath, JSON.stringify(configForExrates));
 
-												this.timeout(60000);
+												this.timeout(TIMEOUT);
 
 												await commands.deploy({
 													addNewSynths: true,
@@ -885,7 +887,7 @@ describe('publish scripts', function() {
 
 							fs.writeFileSync(configJSONPath, JSON.stringify(configForExrates));
 
-							this.timeout(60000);
+							this.timeout(TIMEOUT);
 
 							await commands.deploy({
 								network,
@@ -982,7 +984,7 @@ describe('publish scripts', function() {
 					describe('when re-deployed', () => {
 						let AddressResolver;
 						beforeEach(async () => {
-							this.timeout(60000);
+							this.timeout(TIMEOUT);
 
 							await commands.deploy({
 								network,
@@ -1078,7 +1080,7 @@ describe('publish scripts', function() {
 
 							assert.strictEqual(existingExchanger, targets['Exchanger'].address);
 
-							this.timeout(60000);
+							this.timeout(TIMEOUT);
 
 							await commands.deploy({
 								network,

--- a/test/testnet/index.js
+++ b/test/testnet/index.js
@@ -23,7 +23,7 @@ const commands = {
 
 const testUtils = require('../utils');
 
-const { loadConnections, confirmAction } = require('../../publish/src/util');
+const { loadConnections, confirmAction, ensureNetwork } = require('../../publish/src/util');
 
 const logExchangeRates = (
 	currencyKeys,
@@ -58,9 +58,8 @@ program
 	.option('-g, --gas-price <value>', 'Gas price in GWEI', '5')
 	.option('-y, --yes', 'Dont prompt, just reply yes.')
 	.action(async ({ network, yes, gasPrice: gasPriceInGwei }) => {
-		if (!/^(kovan|rinkeby|ropsten|mainnet|local)$/.test(network)) {
-			throw Error('Unsupported environment', network);
-		}
+		ensureNetwork(network);
+
 		let esLinkPrefix;
 		try {
 			console.log(`Running tests on ${network}`);


### PR DESCRIPTION
This command helps clear out all unsettled exchanges from `ExchangeState` in some network.

This is necessary before either a replacement of `ExchangeRates` or an upgrade of any aggregator in `ExchangeRates`. This is because SIP-37 tracks `roundId` parameters for a synth, and this would be lost in any upgrade.

Additionally, this command can be invoked to clear our all `ExchangeState` entries, allowing it to be replaced. 

Run:
```bash
$ node publish settle --network kovan --gas-price 3 --latest --old-proxy
```

> Old proxy is for unsettled exchanges emitted on the old `ProxySynthetix` in any network. These were migrated to Phase 2 on May 11, so once these have all been settled on all environments, this support should be removed from here.

> **Note**: due to SIP-44, if a synth is suspended it cannot be settled. This means that market closure synths - like `sNIKKEI` and `sFTSE` - cannot be settled while the market it closes.