### PR TITLE
Adjusting defaults to SCCP-43

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ const constants = {
 // The solidity defaults are managed here in the same format they will be stored, hence all
 // numbers are converted to strings and those with 18 decimals are also converted to wei amounts
 const defaults = {
-	WAITING_PERIOD_SECS: '180',
+	WAITING_PERIOD_SECS: (60 * 5).toString(), // 5 mins
 	PRICE_DEVIATION_THRESHOLD_FACTOR: w3utils.toWei('3'),
 	TRADING_REWARDS_ENABLED: false,
 	ISSUANCE_RATIO: w3utils
@@ -84,11 +84,11 @@ const defaults = {
 	LIQUIDATION_DELAY: (3600 * 24 * 14).toString(), // 2 weeks
 	LIQUIDATION_RATIO: w3utils.toWei('0.5'), // 200% cratio
 	LIQUIDATION_PENALTY: w3utils.toWei('0.1'), // 10% penalty
-	RATE_STALE_PERIOD: (3600 * 3).toString(), // 3 hours
+	RATE_STALE_PERIOD: (3600 * 25).toString(), // 25 hours
 	EXCHANGE_FEE_RATES: {
 		forex: w3utils.toWei('0.003'),
-		commodity: w3utils.toWei('0.01'),
-		equities: w3utils.toWei('0.005'),
+		commodity: w3utils.toWei('0.003'),
+		equities: w3utils.toWei('0.003'),
 		crypto: w3utils.toWei('0.003'),
 		index: w3utils.toWei('0.003'),
 	},


### PR DESCRIPTION
Adding these to defaults as this is necessary because SIP-64 introduces a new `SystemSettings` contract where these will first be set.