### PR TITLE
Fix buildler-gas-reporter production reports

### DIFF
--- a/buidler.config.js
+++ b/buidler.config.js
@@ -257,7 +257,7 @@ task('test')
 				bre.config.mocha.invert = true;
 			}
 			// Tell buidler-gas-reporter not to wrap provider when using ganache
-			if (bre.network.name === 'localhost'){
+			if (bre.network.name === 'localhost') {
 				bre.config.gasReporter.fast = false;
 			}
 		}

--- a/buidler.config.js
+++ b/buidler.config.js
@@ -256,6 +256,10 @@ task('test')
 				bre.config.mocha.grep = '@gas-skip';
 				bre.config.mocha.invert = true;
 			}
+			// Tell buidler-gas-reporter not to wrap provider when using ganache
+			if (bre.network.name === 'localhost'){
+				bre.config.gasReporter.fast = false;
+			}
 		}
 
 		if (gasOutputFile) {

--- a/codechecks.yml
+++ b/codechecks.yml
@@ -1,2 +1,6 @@
 checks:
   - name: eth-gas-reporter/codechecks
+settings:
+  branches:
+    - develop
+    - master


### PR DESCRIPTION
#722 

Synthetix is using a beta version of the gas-reporter that's buidlerevm-compatible when the `fast` option is enabled. It wraps the provider in a way which doesn't work for ganache. Disabling `fast` asks the reporter to fall back on it's default logic (e.g slow) ...


![Screen Shot 2020-09-15 at 1 44 16 PM](https://user-images.githubusercontent.com/7332026/93264558-25b6a480-f75c-11ea-957d-17a69499d388.png)




Also saw the diff is missing from the codechecks report since the migration to CircleCI in #684. Codechecks has [trouble discovering the commit hash][1] of the merge target in CircleCI unless it knows the branch name - have added some config to the `.yml` to help with this. Hopefully it will start to record the run history again and make target comparison possible.

[1]: https://github.com/codechecks/docs/blob/master/configuration.md#settings 