### PR TITLE
Addind decode functionality to binary

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -4,10 +4,20 @@
 
 const fs = require('fs');
 const path = require('path');
+const util = require('util');
 
 const { getSuspensionReasons, networks, toBytes32, wrap } = require('./index');
 
-const { getAST, getSource, getSynths, getTarget, getUsers, getVersions, getStakingRewards } = wrap({
+const {
+	decode,
+	getAST,
+	getSource,
+	getSynths,
+	getTarget,
+	getUsers,
+	getVersions,
+	getStakingRewards,
+} = wrap({
 	fs,
 	path,
 });
@@ -37,6 +47,14 @@ program
 			);
 		}
 		console.log(toBytes32(key));
+	});
+
+program
+	.command('decode <data> [target]')
+	.description('Decode a data payload from a Synthetix contract')
+	.option('-n, --network <value>', 'The network to use', x => x.toLowerCase(), 'mainnet')
+	.action(async (data, target, { network }) => {
+		console.log(util.inspect(decode({ network, data, target }), false, null, true));
 	});
 
 program

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const w3utils = require('web3-utils');
+const abiDecoder = require('abi-decoder');
 
 // load the data in explicitly (not programmatically) so webpack knows what to bundle
 const data = {
@@ -292,8 +293,24 @@ const getSuspensionReasons = ({ code = undefined } = {}) => {
 	return code ? suspensionReasonMap[code] : suspensionReasonMap;
 };
 
+const decode = ({ network = 'mainnet', fs, path, data, target } = {}) => {
+	const sources = getSource({ network, path, fs });
+	for (const { abi } of Object.values(sources)) {
+		abiDecoder.addABI(abi);
+	}
+	const targets = getTarget({ network, path, fs });
+	let contract;
+	if (target) {
+		contract = Object.values(targets).filter(
+			({ address }) => address.toLowerCase() === target.toLowerCase()
+		)[0].name;
+	}
+	return { method: abiDecoder.decodeMethod(data), contract };
+};
+
 const wrap = ({ network, fs, path }) =>
 	[
+		'decode',
 		'getAST',
 		'getPathToNetwork',
 		'getSource',
@@ -309,6 +326,7 @@ const wrap = ({ network, fs, path }) =>
 
 module.exports = {
 	constants,
+	decode,
 	defaults,
 	getAST,
 	getPathToNetwork,

--- a/package-lock.json
+++ b/package-lock.json
@@ -737,6 +737,12 @@
 					"requires": {
 						"source-map-support": "^0.5.16"
 					}
+				},
+				"@truffle/error": {
+					"version": "0.0.8",
+					"resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.8.tgz",
+					"integrity": "sha512-x55rtRuNfRO1azmZ30iR0pf0OJ6flQqbax1hJz+Avk1K5fdmOv5cr22s9qFnwTWnS6Bw0jvJEoR0ITsM7cPKtQ==",
+					"dev": true
 				}
 			}
 		},
@@ -788,6 +794,12 @@
 				"web3-utils": "1.2.1"
 			},
 			"dependencies": {
+				"bn.js": {
+					"version": "4.11.9",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+					"integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+					"optional": true
+				},
 				"semver": {
 					"version": "6.3.0",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -807,20 +819,28 @@
 						"randomhex": "0.1.5",
 						"underscore": "1.9.1",
 						"utf8": "3.0.0"
+					},
+					"dependencies": {
+						"bn.js": {
+							"version": "4.11.8",
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+							"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+							"optional": true
+						}
 					}
 				}
 			}
 		},
 		"@truffle/contract": {
-			"version": "4.2.18",
-			"resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.2.18.tgz",
-			"integrity": "sha512-X3kWO4oZ80e5PcZMFRLA2DjwlqabLOB++25+sofX2uH2mb2l1kjIdmyjNKPGXXnGhzGsRCxY9ZBRn3zyoMe+Xw==",
+			"version": "4.2.19",
+			"resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.2.19.tgz",
+			"integrity": "sha512-QQmsgGc5U/UNQt12elmSnkADJN9jPG5QtdnLYHc6lGnRZst6IZDt0jdgUae9P4yMXXuAoqlr0Gxp7SzyZJIhSw==",
 			"optional": true,
 			"requires": {
 				"@truffle/blockchain-utils": "^0.0.24",
 				"@truffle/contract-schema": "^3.2.3",
 				"@truffle/debug-utils": "^4.2.5",
-				"@truffle/error": "^0.0.9",
+				"@truffle/error": "^0.0.10",
 				"@truffle/interface-adapter": "^0.4.15",
 				"bignumber.js": "^7.2.1",
 				"ethereum-ens": "^0.8.0",
@@ -833,12 +853,6 @@
 				"web3-utils": "1.2.1"
 			},
 			"dependencies": {
-				"@truffle/error": {
-					"version": "0.0.9",
-					"resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.9.tgz",
-					"integrity": "sha512-afT1ssCQ1wq0LbZMPIJ7Lc5SjyOMAP2IHRNrrkoUJQtjAw3rvcE2i2Jq1BNMa5K548nUSM9C9MqX/Eo7csq8cQ==",
-					"optional": true
-				},
 				"web3": {
 					"version": "1.2.1",
 					"resolved": "https://registry.npmjs.org/web3/-/web3-1.2.1.tgz",
@@ -897,10 +911,10 @@
 			}
 		},
 		"@truffle/error": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.8.tgz",
-			"integrity": "sha512-x55rtRuNfRO1azmZ30iR0pf0OJ6flQqbax1hJz+Avk1K5fdmOv5cr22s9qFnwTWnS6Bw0jvJEoR0ITsM7cPKtQ==",
-			"dev": true
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.10.tgz",
+			"integrity": "sha512-7WrOoqH3VpfnaTB4TUKRAxzjuMZ3yP/sVet4zCdqGVcH/m1niu/ncttPy8LBfYi437PlBlhj7BpExKLYRPgAIA==",
+			"optional": true
 		},
 		"@truffle/interface-adapter": {
 			"version": "0.4.15",
@@ -1739,9 +1753,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "14.0.27",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
-			"integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
+			"version": "14.6.0",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
+			"integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
 		},
 		"@types/pbkdf2": {
 			"version": "3.1.0",
@@ -2010,7 +2024,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-2.3.0.tgz",
 			"integrity": "sha512-RZXG5mo1JhJjTBg/4NXlS8hyTr2fxiuFaz3UveRpoX9IIc3LPHmWz89dFqTHNQVbWi3VZqxSJqfUwWpb/mCHxA==",
-			"dev": true,
 			"requires": {
 				"web3-eth-abi": "^1.2.1",
 				"web3-utils": "^1.2.1"
@@ -2067,9 +2080,9 @@
 			"integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
 		},
 		"ajv": {
-			"version": "6.12.3",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-			"integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+			"version": "6.12.4",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+			"integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -2296,13 +2309,14 @@
 			}
 		},
 		"asn1.js": {
-			"version": "4.10.1",
-			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
-			"integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
+			"version": "5.4.1",
+			"resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+			"integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
 			"requires": {
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
-				"minimalistic-assert": "^1.0.0"
+				"minimalistic-assert": "^1.0.0",
+				"safer-buffer": "^2.1.0"
 			}
 		},
 		"assert": {
@@ -2747,9 +2761,9 @@
 			},
 			"dependencies": {
 				"bn.js": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-					"integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA=="
+					"version": "5.1.3",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+					"integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
 				}
 			}
 		},
@@ -2920,9 +2934,9 @@
 			},
 			"dependencies": {
 				"get-stream": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-					"integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+					"integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
 					"requires": {
 						"pump": "^3.0.0"
 					}
@@ -3562,12 +3576,12 @@
 			}
 		},
 		"create-ecdh": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
-			"integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+			"integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
 			"requires": {
 				"bn.js": "^4.1.0",
-				"elliptic": "^6.0.0"
+				"elliptic": "^6.5.3"
 			}
 		},
 		"create-hash": {
@@ -5397,9 +5411,9 @@
 			},
 			"dependencies": {
 				"bn.js": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.2.tgz",
-					"integrity": "sha512-40rZaf3bUNKTVYu9sIeeEGOg7g14Yvnj9kH7b50EiwX0Q7A6umbvfI5tvHaOERH0XigqKkfLkFQxzb4e6CIXnA==",
+					"version": "5.1.3",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+					"integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ==",
 					"dev": true
 				},
 				"buffer-xor": {
@@ -17570,11 +17584,6 @@
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
 			"integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
 		},
-		"graceful-readlink": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
-			"integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
-		},
 		"growl": {
 			"version": "1.10.5",
 			"resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
@@ -18886,9 +18895,9 @@
 			}
 		},
 		"lodash": {
-			"version": "4.17.19",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-			"integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+			"version": "4.17.20",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
 		},
 		"lodash.clonedeep": {
 			"version": "4.5.0",
@@ -20222,13 +20231,12 @@
 			}
 		},
 		"parse-asn1": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.5.tgz",
-			"integrity": "sha512-jkMYn1dcJqF6d5CpU689bq7w/b5ALS9ROVSpQDPrZsqqesUJii9qutvoT5ltGedNXMO2e16YUWIghG9KxaViTQ==",
+			"version": "5.1.6",
+			"resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+			"integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
 			"requires": {
-				"asn1.js": "^4.0.0",
+				"asn1.js": "^5.2.0",
 				"browserify-aes": "^1.0.0",
-				"create-hash": "^1.1.0",
 				"evp_bytestokey": "^1.0.0",
 				"pbkdf2": "^3.0.3",
 				"safe-buffer": "^5.1.1"
@@ -21266,20 +21274,17 @@
 			}
 		},
 		"seek-bzip": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.5.tgz",
-			"integrity": "sha1-z+kXyz0nS8/6x5J1ivUxc+sfq9w=",
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",
+			"integrity": "sha512-e1QtP3YL5tWww8uKaOCQ18UxIT2laNBXHjV/S2WYCiK4udiv8lkG89KRIoCjUagnAmCBurjF4zEVX2ByBbnCjQ==",
 			"requires": {
-				"commander": "~2.8.1"
+				"commander": "^2.8.1"
 			},
 			"dependencies": {
 				"commander": {
-					"version": "2.8.1",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
-					"integrity": "sha1-Br42f+v9oMMwqh4qBy09yXYkJdQ=",
-					"requires": {
-						"graceful-readlink": ">= 1.0.0"
-					}
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 				}
 			}
 		},

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
 		"@nomiclabs/buidler": "1.3.7",
 		"@nomiclabs/buidler-truffle5": "1.3.4",
 		"@nomiclabs/buidler-web3": "1.3.4",
-		"abi-decoder": "2.3.0",
 		"axios": "0.19.2",
 		"bn.js": "4.11.8",
 		"buidler-ast-doc": "0.0.14-rc",
@@ -98,6 +97,7 @@
 		"webpack-cli": "3.3.12"
 	},
 	"dependencies": {
+		"abi-decoder": "2.3.0",
 		"@chainlink/contracts-0.0.9": "npm:@chainlink/contracts@0.0.9",
 		"commander": "5.1.0",
 		"openzeppelin-solidity-2.3.0": "npm:openzeppelin-solidity@2.3.0",


### PR DESCRIPTION
Creates a new decode functionality for transactions that target the Synthetix ecosystem.

![image](https://user-images.githubusercontent.com/799038/90703453-ce580e00-e25b-11ea-9d0e-a0fa5b29fac1.png)

> Note: I've opted for `util.inspect` instead of `JSON.stringify` as the former can output ANSI colo(u)?rs. I suspect that's better in 99% of cases so I propose to make it a default 