### PR TITLE
Avoid inlining in some modifiers

### DIFF
--- a/contracts/Owned.sol
+++ b/contracts/Owned.sol
@@ -25,8 +25,12 @@ contract Owned {
     }
 
     modifier onlyOwner {
-        require(msg.sender == owner, "Only the contract owner may perform this action");
+        _onlyOwner();
         _;
+    }
+
+    function _onlyOwner() private view {
+        require(msg.sender == owner, "Only the contract owner may perform this action");
     }
 
     event OwnerNominated(address newOwner);

--- a/contracts/Proxyable.sol
+++ b/contracts/Proxyable.sol
@@ -42,23 +42,35 @@ contract Proxyable is Owned {
     }
 
     modifier onlyProxy {
-        require(Proxy(msg.sender) == proxy || Proxy(msg.sender) == integrationProxy, "Only the proxy can call");
+        _onlyProxy();
         _;
+    }
+
+    function _onlyProxy() private view {
+        require(Proxy(msg.sender) == proxy || Proxy(msg.sender) == integrationProxy, "Only the proxy can call");
     }
 
     modifier optionalProxy {
-        if (Proxy(msg.sender) != proxy && Proxy(msg.sender) != integrationProxy && messageSender != msg.sender) {
-            messageSender = msg.sender;
-        }
+        _optionalProxy();
         _;
     }
 
+    function _optionalProxy() private {
+        if (Proxy(msg.sender) != proxy && Proxy(msg.sender) != integrationProxy && messageSender != msg.sender) {
+            messageSender = msg.sender;
+        }
+    }
+
     modifier optionalProxy_onlyOwner {
+        _optionalProxy_onlyOwner();
+        _;
+    }
+
+    function _optionalProxy_onlyOwner() private {
         if (Proxy(msg.sender) != proxy && Proxy(msg.sender) != integrationProxy && messageSender != msg.sender) {
             messageSender = msg.sender;
         }
         require(messageSender == owner, "Owner only function");
-        _;
     }
 
     event ProxyUpdated(address proxyAddress);


### PR DESCRIPTION
Some of the contracts are starting to have bytecode size above the limit of what can be deployed in mainnet (24kb) (https://github.com/ethereum/EIPs/blob/master/EIPS/eip-170.md).

This PR performs a surgical change to reduce the contract size of Synthetix.sol (changes as little code as possible). The reduction is achieved by using internal functions in base modifiers, which avoids inlining in such modifiers. Operation gas costs should increase marginally, and deployment gas costs greatly.

#### Size reduction (with --use-OVM and the default 200 optimizer runs)

Contract | Size | Size change
-------- | ---- | -----------
AddressListLib.sol | 82 Bytes (0.33%)
AddressResolver.sol | 2.41 KB (10.04%) | -3.75%
BinaryOption.sol | 5.2 KB (21.66%)
BinaryOptionMarket.sol | 15.64 KB (65.17%) | -2.53%
BinaryOptionMarketData.sol | 5.2 KB (21.68%)
BinaryOptionMarketFactory.sol | 29.79 KB (124.14%) | -3.03%
BinaryOptionMarketManager.sol | 14.95 KB (62.27%) | -11.03%
ContractStorage.sol | 0 Bytes (0.00%)
DappMaintenance.sol | 1.72 KB (7.18%) | -14.69%
DelegateApprovals.sol | 4.36 KB (18.15%) | -2.11%
Depot.sol | 16.45 KB (68.55%) | -5.87%
EscrowChecker.sol | 980 Bytes (3.99%)
EternalStorage.sol | 5.56 KB (23.17%) | -1.66%
EtherCollateral.sol | 14.27 KB (59.46%) | -6.07%
ExchangeRates.sol | 19.19 KB (79.94%) | 0.68%
ExchangeState.sol | 3.45 KB (14.38%) | -5.41%
Exchanger.sol | 16.73 KB (69.73%) | -0.56%
ExternStateToken.sol | 5.91 KB (24.61%) | -9.56%
FeePool.sol | 18.84 KB (78.49%) | -6.69%
FeePoolEternalStorage.sol | 6.51 KB (27.14%) | -2.94%
FeePoolState.sol | 4.53 KB (18.86%) | -11.90%
FlexibleStorage.sol | 11.66 KB (48.59%)
Issuer.sol | 20.51 KB (85.44%) | -1.45%
LimitedSetup.sol | 0 Bytes (0.00%)
Liquidations.sol | 8.61 KB (35.89%) | -1.08%
Math.sol | 82 Bytes (0.33%)
MixinResolver.sol | 0 Bytes (0.00%)
MixinSystemSettings.sol | 0 Bytes (0.00%)
MultiCollateralSynth.sol | 14.35 KB (59.79%) | -12.50%
Owned.sol | 1.07 KB (4.47%) | 1.29%
Pausable.sol | 0 Bytes (0.00%)
Proxy.sol | 2.17 KB (9.04%) | -3.98%
ProxyERC20.sol | 4.9 KB (20.43%) | -1.88%
Proxyable.sol | 0 Bytes (0.00%)
PurgeableSynth.sol | 15.41 KB (64.20%) | -13.59%
ReadProxy.sol | 1.44 KB (5.98%) | -5.89%
RewardEscrow.sol | 5.78 KB (24.07%) | -3.30%
RewardsDistribution.sol | 5.62 KB (23.42%) | -11.26%
RewardsDistributionRecipient.sol | 0 Bytes (0.00%)
SafeDecimalMath.sol | 318 Bytes (1.29%)
SelfDestructible.sol | 0 Bytes (0.00%)
StakingRewards.sol | 8.05 KB (33.54%) | -4.80%
State.sol | 0 Bytes (0.00%)
SupplySchedule.sol | 4.71 KB (19.61%) | -4.02%
Synth.sol | 14.13 KB (58.86%) | -12.67%
SynthUtil.sol | 5.39 KB (22.47%)
Synthetix.sol | 22.2 KB (92.52%) | -17.00%
SynthetixEscrow.sol | 5.95 KB (24.78%) | -6.36%
SynthetixState.sol | 3.05 KB (12.73%) | -2.98%
SystemSettings.sol | 11.23 KB (46.81%) | -11.36%
SystemStatus.sol | 5.92 KB (24.68%) | -1.59%
TokenState.sol | 1.96 KB (8.15%) | -4.39%
TradingRewards.sol | 10.29 KB (42.88%) | -6.55%
