### PR TITLE
Reduce contract sizes: Error messages

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -24,6 +24,7 @@
 		"two-lines-top-level-separator": "off",
 		"var-name-mixedcase": "off",
 		"visibility-modifier-order": "off",
+		"reason-string": "error",
 		"---THE BELOW ARE FROM SOLHINT:RECOMMENDED ---": "---to be removed once https://github.com/juanfranblanco/vscode-solidity/issues/144 is fixed ---",
 		"state-visibility": "warn",
 		"payable-fallback": "warn",

--- a/buidler.config.js
+++ b/buidler.config.js
@@ -216,10 +216,11 @@ task('test')
 	.addFlag('gas', 'Compile gas usage')
 	.addFlag('ovm', 'Run tests on the OVM using a custom OVM provider')
 	.addFlag('native', 'Compile with the native solc compiler')
+	.addFlag('bail', 'Stops testing as soon as one test fails')
 	.addOptionalParam('gasOutputFile', 'Gas reporter output file')
 	.addOptionalParam('grep', 'Filter tests to only those with given logic')
 	.setAction(async (taskArguments, bre, runSuper) => {
-		const { gas, grep, ovm, native, gasOutputFile } = taskArguments;
+		const { gas, grep, ovm, native, gasOutputFile, bail } = taskArguments;
 
 		if (ovm) {
 			bre.ovm = true;
@@ -235,6 +236,10 @@ task('test')
 				bre.config.mocha.invert = true;
 			}
 			bre.config.mocha.timeout = 10000000;
+		}
+
+		if (bail) {
+			bre.config.mocha.bail = true;
 		}
 
 		if (native) {

--- a/contracts/BinaryOption.sol
+++ b/contracts/BinaryOption.sol
@@ -201,7 +201,7 @@ contract BinaryOption is IERC20, IBinaryOption {
     }
 
     function approve(address _spender, uint _value) external returns (bool success) {
-        require(_spender != address(0));
+        require(_spender != address(0), "Invalid spender");
         allowance[msg.sender][_spender] = _value;
         emit Approval(msg.sender, _spender, _value);
         return true;

--- a/contracts/BinaryOptionMarket.sol
+++ b/contracts/BinaryOptionMarket.sol
@@ -398,7 +398,7 @@ contract BinaryOptionMarket is Owned, MixinResolver, IBinaryOptionMarket {
     }
 
     function _requireManagerNotPaused() internal view {
-        require(!_manager().paused(), "This action cannot be performed while the contract is paused");
+        require(!_manager().paused(), "Contract is paused");
     }
 
     function requireActiveAndUnpaused() external view {

--- a/contracts/BinaryOptionMarketManager.sol
+++ b/contracts/BinaryOptionMarketManager.sol
@@ -188,7 +188,7 @@ contract BinaryOptionMarketManager is Owned, Pausable, SelfDestructible, MixinRe
 
     function setPoolFee(uint _poolFee) public onlyOwner {
         uint totalFee = _poolFee + fees.creatorFee;
-        require(totalFee < SafeDecimalMath.unit(), "Total fee must be less than 100%.");
+        require(totalFee < SafeDecimalMath.unit(), "Total fee must be < 100%.");
         require(0 < totalFee, "Total fee must be nonzero.");
         fees.poolFee = _poolFee;
         emit PoolFeeUpdated(_poolFee);
@@ -196,14 +196,14 @@ contract BinaryOptionMarketManager is Owned, Pausable, SelfDestructible, MixinRe
 
     function setCreatorFee(uint _creatorFee) public onlyOwner {
         uint totalFee = _creatorFee + fees.poolFee;
-        require(totalFee < SafeDecimalMath.unit(), "Total fee must be less than 100%.");
+        require(totalFee < SafeDecimalMath.unit(), "Total fee must be < 100%.");
         require(0 < totalFee, "Total fee must be nonzero.");
         fees.creatorFee = _creatorFee;
         emit CreatorFeeUpdated(_creatorFee);
     }
 
     function setRefundFee(uint _refundFee) public onlyOwner {
-        require(_refundFee <= SafeDecimalMath.unit(), "Refund fee must be no greater than 100%.");
+        require(_refundFee <= SafeDecimalMath.unit(), "Refund fee must be <= 100%.");
         fees.refundFee = _refundFee;
         emit RefundFeeUpdated(_refundFee);
     }
@@ -214,7 +214,7 @@ contract BinaryOptionMarketManager is Owned, Pausable, SelfDestructible, MixinRe
     }
 
     function setCreatorSkewLimit(uint _creatorSkewLimit) public onlyOwner {
-        require(_creatorSkewLimit <= SafeDecimalMath.unit(), "Creator skew limit must be no greater than 1.");
+        require(_creatorSkewLimit <= SafeDecimalMath.unit(), "Creator skew limit must be <= 1.");
         creatorLimits.skewLimit = _creatorSkewLimit;
         emit CreatorSkewLimitUpdated(_creatorSkewLimit);
     }
@@ -369,7 +369,7 @@ contract BinaryOptionMarketManager is Owned, Pausable, SelfDestructible, MixinRe
     }
 
     function receiveMarkets(bool active, BinaryOptionMarket[] calldata marketsToReceive) external {
-        require(msg.sender == address(_migratingManager), "Only permitted for migrating manager.");
+        require(msg.sender == address(_migratingManager), "Only migrating manager.");
 
         uint _numMarkets = marketsToReceive.length;
         if (_numMarkets == 0) {
@@ -394,12 +394,12 @@ contract BinaryOptionMarketManager is Owned, Pausable, SelfDestructible, MixinRe
     /* ========== MODIFIERS ========== */
 
     modifier onlyActiveMarkets() {
-        require(_activeMarkets.contains(msg.sender), "Permitted only for active markets.");
+        require(_activeMarkets.contains(msg.sender), "Only active markets.");
         _;
     }
 
     modifier onlyKnownMarkets() {
-        require(_isKnownMarket(msg.sender), "Permitted only for known markets.");
+        require(_isKnownMarket(msg.sender), "Only known markets.");
         _;
     }
 

--- a/contracts/ContractStorage.sol
+++ b/contracts/ContractStorage.sol
@@ -54,7 +54,7 @@ contract ContractStorage {
             contractName,
             "Cannot find contract in Address Resolver"
         );
-        require(callingContract == msg.sender, "Can only be invoked by the configured contract");
+        require(callingContract == msg.sender, "Only configured contract");
         _;
     }
 

--- a/contracts/DelegateApprovals.sol
+++ b/contracts/DelegateApprovals.sol
@@ -151,7 +151,7 @@ contract DelegateApprovals is Owned, IDelegateApprovals {
     }
 
     function setEternalStorage(EternalStorage _eternalStorage) external onlyOwner {
-        require(address(_eternalStorage) != address(0), "Can't set eternalStorage to address(0)");
+        require(address(_eternalStorage) != address(0), "Invalid eternalStorage");
         eternalStorage = _eternalStorage;
         emit EternalStorageUpdated(address(eternalStorage));
     }

--- a/contracts/Depot.sol
+++ b/contracts/Depot.sol
@@ -112,7 +112,7 @@ contract Depot is Owned, SelfDestructible, Pausable, ReentrancyGuard, MixinResol
      */
     function setMinimumDepositAmount(uint _amount) external onlyOwner {
         // Do not allow us to set it less than 1 dollar opening up to fractional desposits in the queue again
-        require(_amount > SafeDecimalMath.unit(), "Minimum deposit amount must be greater than UNIT");
+        require(_amount > SafeDecimalMath.unit(), "Minimum deposit must be > UNIT");
         minimumDepositAmount = _amount;
         emit MinimumDepositAmountUpdated(minimumDepositAmount);
     }
@@ -144,7 +144,7 @@ contract Depot is Owned, SelfDestructible, Pausable, ReentrancyGuard, MixinResol
     }
 
     function _exchangeEtherForSynths() internal returns (uint) {
-        require(msg.value <= maxEthPurchase, "ETH amount above maxEthPurchase limit");
+        require(msg.value <= maxEthPurchase, "ETH amount > maxEthPurchase");
         uint ethToSend;
 
         // The multiplication works here because exchangeRates().rateForCurrency(ETH) is specified in
@@ -270,7 +270,7 @@ contract Depot is Owned, SelfDestructible, Pausable, ReentrancyGuard, MixinResol
             uint // Returns the number of Synths (sUSD) received
         )
     {
-        require(guaranteedRate == exchangeRates().rateForCurrency(ETH), "Guaranteed rate would not be received");
+        require(guaranteedRate == exchangeRates().rateForCurrency(ETH), "Invalid guaranteed rate");
 
         return _exchangeEtherForSynths();
     }
@@ -322,11 +322,8 @@ contract Depot is Owned, SelfDestructible, Pausable, ReentrancyGuard, MixinResol
             uint // Returns the number of SNX received
         )
     {
-        require(guaranteedEtherRate == exchangeRates().rateForCurrency(ETH), "Guaranteed ether rate would not be received");
-        require(
-            guaranteedSynthetixRate == exchangeRates().rateForCurrency(SNX),
-            "Guaranteed synthetix rate would not be received"
-        );
+        require(guaranteedEtherRate == exchangeRates().rateForCurrency(ETH), "Invalid guaranteed Ether");
+        require(guaranteedSynthetixRate == exchangeRates().rateForCurrency(SNX), "Invalid guaranteed snx rate");
 
         return _exchangeEtherForSNX();
     }
@@ -377,7 +374,7 @@ contract Depot is Owned, SelfDestructible, Pausable, ReentrancyGuard, MixinResol
             uint // Returns the number of SNX received
         )
     {
-        require(guaranteedRate == exchangeRates().rateForCurrency(SNX), "Guaranteed rate would not be received");
+        require(guaranteedRate == exchangeRates().rateForCurrency(SNX), "Invalid guaranteed rate");
 
         return _exchangeSynthsForSNX(synthAmount);
     }
@@ -427,7 +424,7 @@ contract Depot is Owned, SelfDestructible, Pausable, ReentrancyGuard, MixinResol
         smallDeposits[msg.sender] = 0;
 
         // If there's nothing to do then go ahead and revert the transaction
-        require(synthsToSend > 0, "You have no deposits to withdraw.");
+        require(synthsToSend > 0, "No deposits to withdraw.");
 
         // Send their deposits back to them (minus fees)
         synthsUSD().transfer(msg.sender, synthsToSend);

--- a/contracts/ExchangeRates.sol
+++ b/contracts/ExchangeRates.sol
@@ -61,7 +61,7 @@ contract ExchangeRates is Owned, SelfDestructible, MixinResolver, MixinSystemSet
         bytes32[] memory _currencyKeys,
         uint[] memory _newRates
     ) public Owned(_owner) SelfDestructible() MixinResolver(_resolver, addressesToCache) MixinSystemSettings() {
-        require(_currencyKeys.length == _newRates.length, "Currency key length and rate length must match.");
+        require(_currencyKeys.length == _newRates.length, "Currency key and rate mismatch");
 
         oracle = _oracle;
 
@@ -108,9 +108,9 @@ contract ExchangeRates is Owned, SelfDestructible, MixinResolver, MixinSystemSet
     ) external onlyOwner {
         // 0 < lowerLimit < entryPoint => 0 < entryPoint
         require(lowerLimit > 0, "lowerLimit must be above 0");
-        require(upperLimit > entryPoint, "upperLimit must be above the entryPoint");
-        require(upperLimit < entryPoint.mul(2), "upperLimit must be less than double entryPoint");
-        require(lowerLimit < entryPoint, "lowerLimit must be below the entryPoint");
+        require(upperLimit > entryPoint, "upperLimit must be > entryPoint");
+        require(upperLimit < entryPoint.mul(2), "upperLimit > 2*entryPoint");
+        require(lowerLimit < entryPoint, "lowerLimit must be < entryPoint");
 
         require(!(freezeAtUpperLimit && freezeAtLowerLimit), "Cannot freeze at both limits");
 
@@ -449,7 +449,7 @@ contract ExchangeRates is Owned, SelfDestructible, MixinResolver, MixinSystemSet
         uint[] memory newRates,
         uint timeSent
     ) internal returns (bool) {
-        require(currencyKeys.length == newRates.length, "Currency key array length must match rates array length.");
+        require(currencyKeys.length == newRates.length, "Currency key array mismatch");
         require(timeSent < (now + ORACLE_FUTURE_LIMIT), "Time is too far into the future");
 
         // Loop through each key and perform update.
@@ -459,8 +459,8 @@ contract ExchangeRates is Owned, SelfDestructible, MixinResolver, MixinSystemSet
             // Should not set any rate to zero ever, as no asset will ever be
             // truely worthless and still valid. In this scenario, we should
             // delete the rate and remove it from the system.
-            require(newRates[i] != 0, "Zero is not a valid rate, please call deleteRate instead.");
-            require(currencyKey != "sUSD", "Rate of sUSD cannot be updated, it's always UNIT.");
+            require(newRates[i] != 0, "Zero is not a valid rate");
+            require(currencyKey != "sUSD", "Rate of sUSD cannot be updated");
 
             // We should only update the rate if it's at least the same age as the last rate we've got.
             if (timeSent < _getUpdatedTime(currencyKey)) {
@@ -638,7 +638,7 @@ contract ExchangeRates is Owned, SelfDestructible, MixinResolver, MixinSystemSet
     /* ========== MODIFIERS ========== */
 
     modifier onlyOracle {
-        require(msg.sender == oracle, "Only the oracle can perform this action");
+        require(msg.sender == oracle, "Not oracle");
         _;
     }
 

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -526,7 +526,7 @@ contract Exchanger is Owned, MixinResolver, MixinSystemSettings, IExchanger {
         bytes32[] memory synthKeys = new bytes32[](2);
         synthKeys[0] = sourceCurrencyKey;
         synthKeys[1] = destinationCurrencyKey;
-        require(!exchangeRates().anyRateIsInvalid(synthKeys), "Src/dest rate invalid or not found");
+        require(!exchangeRates().anyRateIsInvalid(synthKeys), "Src/dest rate invalid");
     }
 
     function _isSynthRateInvalid(bytes32 currencyKey, uint currentRate) internal view returns (bool) {
@@ -577,7 +577,7 @@ contract Exchanger is Owned, MixinResolver, MixinSystemSettings, IExchanger {
             uint numEntriesSettled
         )
     {
-        require(maxSecsLeftInWaitingPeriod(from, currencyKey) == 0, "Cannot settle during waiting period");
+        require(maxSecsLeftInWaitingPeriod(from, currencyKey) == 0, "Cannot settle in waiting period");
 
         (
             uint reclaimAmount,
@@ -776,7 +776,7 @@ contract Exchanger is Owned, MixinResolver, MixinSystemSettings, IExchanger {
         ISynthetix _synthetix = synthetix();
         require(
             msg.sender == address(_synthetix) || _synthetix.synthsByAddress(msg.sender) != bytes32(0),
-            "Exchanger: Only synthetix or a synth contract can perform this action"
+            "Only synthetix or a synth"
         );
         _;
     }

--- a/contracts/FeePool.sol
+++ b/contracts/FeePool.sol
@@ -314,10 +314,7 @@ contract FeePool is Owned, Proxyable, SelfDestructible, LimitedSetup, MixinResol
         // Get the claimingAddress available fees and rewards
         (availableFees, availableRewards) = feesAvailable(claimingAddress);
 
-        require(
-            availableFees > 0 || availableRewards > 0,
-            "No fees or rewards available for period, or fees already claimed"
-        );
+        require(availableFees > 0 || availableRewards > 0, "No fees or rewards available");
 
         // Record the address has claimed for this period
         _setLastFeeWithdrawal(claimingAddress, _recentFeePeriodsStorage(1).feePeriodId);
@@ -729,7 +726,7 @@ contract FeePool is Owned, Proxyable, SelfDestructible, LimitedSetup, MixinResol
         bool isExchanger = msg.sender == address(exchanger());
         bool isSynth = issuer().synthsByAddress(msg.sender) != bytes32(0);
 
-        require(isExchanger || isSynth, "Only Exchanger, Synths Authorised");
+        require(isExchanger || isSynth, "Only Exchanger, Synths");
         _;
     }
 

--- a/contracts/FeePoolState.sol
+++ b/contracts/FeePoolState.sol
@@ -59,7 +59,7 @@ contract FeePoolState is Owned, SelfDestructible, LimitedSetup {
         view
         returns (uint debtPercentage, uint debtEntryIndex)
     {
-        require(index < FEE_PERIOD_LENGTH, "index exceeds the FEE_PERIOD_LENGTH");
+        require(index < FEE_PERIOD_LENGTH, "index > FEE_PERIOD_LENGTH");
 
         debtPercentage = accountIssuanceLedger[account][index].debtPercentage;
         debtEntryIndex = accountIssuanceLedger[account][index].debtEntryIndex;
@@ -152,7 +152,7 @@ contract FeePoolState is Owned, SelfDestructible, LimitedSetup {
     /* ========== MODIFIERS ========== */
 
     modifier onlyFeePool {
-        require(msg.sender == address(feePool), "Only the FeePool contract can perform this action");
+        require(msg.sender == address(feePool), "Only FeePool contract");
         _;
     }
 

--- a/contracts/Issuer.sol
+++ b/contracts/Issuer.sol
@@ -778,7 +778,7 @@ contract Issuer is Owned, MixinResolver, MixinSystemSettings, IIssuer {
     /* ========== MODIFIERS ========== */
 
     modifier onlySynthetix() {
-        require(msg.sender == address(synthetix()), "Issuer: Only the synthetix contract can perform this action");
+        require(msg.sender == address(synthetix()), "Only synthetix contract");
         _;
     }
 

--- a/contracts/LimitedSetup.sol
+++ b/contracts/LimitedSetup.sol
@@ -14,7 +14,7 @@ contract LimitedSetup {
     }
 
     modifier onlyDuringSetup {
-        require(now < setupExpiryTime, "Can only perform this action during setup");
+        require(now < setupExpiryTime, "Only during setup");
         _;
     }
 }

--- a/contracts/Liquidations.sol
+++ b/contracts/Liquidations.sol
@@ -176,15 +176,12 @@ contract Liquidations is Owned, MixinResolver, MixinSystemSettings, ILiquidation
         require(getLiquidationDelay() > 0, "Liquidation delay not set");
 
         LiquidationEntry memory liquidation = _getLiquidationEntryForAccount(account);
-        require(liquidation.deadline == 0, "Account already flagged for liquidation");
+        require(liquidation.deadline == 0, "Already flagged for liquidation");
 
         uint accountsCollateralisationRatio = synthetix().collateralisationRatio(account);
 
         // if accounts issuance ratio is greater than or equal to liquidation ratio set liquidation entry
-        require(
-            accountsCollateralisationRatio >= getLiquidationRatio(),
-            "Account issuance ratio is less than liquidation ratio"
-        );
+        require(accountsCollateralisationRatio >= getLiquidationRatio(), "Issuance rat < liquidation rat");
 
         uint deadline = now.add(getLiquidationDelay());
 
@@ -241,7 +238,7 @@ contract Liquidations is Owned, MixinResolver, MixinSystemSettings, ILiquidation
 
     /* ========== MODIFIERS ========== */
     modifier onlyIssuer() {
-        require(msg.sender == address(issuer()), "Liquidations: Only the Issuer contract can perform this action");
+        require(msg.sender == address(issuer()), "Only Issuer contract");
         _;
     }
 

--- a/contracts/MultiCollateralSynth.sol
+++ b/contracts/MultiCollateralSynth.sol
@@ -61,10 +61,7 @@ contract MultiCollateralSynth is Synth {
         bool isIssuer = msg.sender == address(issuer());
         bool isMultiCollateral = msg.sender == address(multiCollateral());
 
-        require(
-            isFeePool || isExchanger || isIssuer || isMultiCollateral,
-            "Only FeePool, Exchanger, Issuer or MultiCollateral contracts allowed"
-        );
+        require(isFeePool || isExchanger || isIssuer || isMultiCollateral, "Only internal contracts");
         _;
     }
 }

--- a/contracts/Owned.sol
+++ b/contracts/Owned.sol
@@ -18,14 +18,14 @@ contract Owned {
     }
 
     function acceptOwnership() external {
-        require(msg.sender == nominatedOwner, "You must be nominated before you can accept ownership");
+        require(msg.sender == nominatedOwner, "Not nominated");
         emit OwnerChanged(owner, nominatedOwner);
         owner = nominatedOwner;
         nominatedOwner = address(0);
     }
 
     modifier onlyOwner {
-        require(msg.sender == owner, "Only the contract owner may perform this action");
+        require(msg.sender == owner, "Only contract owner");
         _;
     }
 

--- a/contracts/Pausable.sol
+++ b/contracts/Pausable.sol
@@ -40,7 +40,7 @@ contract Pausable is Owned {
     event PauseChanged(bool isPaused);
 
     modifier notPaused {
-        require(!paused, "This action cannot be performed while the contract is paused");
+        require(!paused, "Contract is paused");
         _;
     }
 }

--- a/contracts/PurgeableSynth.sol
+++ b/contracts/PurgeableSynth.sol
@@ -48,10 +48,7 @@ contract PurgeableSynth is Synth {
         uint maxSupplyToPurge = exRates.effectiveValue("sUSD", maxSupplyToPurgeInUSD, currencyKey);
 
         // Only allow purge when total supply is lte the max or the rate is frozen in ExchangeRates
-        require(
-            totalSupply <= maxSupplyToPurge || exRates.rateIsFrozen(currencyKey),
-            "Cannot purge as total supply is above threshold and rate is not frozen."
-        );
+        require(totalSupply <= maxSupplyToPurge || exRates.rateIsFrozen(currencyKey), "Cannot purge");
 
         for (uint i = 0; i < addresses.length; i++) {
             address holder = addresses[i];

--- a/contracts/RewardEscrow.sol
+++ b/contracts/RewardEscrow.sol
@@ -179,7 +179,7 @@ contract RewardEscrow is Owned, IRewardEscrow {
         totalEscrowedBalance = totalEscrowedBalance.add(quantity);
         require(
             totalEscrowedBalance <= IERC20(address(synthetix)).balanceOf(address(this)),
-            "Must be enough balance in the contract to provide for the vesting entry"
+            "Not enough balance for vesting"
         );
 
         /* Disallow arbitrarily long vesting schedules in light of the gas limit. */
@@ -194,10 +194,7 @@ contract RewardEscrow is Owned, IRewardEscrow {
         } else {
             /* Disallow adding new vested SNX earlier than the last one.
              * Since entries are only appended, this means that no vesting date can be repeated. */
-            require(
-                getVestingTime(account, scheduleLength - 1) < time,
-                "Cannot add new vested entries earlier than the last one"
-            );
+            require(getVestingTime(account, scheduleLength - 1) < time, "Invalid entry time");
             totalEscrowedAccountBalance[account] = totalEscrowedAccountBalance[account].add(quantity);
         }
 
@@ -252,7 +249,7 @@ contract RewardEscrow is Owned, IRewardEscrow {
     modifier onlyFeePool() {
         bool isFeePool = msg.sender == address(feePool);
 
-        require(isFeePool, "Only the FeePool contracts can perform this action");
+        require(isFeePool, "Only FeePool contracts");
         _;
     }
 

--- a/contracts/RewardsDistribution.sol
+++ b/contracts/RewardsDistribution.sol
@@ -148,10 +148,7 @@ contract RewardsDistribution is Owned, IRewardsDistribution {
         require(rewardEscrow != address(0), "RewardEscrow is not set");
         require(synthetixProxy != address(0), "SynthetixProxy is not set");
         require(feePoolProxy != address(0), "FeePoolProxy is not set");
-        require(
-            IERC20(synthetixProxy).balanceOf(address(this)) >= amount,
-            "RewardsDistribution contract does not have enough tokens to distribute"
-        );
+        require(IERC20(synthetixProxy).balanceOf(address(this)) >= amount, "Not enough tokens to distribute");
 
         uint remainder = amount;
 

--- a/contracts/RewardsDistributionRecipient.sol
+++ b/contracts/RewardsDistributionRecipient.sol
@@ -11,7 +11,7 @@ contract RewardsDistributionRecipient is Owned {
     function notifyRewardAmount(uint256 reward) external;
 
     modifier onlyRewardsDistribution() {
-        require(msg.sender == rewardsDistribution, "Caller is not RewardsDistribution contract");
+        require(msg.sender == rewardsDistribution, "Only RewardsDistribution");
         _;
     }
 

--- a/contracts/StakingRewards.sol
+++ b/contracts/StakingRewards.sol
@@ -139,17 +139,14 @@ contract StakingRewards is IStakingRewards, RewardsDistributionRecipient, Reentr
         // Cannot recover the staking token or the rewards token
         require(
             tokenAddress != address(stakingToken) && tokenAddress != address(rewardsToken) && !isSNX,
-            "Cannot withdraw the staking or rewards tokens"
+            "Token not withdrawable"
         );
         IERC20(tokenAddress).safeTransfer(owner, tokenAmount);
         emit Recovered(tokenAddress, tokenAmount);
     }
 
     function setRewardsDuration(uint256 _rewardsDuration) external onlyOwner {
-        require(
-            periodFinish == 0 || block.timestamp > periodFinish,
-            "Previous rewards period must be complete before changing the duration for the new period"
-        );
+        require(periodFinish == 0 || block.timestamp > periodFinish, "Period not finished");
         rewardsDuration = _rewardsDuration;
         emit RewardsDurationUpdated(rewardsDuration);
     }

--- a/contracts/State.sol
+++ b/contracts/State.sol
@@ -29,7 +29,7 @@ contract State is Owned {
     /* ========== MODIFIERS ========== */
 
     modifier onlyAssociatedContract {
-        require(msg.sender == associatedContract, "Only the associated contract can perform this action");
+        require(msg.sender == associatedContract, "Only associated contract");
         _;
     }
 

--- a/contracts/SupplySchedule.sol
+++ b/contracts/SupplySchedule.sol
@@ -184,7 +184,7 @@ contract SupplySchedule is Owned {
      * @param amount the amount of SNX to reward the minter.
      * */
     function setMinterReward(uint amount) external onlyOwner {
-        require(amount <= MAX_MINTER_REWARD, "Reward cannot exceed max minter reward");
+        require(amount <= MAX_MINTER_REWARD, "Reward > max minter reward");
         minterReward = amount;
         emit MinterRewardUpdated(minterReward);
     }
@@ -208,10 +208,7 @@ contract SupplySchedule is Owned {
      * @notice Only the Synthetix contract is authorised to call this function
      * */
     modifier onlySynthetix() {
-        require(
-            msg.sender == address(Proxy(address(synthetixProxy)).target()),
-            "Only the synthetix contract can perform this action"
-        );
+        require(msg.sender == address(Proxy(address(synthetixProxy)).target()), "Only synthetix contract");
         _;
     }
 

--- a/contracts/Synth.sol
+++ b/contracts/Synth.sol
@@ -191,8 +191,8 @@ contract Synth is Owned, IERC20, ExternStateToken, MixinResolver, ISynth {
     }
 
     function _ensureCanTransfer(address from, uint value) internal view {
-        require(exchanger().maxSecsLeftInWaitingPeriod(from, currencyKey) == 0, "Cannot transfer during waiting period");
-        require(transferableSynths(from) >= value, "Insufficient balance after any settlement owing");
+        require(exchanger().maxSecsLeftInWaitingPeriod(from, currencyKey) == 0, "No transfer in waiting period");
+        require(transferableSynths(from) >= value, "Insufficient balance");
         systemStatus().requireSynthActive(currencyKey);
     }
 
@@ -235,7 +235,7 @@ contract Synth is Owned, IERC20, ExternStateToken, MixinResolver, ISynth {
         bool isExchanger = msg.sender == address(exchanger());
         bool isIssuer = msg.sender == address(issuer());
 
-        require(isFeePool || isExchanger || isIssuer, "Only FeePool, Exchanger or Issuer contracts allowed");
+        require(isFeePool || isExchanger || isIssuer, "Only internal contracts");
         _;
     }
 

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -150,7 +150,7 @@ contract Synthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
                 account,
                 tokenState.balanceOf(account)
             );
-            require(value <= transferable, "Cannot transfer staked or escrowed SNX");
+            require(value <= transferable, "Cannot transfer staked/escrowed");
             require(!anyRateIsInvalid, "A synth or SNX rate is invalid");
         }
         return true;
@@ -418,14 +418,7 @@ contract Synthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         bytes32 toCurrencyKey,
         uint256 toAmount
     ) external onlyExchanger {
-        proxy._emit(
-            abi.encode(toCurrencyKey, toAmount),
-            2,
-            EXCHANGE_TRACKING_SIG,
-            trackingCode,
-            0,
-            0
-        );
+        proxy._emit(abi.encode(toCurrencyKey, toAmount), 2, EXCHANGE_TRACKING_SIG, trackingCode, 0, 0);
     }
 
     event ExchangeReclaim(address indexed account, bytes32 currencyKey, uint amount);

--- a/contracts/SynthetixEscrow.sol
+++ b/contracts/SynthetixEscrow.sol
@@ -160,10 +160,7 @@ contract SynthetixEscrow is Owned, LimitedSetup(8 weeks), IHasBalance {
 
         /* There must be enough balance in the contract to provide for the vesting entry. */
         totalVestedBalance = totalVestedBalance.add(quantity);
-        require(
-            totalVestedBalance <= IERC20(address(synthetix)).balanceOf(address(this)),
-            "Must be enough balance in the contract to provide for the vesting entry"
-        );
+        require(totalVestedBalance <= IERC20(address(synthetix)).balanceOf(address(this)), "No balance for vesting");
 
         /* Disallow arbitrarily long vesting schedules in light of the gas limit. */
         uint scheduleLength = vestingSchedules[account].length;
@@ -174,10 +171,7 @@ contract SynthetixEscrow is Owned, LimitedSetup(8 weeks), IHasBalance {
         } else {
             /* Disallow adding new vested SNX earlier than the last one.
              * Since entries are only appended, this means that no vesting date can be repeated. */
-            require(
-                getVestingTime(account, numVestingEntries(account) - 1) < time,
-                "Cannot add new vested entries earlier than the last one"
-            );
+            require(getVestingTime(account, numVestingEntries(account) - 1) < time, "Invalid entry time");
             totalVestedAccountBalance[account] = totalVestedAccountBalance[account].add(quantity);
         }
 

--- a/contracts/SystemSettings.sol
+++ b/contracts/SystemSettings.sol
@@ -146,7 +146,7 @@ contract SystemSettings is Owned, MixinResolver, MixinSystemSettings, ISystemSet
     }
 
     function setIssuanceRatio(uint _issuanceRatio) external onlyOwner {
-        require(_issuanceRatio <= MAX_ISSUANCE_RATIO, "New issuance ratio cannot exceed MAX_ISSUANCE_RATIO");
+        require(_issuanceRatio <= MAX_ISSUANCE_RATIO, "Issuance > MAX_ISSUANCE_RATIO");
         flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_ISSUANCE_RATIO, _issuanceRatio);
         emit IssuanceRatioUpdated(_issuanceRatio);
     }
@@ -184,13 +184,13 @@ contract SystemSettings is Owned, MixinResolver, MixinSystemSettings, ISystemSet
     function setLiquidationRatio(uint _liquidationRatio) external onlyOwner {
         require(
             _liquidationRatio <= MAX_LIQUIDATION_RATIO.divideDecimal(SafeDecimalMath.unit().add(getLiquidationPenalty())),
-            "liquidationRatio > MAX_LIQUIDATION_RATIO / (1 + penalty)"
+            "Invalid liquidationRatio"
         );
 
         // MIN_LIQUIDATION_RATIO is a product of target issuance ratio * RATIO_FROM_TARGET_BUFFER
         // Ensures that liquidation ratio is set so that there is a buffer between the issuance ratio and liquidation ratio.
         uint MIN_LIQUIDATION_RATIO = getIssuanceRatio().multiplyDecimal(RATIO_FROM_TARGET_BUFFER);
-        require(_liquidationRatio >= MIN_LIQUIDATION_RATIO, "liquidationRatio < MIN_LIQUIDATION_RATIO");
+        require(_liquidationRatio >= MIN_LIQUIDATION_RATIO, "Invalid liquidationRatio");
 
         flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_RATIO, _liquidationRatio);
 
@@ -198,7 +198,7 @@ contract SystemSettings is Owned, MixinResolver, MixinSystemSettings, ISystemSet
     }
 
     function setLiquidationPenalty(uint penalty) external onlyOwner {
-        require(penalty <= MAX_LIQUIDATION_PENALTY, "penalty > MAX_LIQUIDATION_PENALTY");
+        require(penalty <= MAX_LIQUIDATION_PENALTY, "Invalid penalty");
 
         flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_PENALTY, penalty);
 

--- a/contracts/SystemStatus.sol
+++ b/contracts/SystemStatus.sol
@@ -39,19 +39,19 @@ contract SystemStatus is Owned, ISystemStatus {
     function requireIssuanceActive() external view {
         // Issuance requires the system be active
         _internalRequireSystemActive();
-        require(!issuanceSuspension.suspended, "Issuance is suspended. Operation prohibited");
+        require(!issuanceSuspension.suspended, "Issuance is suspended");
     }
 
     function requireExchangeActive() external view {
         // Issuance requires the system be active
         _internalRequireSystemActive();
-        require(!exchangeSuspension.suspended, "Exchange is suspended. Operation prohibited");
+        require(!exchangeSuspension.suspended, "Exchange is suspended");
     }
 
     function requireSynthActive(bytes32 currencyKey) external view {
         // Synth exchange and transfer requires the system be active
         _internalRequireSystemActive();
-        require(!synthSuspension[currencyKey].suspended, "Synth is suspended. Operation prohibited");
+        require(!synthSuspension[currencyKey].suspended, "Synth is suspended");
     }
 
     function requireSynthsActive(bytes32 sourceCurrencyKey, bytes32 destinationCurrencyKey) external view {
@@ -60,7 +60,7 @@ contract SystemStatus is Owned, ISystemStatus {
 
         require(
             !synthSuspension[sourceCurrencyKey].suspended && !synthSuspension[destinationCurrencyKey].suspended,
-            "One or more synths are suspended. Operation prohibited"
+            "One or more synths are suspended"
         );
     }
 
@@ -150,19 +150,18 @@ contract SystemStatus is Owned, ISystemStatus {
     /* ========== INTERNAL FUNCTIONS ========== */
 
     function _requireAccessToSuspend(bytes32 section) internal view {
-        require(accessControl[section][msg.sender].canSuspend, "Restricted to access control list");
+        require(accessControl[section][msg.sender].canSuspend, "Access restricted");
     }
 
     function _requireAccessToResume(bytes32 section) internal view {
-        require(accessControl[section][msg.sender].canResume, "Restricted to access control list");
+        require(accessControl[section][msg.sender].canResume, "Access restricted");
     }
 
     function _internalRequireSystemActive() internal view {
         require(
+            // solhint-disable-next-line
             !systemSuspension.suspended,
-            systemSuspension.reason == SUSPENSION_REASON_UPGRADE
-                ? "Synthetix is suspended, upgrade in progress... please stand by"
-                : "Synthetix is suspended. Operation prohibited"
+            systemSuspension.reason == SUSPENSION_REASON_UPGRADE ? "Upgrade in progress" : "Synthetix is suspended"
         );
     }
 

--- a/contracts/test-helpers/TokenExchanger.sol
+++ b/contracts/test-helpers/TokenExchanger.sol
@@ -47,20 +47,17 @@ contract TokenExchanger is Owned {
         uint amount
     ) public synthetixProxyIsSet returns (bool) {
         // Call Immutable static call #1
-        require(checkBalance(fromAccount) >= amount, "fromAccount does not have the required balance to spend");
+        require(checkBalance(fromAccount) >= amount, "Insufficient balance");
 
         // Call Immutable static call #2
-        require(
-            checkAllowance(fromAccount, address(this)) >= amount,
-            "I TokenExchanger, do not have approval to spend this guys tokens"
-        );
+        require(checkAllowance(fromAccount, address(this)) >= amount, "Insufficient approval");
 
         // Call Mutable call
         return IERC20(integrationProxy).transferFrom(fromAccount, toAccount, amount);
     }
 
     modifier synthetixProxyIsSet {
-        require(integrationProxy != address(0), "Synthetix Integration proxy address not set");
+        require(integrationProxy != address(0), "Proxy address not set");
         _;
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -324,6 +324,72 @@
 				"ethers-v5": "npm:ethers@5.0.7"
 			},
 			"dependencies": {
+				"@ethereum-waffle/chai": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@ethereum-waffle/chai/-/chai-3.1.0.tgz",
+					"integrity": "sha512-erBoZoseFXZPEEbv9GHqJKjGAG4u1m/NzTRvXUGFDngdZYsBzMDTVU63vIrGVlVu3Cu7Wd5KfdhYib+/iH2xcQ==",
+					"dev": true,
+					"requires": {
+						"@ethereum-waffle/provider": "^3.1.0",
+						"ethers": "^5.0.0"
+					}
+				},
+				"@ethereum-waffle/compiler": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@ethereum-waffle/compiler/-/compiler-3.1.0.tgz",
+					"integrity": "sha512-qFwy9OHbbvltns4tz12mpbSryg8rCpATsdjM+PtSSXSJ7s04fcDlKWJgFERE3jsxE7GMGH8mfr4e7Jqncxxh7w==",
+					"dev": true,
+					"requires": {
+						"@resolver-engine/imports": "^0.3.3",
+						"@resolver-engine/imports-fs": "^0.3.3",
+						"@types/mkdirp": "^0.5.2",
+						"@types/node-fetch": "^2.5.5",
+						"ethers": "^5.0.1",
+						"mkdirp": "^0.5.1",
+						"node-fetch": "^2.6.0",
+						"solc": "^0.6.3"
+					}
+				},
+				"@ethereum-waffle/mock-contract": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@ethereum-waffle/mock-contract/-/mock-contract-3.1.0.tgz",
+					"integrity": "sha512-mhvyb9P5aM7D2qHmaAH2ONbR95L7pVveRR9s7zfcxYdzJP0KCjy2IZfPmhOZDe/lW1tXuM3m/OL+oHfKTRYbdw==",
+					"dev": true,
+					"requires": {
+						"@ethersproject/abi": "^5.0.1",
+						"ethers": "^5.0.1"
+					}
+				},
+				"@ethereum-waffle/provider": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/@ethereum-waffle/provider/-/provider-3.1.0.tgz",
+					"integrity": "sha512-MPlmtYWVEjObSrneZQKHprRe00Da768IdT1+hyWq5x6uXluYdqo5hZc9LVNTd2f9WfHasZ8YWZLUC/wsEb86ig==",
+					"dev": true,
+					"requires": {
+						"@ethereum-waffle/ens": "^3.1.0",
+						"ethers": "^5.0.1",
+						"ganache-core": "^2.10.2",
+						"patch-package": "^6.2.2",
+						"postinstall-postinstall": "^2.1.0"
+					}
+				},
+				"@ethersproject/abi": {
+					"version": "5.0.5",
+					"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.5.tgz",
+					"integrity": "sha512-FNx6UMm0LnmCMFzN3urohFwZpjbUHPvc/O60h4qkF4yiJxLJ/G7QOSPjkHQ/q/QibagR4S7OKQawRy0NcvWa9w==",
+					"dev": true,
+					"requires": {
+						"@ethersproject/address": "^5.0.4",
+						"@ethersproject/bignumber": "^5.0.7",
+						"@ethersproject/bytes": "^5.0.4",
+						"@ethersproject/constants": "^5.0.4",
+						"@ethersproject/hash": "^5.0.4",
+						"@ethersproject/keccak256": "^5.0.3",
+						"@ethersproject/logger": "^5.0.5",
+						"@ethersproject/properties": "^5.0.3",
+						"@ethersproject/strings": "^5.0.4"
+					}
+				},
 				"@nomiclabs/buidler": {
 					"version": "1.4.5",
 					"resolved": "https://registry.npmjs.org/@nomiclabs/buidler/-/buidler-1.4.5.tgz",
@@ -413,17 +479,55 @@
 					"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
 					"dev": true
 				},
-				"ethereum-waffle-v2": {
-					"version": "npm:ethereum-waffle@2.5.1",
-					"resolved": "https://registry.npmjs.org/ethereum-waffle/-/ethereum-waffle-2.5.1.tgz",
-					"integrity": "sha512-GPumiHpJHN9ONO7owo4mEZJDZzyDRawV3ukBdd+mPCxJkJbe69LTvza1nxcgwMjruXOd9GHaOnE/C2Sb+uGuMA==",
+				"ethereum-waffle-v3": {
+					"version": "npm:ethereum-waffle@3.1.0",
+					"resolved": "https://registry.npmjs.org/ethereum-waffle/-/ethereum-waffle-3.1.0.tgz",
+					"integrity": "sha512-QSEzYhxBAjJAgVXZcR1lMB4Px1lAtf8M3QQPIflasNwHpw/VZWaYqN4o2fl615iPtOc3FFtMu1JSEbiuYojk/w==",
 					"dev": true,
 					"requires": {
-						"@ethereum-waffle/chai": "^2.5.1",
-						"@ethereum-waffle/compiler": "^2.5.1",
-						"@ethereum-waffle/mock-contract": "^2.5.1",
-						"@ethereum-waffle/provider": "^2.5.1",
-						"ethers": "^4.0.45"
+						"@ethereum-waffle/chai": "^3.1.0",
+						"@ethereum-waffle/compiler": "^3.1.0",
+						"@ethereum-waffle/mock-contract": "^3.1.0",
+						"@ethereum-waffle/provider": "^3.1.0",
+						"ethers": "^5.0.1"
+					}
+				},
+				"ethers": {
+					"version": "5.0.13",
+					"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.13.tgz",
+					"integrity": "sha512-xtSVE6r3ltLZ2EHtzA0rd1s2TQaLTC11qhSG+iYhOgno+lhyIXffBC8CzLkQEp51+GlRTn9/xCjly6JCn5qwMA==",
+					"dev": true,
+					"requires": {
+						"@ethersproject/abi": "^5.0.5",
+						"@ethersproject/abstract-provider": "^5.0.4",
+						"@ethersproject/abstract-signer": "^5.0.4",
+						"@ethersproject/address": "^5.0.4",
+						"@ethersproject/base64": "^5.0.3",
+						"@ethersproject/basex": "^5.0.3",
+						"@ethersproject/bignumber": "^5.0.7",
+						"@ethersproject/bytes": "^5.0.4",
+						"@ethersproject/constants": "^5.0.4",
+						"@ethersproject/contracts": "^5.0.4",
+						"@ethersproject/hash": "^5.0.4",
+						"@ethersproject/hdnode": "^5.0.4",
+						"@ethersproject/json-wallets": "^5.0.6",
+						"@ethersproject/keccak256": "^5.0.3",
+						"@ethersproject/logger": "^5.0.5",
+						"@ethersproject/networks": "^5.0.3",
+						"@ethersproject/pbkdf2": "^5.0.3",
+						"@ethersproject/properties": "^5.0.3",
+						"@ethersproject/providers": "^5.0.8",
+						"@ethersproject/random": "^5.0.3",
+						"@ethersproject/rlp": "^5.0.3",
+						"@ethersproject/sha2": "^5.0.3",
+						"@ethersproject/signing-key": "^5.0.4",
+						"@ethersproject/solidity": "^5.0.4",
+						"@ethersproject/strings": "^5.0.4",
+						"@ethersproject/transactions": "^5.0.5",
+						"@ethersproject/units": "^5.0.4",
+						"@ethersproject/wallet": "^5.0.4",
+						"@ethersproject/web": "^5.0.6",
+						"@ethersproject/wordlists": "^5.0.4"
 					}
 				},
 				"fs-extra": {
@@ -7233,188 +7337,17 @@
 				"web3": "^1.0.0-beta.34"
 			}
 		},
-		"ethereum-waffle-v3": {
-			"version": "npm:ethereum-waffle@3.1.0",
-			"resolved": "https://registry.npmjs.org/ethereum-waffle/-/ethereum-waffle-3.1.0.tgz",
-			"integrity": "sha512-QSEzYhxBAjJAgVXZcR1lMB4Px1lAtf8M3QQPIflasNwHpw/VZWaYqN4o2fl615iPtOc3FFtMu1JSEbiuYojk/w==",
+		"ethereum-waffle-v2": {
+			"version": "npm:ethereum-waffle@2.5.1",
+			"resolved": "https://registry.npmjs.org/ethereum-waffle/-/ethereum-waffle-2.5.1.tgz",
+			"integrity": "sha512-GPumiHpJHN9ONO7owo4mEZJDZzyDRawV3ukBdd+mPCxJkJbe69LTvza1nxcgwMjruXOd9GHaOnE/C2Sb+uGuMA==",
 			"dev": true,
 			"requires": {
-				"@ethereum-waffle/chai": "^3.1.0",
-				"@ethereum-waffle/compiler": "^3.1.0",
-				"@ethereum-waffle/mock-contract": "^3.1.0",
-				"@ethereum-waffle/provider": "^3.1.0",
-				"ethers": "^5.0.1"
-			},
-			"dependencies": {
-				"@ethereum-waffle/chai": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/@ethereum-waffle/chai/-/chai-3.1.0.tgz",
-					"integrity": "sha512-erBoZoseFXZPEEbv9GHqJKjGAG4u1m/NzTRvXUGFDngdZYsBzMDTVU63vIrGVlVu3Cu7Wd5KfdhYib+/iH2xcQ==",
-					"dev": true,
-					"requires": {
-						"@ethereum-waffle/provider": "^3.1.0",
-						"ethers": "^5.0.0"
-					}
-				},
-				"@ethereum-waffle/compiler": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/@ethereum-waffle/compiler/-/compiler-3.1.0.tgz",
-					"integrity": "sha512-qFwy9OHbbvltns4tz12mpbSryg8rCpATsdjM+PtSSXSJ7s04fcDlKWJgFERE3jsxE7GMGH8mfr4e7Jqncxxh7w==",
-					"dev": true,
-					"requires": {
-						"@resolver-engine/imports": "^0.3.3",
-						"@resolver-engine/imports-fs": "^0.3.3",
-						"@types/mkdirp": "^0.5.2",
-						"@types/node-fetch": "^2.5.5",
-						"ethers": "^5.0.1",
-						"mkdirp": "^0.5.1",
-						"node-fetch": "^2.6.0",
-						"solc": "^0.6.3"
-					}
-				},
-				"@ethereum-waffle/mock-contract": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/@ethereum-waffle/mock-contract/-/mock-contract-3.1.0.tgz",
-					"integrity": "sha512-mhvyb9P5aM7D2qHmaAH2ONbR95L7pVveRR9s7zfcxYdzJP0KCjy2IZfPmhOZDe/lW1tXuM3m/OL+oHfKTRYbdw==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/abi": "^5.0.1",
-						"ethers": "^5.0.1"
-					}
-				},
-				"@ethereum-waffle/provider": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/@ethereum-waffle/provider/-/provider-3.1.0.tgz",
-					"integrity": "sha512-MPlmtYWVEjObSrneZQKHprRe00Da768IdT1+hyWq5x6uXluYdqo5hZc9LVNTd2f9WfHasZ8YWZLUC/wsEb86ig==",
-					"dev": true,
-					"requires": {
-						"@ethereum-waffle/ens": "^3.1.0",
-						"ethers": "^5.0.1",
-						"ganache-core": "^2.10.2",
-						"patch-package": "^6.2.2",
-						"postinstall-postinstall": "^2.1.0"
-					}
-				},
-				"@ethersproject/abi": {
-					"version": "5.0.5",
-					"resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.0.5.tgz",
-					"integrity": "sha512-FNx6UMm0LnmCMFzN3urohFwZpjbUHPvc/O60h4qkF4yiJxLJ/G7QOSPjkHQ/q/QibagR4S7OKQawRy0NcvWa9w==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/address": "^5.0.4",
-						"@ethersproject/bignumber": "^5.0.7",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/constants": "^5.0.4",
-						"@ethersproject/hash": "^5.0.4",
-						"@ethersproject/keccak256": "^5.0.3",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/properties": "^5.0.3",
-						"@ethersproject/strings": "^5.0.4"
-					}
-				},
-				"commander": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-3.0.2.tgz",
-					"integrity": "sha512-Gar0ASD4BDyKC4hl4DwHqDrmvjoxWKZigVnAbn5H1owvm4CxCPdb0HQDehwNYMJpla5+M2tPmPARzhtYuwpHow==",
-					"dev": true
-				},
-				"ethers": {
-					"version": "5.0.13",
-					"resolved": "https://registry.npmjs.org/ethers/-/ethers-5.0.13.tgz",
-					"integrity": "sha512-xtSVE6r3ltLZ2EHtzA0rd1s2TQaLTC11qhSG+iYhOgno+lhyIXffBC8CzLkQEp51+GlRTn9/xCjly6JCn5qwMA==",
-					"dev": true,
-					"requires": {
-						"@ethersproject/abi": "^5.0.5",
-						"@ethersproject/abstract-provider": "^5.0.4",
-						"@ethersproject/abstract-signer": "^5.0.4",
-						"@ethersproject/address": "^5.0.4",
-						"@ethersproject/base64": "^5.0.3",
-						"@ethersproject/basex": "^5.0.3",
-						"@ethersproject/bignumber": "^5.0.7",
-						"@ethersproject/bytes": "^5.0.4",
-						"@ethersproject/constants": "^5.0.4",
-						"@ethersproject/contracts": "^5.0.4",
-						"@ethersproject/hash": "^5.0.4",
-						"@ethersproject/hdnode": "^5.0.4",
-						"@ethersproject/json-wallets": "^5.0.6",
-						"@ethersproject/keccak256": "^5.0.3",
-						"@ethersproject/logger": "^5.0.5",
-						"@ethersproject/networks": "^5.0.3",
-						"@ethersproject/pbkdf2": "^5.0.3",
-						"@ethersproject/properties": "^5.0.3",
-						"@ethersproject/providers": "^5.0.8",
-						"@ethersproject/random": "^5.0.3",
-						"@ethersproject/rlp": "^5.0.3",
-						"@ethersproject/sha2": "^5.0.3",
-						"@ethersproject/signing-key": "^5.0.4",
-						"@ethersproject/solidity": "^5.0.4",
-						"@ethersproject/strings": "^5.0.4",
-						"@ethersproject/transactions": "^5.0.5",
-						"@ethersproject/units": "^5.0.4",
-						"@ethersproject/wallet": "^5.0.4",
-						"@ethersproject/web": "^5.0.6",
-						"@ethersproject/wordlists": "^5.0.4"
-					}
-				},
-				"fs-extra": {
-					"version": "0.30.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.30.0.tgz",
-					"integrity": "sha1-8jP/zAjU2n1DLapEl3aYnbHfk/A=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.2",
-						"jsonfile": "^2.1.0",
-						"klaw": "^1.0.0",
-						"path-is-absolute": "^1.0.0",
-						"rimraf": "^2.2.8"
-					}
-				},
-				"js-sha3": {
-					"version": "0.8.0",
-					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-					"integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-					"dev": true
-				},
-				"jsonfile": {
-					"version": "2.4.0",
-					"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-					"integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
-					"dev": true,
-					"requires": {
-						"graceful-fs": "^4.1.6"
-					}
-				},
-				"mkdirp": {
-					"version": "0.5.5",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				},
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-					"dev": true
-				},
-				"solc": {
-					"version": "0.6.12",
-					"resolved": "https://registry.npmjs.org/solc/-/solc-0.6.12.tgz",
-					"integrity": "sha512-Lm0Ql2G9Qc7yPP2Ba+WNmzw2jwsrd3u4PobHYlSOxaut3TtUbj9+5ZrT6f4DUpNPEoBaFUOEg9Op9C0mk7ge9g==",
-					"dev": true,
-					"requires": {
-						"command-exists": "^1.2.8",
-						"commander": "3.0.2",
-						"fs-extra": "^0.30.0",
-						"js-sha3": "0.8.0",
-						"memorystream": "^0.3.1",
-						"require-from-string": "^2.0.0",
-						"semver": "^5.5.0",
-						"tmp": "0.0.33"
-					}
-				}
+				"@ethereum-waffle/chai": "^2.5.1",
+				"@ethereum-waffle/compiler": "^2.5.1",
+				"@ethereum-waffle/mock-contract": "^2.5.1",
+				"@ethereum-waffle/provider": "^2.5.1",
+				"ethers": "^4.0.45"
 			}
 		},
 		"ethereumjs-abi": {

--- a/publish/src/solidity.js
+++ b/publish/src/solidity.js
@@ -75,7 +75,7 @@ module.exports = {
 					settings: {
 						optimizer: {
 							enabled: true,
-							runs,
+							runs: parseInt(runs),
 						},
 						outputSelection: {
 							'*': {


### PR DESCRIPTION
Some of the contracts are starting to have bytecode size above the limit of what can be deployed in mainnet (24kb) (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-170.md).

This PR makes sure all error messages fit in bytes32 words. Additionally, it enforces this requirement via the linter, and fixes a small bug in the solidity.js script.

#### Status 

Atm, tests are not updated to look for the shortened error messages. This implies quite a bit of work.

Also, keeping messages within the limit causes some of them to be less aesthetic, so we may want to use error codes.

Finally, messages are currently inconsistent in form. Eg, some report a requirement, and some report the cause of a failure (one is the negation of the other) and we may want to be more consistent about it.

#### Size reduction (with --use-OVM and the default 200 optimizer runs)

Contract | Size | Size change
-------- | ---- | -----------
AddressListLib.sol | 82 Bytes (0.33%)
AddressResolver.sol | 2.43 KB (10.14%) | -2.77%
BinaryOption.sol | 5.26 KB (21.90%) | 1.09%
BinaryOptionMarket.sol | 15.96 KB (66.52%) | -0.51%
BinaryOptionMarketData.sol | 5.2 KB (21.68%)
BinaryOptionMarketFactory.sol | 30.67 KB (127.80%) | -0.17%
BinaryOptionMarketManager.sol | 16.71 KB (69.65%) | -0.50%
ContractStorage.sol | 0 Bytes (0.00%)
DappMaintenance.sol | 1.97 KB (8.23%) | -2.27%
DelegateApprovals.sol | 4.36 KB (18.16%) | -2.06%
Depot.sol | 17.38 KB (72.40%) | -0.58%
EscrowChecker.sol | 980 Bytes (3.99%)
EternalStorage.sol | 5.62 KB (23.42%) | -0.59%
EtherCollateral.sol | 14.88 KB (62.01%) | -2.03%
ExchangeRates.sol | 19.07 KB (79.46%) | 0.08%
ExchangeState.sol | 3.57 KB (14.88%) | -2.06%
Exchanger.sol | 16.73 KB (69.71%) | -0.58%
ExternStateToken.sol | 6.52 KB (27.17%) | -0.15%
FeePool.sol | 20.14 KB (83.90%) | -0.26%
FeePoolEternalStorage.sol | 6.66 KB (27.75%) | -0.77%
FeePoolState.sol | 5.05 KB (21.04%) | -1.71%
FlexibleStorage.sol | 11.71 KB (48.80%) | 0.42%
Issuer.sol | 20.77 KB (86.54%) | -0.17%
LimitedSetup.sol | 0 Bytes (0.00%)
Liquidations.sol | 8.54 KB (35.60%) | -1.87%
Math.sol | 82 Bytes (0.33%)
MixinResolver.sol | 0 Bytes (0.00%)
MixinSystemSettings.sol | 0 Bytes (0.00%)
MultiCollateralSynth.sol | 16.32 KB (68.00%) | -0.49%
Owned.sol | 1002 Bytes (4.08%) | -7.65%
Pausable.sol | 0 Bytes (0.00%)
Proxy.sol | 2.19 KB (9.12%) | -3.07%
ProxyERC20.sol | 4.93 KB (20.54%) | -1.39%
Proxyable.sol | 0 Bytes (0.00%)
PurgeableSynth.sol | 17.7 KB (73.76%) | -0.72%
ReadProxy.sol | 1.46 KB (6.07%) | -4.55%
RewardEscrow.sol | 5.79 KB (24.13%) | -3.06%
RewardsDistribution.sol | 6.29 KB (26.20%) | -0.72%
RewardsDistributionRecipient.sol | 0 Bytes (0.00%)
SafeDecimalMath.sol | 318 Bytes (1.29%)
SelfDestructible.sol | 0 Bytes (0.00%)
StakingRewards.sol | 8.25 KB (34.38%) | -2.41%
State.sol | 0 Bytes (0.00%)
SupplySchedule.sol | 4.8 KB (20.02%) | -2.05%
Synth.sol | 16.11 KB (67.13%) | -0.40%
SynthUtil.sol | 5.39 KB (22.47%)
Synthetix.sol | 26.74 KB (111.41%) | -0.05%
SynthetixEscrow.sol | 6.21 KB (25.87%) | -2.24%
SynthetixState.sol | 3.08 KB (12.83%) | -2.17%
SystemSettings.sol | 12.56 KB (52.33%) | -0.91%
SystemStatus.sol | 5.75 KB (23.95%) | -4.51%
TokenState.sol | 1.96 KB (8.16%) | -4.25%
TradingRewards.sol | 10.98 KB (45.74%) | -0.32%
