### PR TITLE
Optimize SNX transfer/transferFrom gas upto 8k

### DIFF
--- a/contracts/ExternStateToken.sol
+++ b/contracts/ExternStateToken.sol
@@ -84,8 +84,7 @@ contract ExternStateToken is Owned, SelfDestructible, Proxyable {
         require(to != address(0) && to != address(this) && to != address(proxy), "Cannot transfer to this address");
 
         // Insufficient balance will be handled by the safe subtraction.
-        tokenState.setBalanceOf(from, tokenState.balanceOf(from).sub(value));
-        tokenState.setBalanceOf(to, tokenState.balanceOf(to).add(value));
+        tokenState.transferBalance(from, to, value);
 
         // Emit a standard ERC20 transfer event
         emitTransfer(from, to, value);

--- a/contracts/TokenState.sol
+++ b/contracts/TokenState.sol
@@ -4,9 +4,14 @@ pragma solidity ^0.5.16;
 import "./Owned.sol";
 import "./State.sol";
 
+// Libraries
+import "./SafeDecimalMath.sol";
+
 
 // https://docs.synthetix.io/contracts/TokenState
 contract TokenState is Owned, State {
+    using SafeMath for uint;
+
     /* ERC20 fields. */
     mapping(address => uint) public balanceOf;
     mapping(address => mapping(address => uint)) public allowance;
@@ -39,5 +44,17 @@ contract TokenState is Owned, State {
      */
     function setBalanceOf(address account, uint value) external onlyAssociatedContract {
         balanceOf[account] = value;
+    }
+
+    /**
+     * @notice Transfer the value between given accounts
+     * @dev Only the associated contract may call this.
+     * @param from The account whose value to reduce.
+     * @param to The account whose value to increase.
+     * @param value The value to transfer
+     */
+    function transferBalance(address from, address to, uint value) external onlyAssociatedContract {
+        balanceOf[from] = balanceOf[from].sub(value);
+        balanceOf[to] = balanceOf[to].add(value);
     }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
 		"slither": "pip3 install --user slither-analyzer && slither .",
 		"prepublishOnly": "npm run generate-asts",
 		"test": "buidler test",
-		"test:gas": "buidler test --gas --optimizer || cat test-gas-used.log",
+		"test:gas": "buidler test --gas --optimizer && cat test-gas-used.log",
 		"test:legacy": "npm run compile:legacy && buidler test:legacy",
 		"test:deployments": "mocha test/deployments -- --timeout 15000",
 		"test:etherscan": "node test/etherscan",

--- a/test/contracts/TokenState.js
+++ b/test/contracts/TokenState.js
@@ -23,7 +23,7 @@ contract('TokenState', accounts => {
 		ensureOnlyExpectedMutativeFunctions({
 			abi: TokenState.abi,
 			ignoreParents: ['State'],
-			expected: ['setAllowance', 'setBalanceOf'],
+			expected: ['setAllowance', 'setBalanceOf', 'transferBalance'],
 		});
 	});
 	describe('setAllowance()', () => {
@@ -60,6 +60,30 @@ contract('TokenState', accounts => {
 			// but not for any other user
 			assert.equal(await instance.balanceOf(owner), '0');
 			assert.equal(await instance.balanceOf(associatedContract), '0');
+		});
+	});
+	describe('transferBalance()', () => {
+		it('can only be invoked by the associated contracts', async () => {
+			await instance.setBalanceOf(associatedContract, toUnit('1'), { from: associatedContract });
+			await onlyGivenAddressCanInvoke({
+				fnc: instance.transferBalance,
+				accounts,
+				address: associatedContract,
+				args: [associatedContract, associatedContract, toUnit('1')],
+			});
+		});
+		it('when invoked, it transfers the correct balance', async () => {
+			await instance.setBalanceOf(owner, toUnit('100'), { from: associatedContract });
+			await instance.transferBalance(owner, account2, toUnit('10'), { from: associatedContract });
+			assert.bnEqual(await instance.balanceOf(owner), toUnit('90'));
+			assert.bnEqual(await instance.balanceOf(account2), toUnit('10'));
+		});
+		it('when invoked, it do not allow underflow', async () => {
+			await instance.setBalanceOf(owner, toUnit('100'), { from: associatedContract });
+			await assert.revert(
+				instance.transferBalance(owner, account2, toUnit('110'), { from: associatedContract }),
+				'SafeMath: subtraction overflow'
+			);
 		});
 	});
 });


### PR DESCRIPTION
Introducing and calling one `transferBalance()` instead of 2 `balanceOf()` and 2 `setBalanceOf()` would reduce CALL and SLOAD intructions which have prices of 700 and 800 gas respectively.

```
·------------------------------------------------------|---------------------------|-------------|-------------------------------------·
|                 Solc version: 0.5.16                 ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 9007199254740991 gas  │
·······················································|···························|·············|······································
|  Methods                                             ·               32 gwei/gas               ·           239.90 usd/eth            │
···························|···························|·············|·············|·············|···················|··················
|  Contract                ·  Method                   ·  Min        ·  Max        ·  Avg        ·  # calls          ·  usd (avg)      │
···························|···························|·············|·············|·············|···················|··················
|  Synthetix               ·  transfer                 ·      71165  ·     166899  ·      97398  ·               32  ·           0.82  │
···························|···························|·············|·············|·············|···················|··················
|  Synthetix               ·  transferFrom             ·      82672  ·     169241  ·     111514  ·               12  ·           0.94  │
···························|···························|·············|·············|·············|···················|··················
```
```
···························|···························|·············|·············|·············|···················|··················
|  Synthetix               ·  transfer                 ·      63729  ·     159463  ·      89962  ·               32  ·           0.69  │
···························|···························|·············|·············|·············|···················|··················
|  Synthetix               ·  transferFrom             ·      75236  ·     161805  ·     104078  ·               12  ·           0.80  │
···························|···························|·············|·············|·············|···················|··················
```

Can you upgrade SNX token impl with TokenState? I mean you could lazy migrate state to a newer version like this:
```solidity
contract NewTokenState is ITokenState {
    ITokenState public prevState;

    mapping(address => bool) public migrated;
    mapping(address => uint) private _balanceOf;

    modifier migrate(address account) {
        if (!migrated[account]) {
            _balanceOf[account] = prevState.balanceOf(account);
            migrated[account] = true;
        }
        _;
    }

    constructor(ITokenState _prevState) public {
        prevState = _ prevState;
    }

    function balanceOf(address account) public view returns(uint256) {
        return migrated[account] ? _balanceOf[account] : prevState.balanceOf(account);
    }

    function setBalanceOf(addess account, uint256 value) public onlyAssociatedContract migrate(account) {
        _balanceOf[account] = value;
    }

    function transferBalance(address from, address to, uint value) external onlyAssociatedContract migrate(from) migrate(to) {
        _balanceOf[from] = _balanceOf[from].sub(value);
        _balanceOf[to] = _balanceOf[to].add(value);
    }
}
```