### PR TITLE
Fix buildler-gas-reporter production reports (internal PR)

### DIFF
--- a/buidler.config.js
+++ b/buidler.config.js
@@ -256,6 +256,10 @@ task('test')
 				bre.config.mocha.grep = '@gas-skip';
 				bre.config.mocha.invert = true;
 			}
+			// Tell buidler-gas-reporter not to wrap provider when using ganache
+			if (bre.network.name === 'localhost') {
+				bre.config.gasReporter.fast = false;
+			}
 		}
 
 		if (gasOutputFile) {

--- a/codechecks.yml
+++ b/codechecks.yml
@@ -1,2 +1,6 @@
 checks:
   - name: eth-gas-reporter/codechecks
+settings:
+  branches:
+    - develop
+    - master


### PR DESCRIPTION
The same as #723. We are just using an internal branch to be able to bypass the errors returned by CI when using a branch from a forked repo.