### PR TITLE
Fix interactive ui errors

### DIFF
--- a/scripts/airdrop.js
+++ b/scripts/airdrop.js
@@ -131,7 +131,7 @@ async function airdrop({
 			console.log(gray(`  > Transferring ${remaining} SNX to ${staker.address}...`));
 
 			const result = await runTx({
-				tx: await Synthetix.transfer(staker.address, parseEther(`${remaining}`), overrides),
+				txPromise: Synthetix.transfer(staker.address, parseEther(`${remaining}`), overrides),
 				provider,
 			});
 

--- a/scripts/interactive-ui.js
+++ b/scripts/interactive-ui.js
@@ -21,6 +21,7 @@ async function interactiveUi({
 	deploymentPath,
 	privateKey,
 }) {
+	console.clear();
 	console.log('\n');
 	console.log(cyan('Please review this information before you interact with the system:'));
 	console.log(

--- a/scripts/interactive-ui.js
+++ b/scripts/interactive-ui.js
@@ -236,10 +236,10 @@ async function interactiveUi({
 			if (!confirmation) await interact();
 
 			console.log(gray(`  > Sending transaction... ${new Date()}`));
-			const tx = await contract[abiItemName](...inputs, overrides);
+			const txPromise = contract[abiItemName](...inputs, overrides);
 
 			result = await runTx({
-				tx,
+				txPromise,
 				provider,
 			});
 
@@ -314,9 +314,7 @@ program
 	});
 
 if (require.main === module) {
-	// Note: Leave this commented out for production and enable only for debugging of this script.
-	// Why? We process runtime on-chain errors here, and parse them as CLI output.
-	// require('pretty-error').start();
+	require('pretty-error').start();
 
 	program.parse(process.argv);
 }

--- a/scripts/utils/runTx.js
+++ b/scripts/utils/runTx.js
@@ -1,6 +1,22 @@
 const ethers = require('ethers');
 
-async function runTx({ tx, provider }) {
+async function runTx({ txPromise, provider }) {
+	let tx;
+
+	// Method interaction => TransactionRequest
+	try {
+		tx = await txPromise;
+	} catch (error) {
+		error.tx = tx;
+		error.reason = error.error;
+
+		return {
+			success: false,
+			error,
+		}
+	}
+
+	// TransactionRequest => TransactionReceipt
 	try {
 		const receipt = await tx.wait();
 

--- a/scripts/utils/runTx.js
+++ b/scripts/utils/runTx.js
@@ -16,7 +16,7 @@ async function runTx({ txPromise, provider }) {
 		}
 	}
 
-	// TransactionRequest => TransactionReceipt
+	// TransactionResponse => TransactionReceipt
 	try {
 		const receipt = await tx.wait();
 

--- a/scripts/utils/runTx.js
+++ b/scripts/utils/runTx.js
@@ -13,7 +13,7 @@ async function runTx({ txPromise, provider }) {
 		return {
 			success: false,
 			error,
-		}
+		};
 	}
 
 	// TransactionResponse => TransactionReceipt


### PR DESCRIPTION
Ethers transaction lifecycle is:
1. TransactionRequest => A simple object describing a transaction
2. TransactionResponse => A receipt from the VM once it has been submitted to the network.
3. TransactionReceipt => A receipt for after the transaction has been mined.

The `runTx` script utility is designed to catch errors so that errors can be printed out in the console without breaking program execution. Before this PR, it was only catching errors between steps 2 & 3, and not between 1 & 2.