### PR TITLE
Always perform prod tests for mainnet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -333,25 +333,16 @@ workflows:
           network: mainnet
           requires:
             - prepare
-          filters:
-            branches:
-              only: develop
       - fork-deploy:
           name: fork-deploy-mainnet
           network: mainnet
           requires:
             - fork-prepare-deploy-mainnet
-          filters:
-            branches:
-              only: develop
       - fork-test-prod:
           name: fork-test-prod-mainnet
           network: mainnet
           requires:
             - fork-deploy-mainnet
-          filters:
-            branches:
-              only: develop
       # ~~~~~~~~~~~~~~~ RINKEBY ~~~~~~~~~~~~~~~ #
       - fork-prepare-deploy:
           name: fork-prepare-deploy-rinkeby


### PR DESCRIPTION
Previously, prod tests for all networks were run only when merging to develop. With this change, this remains true, except mainnet prod tests are done on *every* PR.