### PR TITLE
Implements two gas reports, one for unit tests, and another for prod tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,7 +56,7 @@ commands:
             - fork_start:
                 network: << parameters.network >>
                 reset: true
-            - run: npm run test:prod:gas
+            - run: npm run test:prod:gas && npx codechecks codechecks.prod.yml
     testnet_pvt:
         description: Run testnet PVT
         parameters:
@@ -131,7 +131,7 @@ jobs:
             - checkout
             - attach_workspace:
                 at: .
-            - run: npm run test:gas && npx codechecks
+            - run: npm run test:gas && npx codechecks codechecks.unit.yml
         working_directory: ~/repo
     lint:
         docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,7 +371,10 @@ workflows:
                     - prepare
     forkprod-tests:
         jobs:
-            - prepare
+            - prepare:
+                filters:
+                    branches:
+                        only: develop
             - fork-prepare-deploy:
                 name: fork-prepare-deploy-mainnet
                 network: mainnet

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,10 +371,7 @@ workflows:
                     - prepare
     forkprod-tests:
         jobs:
-            - prepare:
-                filters:
-                    branches:
-                        only: develop
+            - prepare
             - fork-prepare-deploy:
                 name: fork-prepare-deploy-mainnet
                 network: mainnet

--- a/.circleci/src/commands/fork_test_prod.yml
+++ b/.circleci/src/commands/fork_test_prod.yml
@@ -6,4 +6,4 @@ steps:
   - fork_start:
       network: << parameters.network >>
       reset: true
-  - run: npm run test:prod:gas
+  - run: npm run test:prod:gas && npx codechecks codechecks.prod.yml

--- a/.circleci/src/jobs/gas-report.yml
+++ b/.circleci/src/jobs/gas-report.yml
@@ -5,4 +5,4 @@ steps:
   - checkout
   - attach_workspace:
       at: .
-  - run: npm run test:gas && npx codechecks
+  - run: npm run test:gas && npx codechecks codechecks.unit.yml

--- a/.circleci/src/workflows/forkprod-tests.yml
+++ b/.circleci/src/workflows/forkprod-tests.yml
@@ -1,9 +1,8 @@
 jobs:
-  - prepare
-  # - prepare:
-      # filters:
-      #   branches:
-      #     only: develop
+  - prepare:
+      filters:
+        branches:
+          only: develop
   # ~~~~~~~~~~~~~~~ MAINNET ~~~~~~~~~~~~~~~ #
   - fork-prepare-deploy:
       name: fork-prepare-deploy-mainnet

--- a/.circleci/src/workflows/forkprod-tests.yml
+++ b/.circleci/src/workflows/forkprod-tests.yml
@@ -1,8 +1,9 @@
 jobs:
-  - prepare:
-      filters:
-        branches:
-          only: develop
+  - prepare
+  # - prepare:
+      # filters:
+      #   branches:
+      #     only: develop
   # ~~~~~~~~~~~~~~~ MAINNET ~~~~~~~~~~~~~~~ #
   - fork-prepare-deploy:
       name: fork-prepare-deploy-mainnet

--- a/buidler.config.js
+++ b/buidler.config.js
@@ -306,6 +306,7 @@ module.exports = {
 		enabled: false,
 		showTimeSpent: true,
 		currency: 'USD',
+		maxMethodDiff: 25, // CI will fail if gas usage is > than this %
 		outputFile: 'test-gas-used.log',
 	},
 };

--- a/codechecks.prod.yml
+++ b/codechecks.prod.yml
@@ -1,0 +1,8 @@
+checks:
+  - name: eth-gas-reporter/codechecks
+    options:
+      name: prod-test-gas-report
+settings:
+  branches:
+    - develop
+    - master

--- a/codechecks.unit.yml
+++ b/codechecks.unit.yml
@@ -1,5 +1,7 @@
 checks:
   - name: eth-gas-reporter/codechecks
+    options:
+      name: unit-test-gas-report
 settings:
   branches:
     - develop

--- a/package-lock.json
+++ b/package-lock.json
@@ -13385,12 +13385,12 @@
 			"dev": true
 		},
 		"buidler-gas-reporter": {
-			"version": "0.1.4-beta.4",
-			"resolved": "https://registry.npmjs.org/buidler-gas-reporter/-/buidler-gas-reporter-0.1.4-beta.4.tgz",
-			"integrity": "sha512-NQdwBrPnfdpefnLkuc7EYTPGujh8uJCJxR/SOI3IdADEMS0pGyVOuWBbmbY4n5EOXZqXN3bWy9jDMF3qS6wZRw==",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/buidler-gas-reporter/-/buidler-gas-reporter-0.1.4.tgz",
+			"integrity": "sha512-objSu/tGggxKDmlpZViM9uEKRSo7vXxBsPv+vXegre1AWapJXQNfJPtBmrNvnT5Ixl8pecWSRXsfO95nJAn4yw==",
 			"dev": true,
 			"requires": {
-				"eth-gas-reporter": "^0.2.18-beta.4"
+				"eth-gas-reporter": "^0.2.18"
 			}
 		},
 		"builtin-status-codes": {
@@ -15678,13 +15678,13 @@
 			}
 		},
 		"eth-gas-reporter": {
-			"version": "0.2.18-beta.4",
-			"resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.2.18-beta.4.tgz",
-			"integrity": "sha512-MGvwZsxo1ASzE3qG2WJXqYGgssGwOfUXmOQ3YXulP9kN0AhR0OOQaIaYvFlU15JExk1dQT1YZB38obb8xp37xw==",
+			"version": "0.2.18",
+			"resolved": "https://registry.npmjs.org/eth-gas-reporter/-/eth-gas-reporter-0.2.18.tgz",
+			"integrity": "sha512-P6LQ1QmU9bqU4zmd01Ws/b2EWAD5rT771U0wyJ/c+fKE6RdE9ks8KzjdR1zjosV2uilMfqVTtrBrXveCOnaTyQ==",
 			"dev": true,
 			"requires": {
 				"@ethersproject/abi": "^5.0.0-beta.146",
-				"@solidity-parser/parser": "^0.5.2",
+				"@solidity-parser/parser": "^0.8.0",
 				"cli-table3": "^0.5.0",
 				"colors": "^1.1.2",
 				"ethereumjs-util": "6.2.0",
@@ -15700,6 +15700,12 @@
 				"sync-request": "^6.0.0"
 			},
 			"dependencies": {
+				"@solidity-parser/parser": {
+					"version": "0.8.1",
+					"resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.8.1.tgz",
+					"integrity": "sha512-DF7H6T8I4lo2IZOE2NZwt3631T8j1gjpQLjmvY2xBNK50c4ltslR4XPKwT6RkeSd4+xCAK0GHC/k7sbRDBE4Yw==",
+					"dev": true
+				},
 				"ansi-colors": {
 					"version": "3.2.3",
 					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
@@ -17274,9 +17280,9 @@
 			}
 		},
 		"flat": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.0.tgz",
-			"integrity": "sha512-Px/TiLIznH7gEDlPXcUD4KnBusa6kR6ayRUVcnEAbreRIuhkqow/mun59BuRXwoYk7ZQOLW1ZM05ilIvK38hFw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/flat/-/flat-4.1.1.tgz",
+			"integrity": "sha512-FmTtBsHskrU6FJ2VxCnsDb84wu9zhmO3cUX2kGFb5tuwhfXxGciiT0oRY+cck35QmG+NmGh5eLz6lLCpWTqwpA==",
 			"requires": {
 				"is-buffer": "~2.0.3"
 			}
@@ -36148,9 +36154,9 @@
 			}
 		},
 		"nan": {
-			"version": "2.14.1",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+			"version": "2.14.2",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+			"integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
 		},
 		"nano-json-stream-parser": {
 			"version": "0.1.2",
@@ -37128,9 +37134,9 @@
 					"dev": true
 				},
 				"emoji-regex": {
-					"version": "9.0.0",
-					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.0.0.tgz",
-					"integrity": "sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==",
+					"version": "9.1.1",
+					"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.1.1.tgz",
+					"integrity": "sha512-AaWyDiNO9rbtMIcGl7tdxMcNu8SOLaDLxmQEFT5JhgKufOJzPPkYmgN2QwqTgw4doWMZZQttC6sUWVQjb+1VdA==",
 					"dev": true
 				},
 				"escape-string-regexp": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
 		"axios": "0.19.2",
 		"bn.js": "4.11.8",
 		"buidler-ast-doc": "0.0.14-rc",
-		"buidler-gas-reporter": "^0.1.4-beta.3",
+		"buidler-gas-reporter": "^0.1.4",
 		"chai": "4.2.0",
 		"chalk": "^2.4.2",
 		"concurrently": "5.2.0",


### PR DESCRIPTION
I requested this feature in eth-gas-reporter: https://github.com/cgewecke/eth-gas-reporter/issues/217

This produces a new gas report in the "Checks" section and causes CI to fail if a method call consumes more than 25% than it did before.

Note that the "prod gas report" will only be produced on commits to the develop branch.