### PR TITLE
Use freshDeploy in deploy script

### DIFF
--- a/publish/deployed/local-ovm/config.json
+++ b/publish/deployed/local-ovm/config.json
@@ -29,6 +29,9 @@
 	"EtherCollateral": {
 		"deploy": true
 	},
+	"EtherCollateralsUSD": {
+		"deploy": true
+	},
 	"FeePool": {
 		"deploy": true
 	},

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -92,7 +92,8 @@ const deploy = async ({
 	});
 
 	// Fresh deploy and deployment.json not empty?
-	if (freshDeploy && Object.keys(deployment.targets).length > 0) {
+	console.log(network, deploymentPath);
+	if (freshDeploy && Object.keys(deployment.targets).length > 0 && network !== 'local') {
 		throw new Error(
 			`Cannot make a fresh deploy on ${deploymentPath} because a deployment has already been made on this path. If you intend to deploy a new instance, use a different path or delete the deployment files for this one.`
 		);
@@ -165,7 +166,7 @@ const deploy = async ({
 		specifiedProviderUrl,
 	});
 
-	// allow local deployments to use the private key passed as a CLI option
+	// if not specified, or in a local network, override the private key passed as a CLI option, with the one specified in .env
 	if (network !== 'local' || !privateKey) {
 		privateKey = envPrivateKey;
 	}
@@ -231,7 +232,7 @@ const deploy = async ({
 		currentLastMintEvent =
 			inflationStartDate + currentWeekOfInflation * secondsInWeek + mintingBuffer;
 	} catch (err) {
-		if (freshDeploy || network === 'local') {
+		if (freshDeploy) {
 			currentSynthetixSupply = await getDeployParameter('INITIAL_ISSUANCE');
 			currentWeekOfInflation = 0;
 			currentLastMintEvent = 0;
@@ -253,7 +254,7 @@ const deploy = async ({
 			oracleExrates = await oldExrates.methods.oracle().call();
 		}
 	} catch (err) {
-		if (freshDeploy || network === 'local') {
+		if (freshDeploy) {
 			currentSynthetixPrice = w3utils.toWei('0.2');
 			oracleExrates = oracleExrates || account;
 			oldExrates = undefined; // unset to signify that a fresh one will be deployed
@@ -276,7 +277,7 @@ const deploy = async ({
 		systemSuspended = systemSuspensionStatus.suspended;
 		systemSuspendedReason = systemSuspensionStatus.reason;
 	} catch (err) {
-		if (!freshDeploy && network !== 'local') {
+		if (!freshDeploy) {
 			console.error(
 				red(
 					'Cannot connect to existing SystemStatus contract. Please double check the deploymentPath is correct for the network allocated'
@@ -915,7 +916,7 @@ const deploy = async ({
 				const oldSynth = getExistingContract({ contract: `Synth${currencyKey}` });
 				originalTotalSupply = await oldSynth.methods.totalSupply().call();
 			} catch (err) {
-				if (network !== 'local' && !freshDeploy) {
+				if (!freshDeploy) {
 					// only throw if not local - allows local environments to handle both new
 					// and updating configurations
 					throw err;

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -92,7 +92,6 @@ const deploy = async ({
 	});
 
 	// Fresh deploy and deployment.json not empty?
-	console.log(network, deploymentPath);
 	if (freshDeploy && Object.keys(deployment.targets).length > 0 && network !== 'local') {
 		throw new Error(
 			`Cannot make a fresh deploy on ${deploymentPath} because a deployment has already been made on this path. If you intend to deploy a new instance, use a different path or delete the deployment files for this one.`

--- a/test/multi/index.js
+++ b/test/multi/index.js
@@ -45,6 +45,7 @@ describe('deploy multiple instances', () => {
 	before('deploy instance 1', async () => {
 		await commands.deploy({
 			network,
+			freshDeploy: true,
 			yes: true,
 			privateKey: deployer.private,
 		});
@@ -53,6 +54,7 @@ describe('deploy multiple instances', () => {
 	before('deploy instance 2', async () => {
 		await commands.deploy({
 			network,
+			freshDeploy: true,
 			yes: true,
 			privateKey: deployer.private,
 			deploymentPath: path.join(__dirname, '..', '..', 'publish', 'deployed', 'local-ovm'),

--- a/test/publish/index.js
+++ b/test/publish/index.js
@@ -212,6 +212,7 @@ describe('publish scripts', () => {
 
 				await commands.deploy({
 					network,
+					freshDeploy: true,
 					yes: true,
 					privateKey: accounts.deployer.private,
 				});

--- a/test/testnet/index.js
+++ b/test/testnet/index.js
@@ -115,6 +115,7 @@ program
 				// now deploy
 				await commands.deploy({
 					network,
+					freshDeploy: network === 'local',
 					yes: true,
 					privateKey,
 				});


### PR DESCRIPTION
Removes redundant `network === 'local'` checks in the deploy script. The `freshDeploy` flag should be enough.