### PR TITLE
Use preferred mainnet provider if available

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 ETHERSCAN_KEY=SomeEtherscanKey
-PROVIDER_URL=https://network.infura.io/v3/SomeInfuraKey
-DEPLOY_PRIVATE_KEY= new one SomeEthereumPrivateKey (including 0x prefix)
-TESTNET_DEPLOY_PRIVATE_KEY=new one SomeEthereumPrivateKey (including 0x prefix)
+PROVIDER_URL=https://network.infura.io/v3/SomeInfuraKey (runtime replaces "network")
+PROVIDER_URL_MAINNET=https://mainnet.infura.io/v3/SomeInfuraKey
+DEPLOY_PRIVATE_KEY=SomeEthereumPrivateKey (including 0x prefix)
+TESTNET_DEPLOY_PRIVATE_KEY=SomeEthereumPrivateKey (including 0x prefix)
 CIRCLECI_TOKEN=Create one via https://app.circleci.com/settings/user/tokens

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -58,7 +58,7 @@ const deploy = async ({
 	dryRun = false,
 	forceUpdateInverseSynthsOnTestnet = false,
 	useFork,
-	providerUrl: specifiedProviderUrl,
+	providerUrl,
 	useOvm,
 	freshDeploy,
 	manageNonces,
@@ -159,11 +159,18 @@ const deploy = async ({
 	// now get the latest time a Solidity file was edited
 	const latestSolTimestamp = getLatestSolTimestamp(CONTRACTS_FOLDER);
 
-	const { providerUrl, privateKey: envPrivateKey, etherscanLinkPrefix } = loadConnections({
+	const { providerUrl: envProviderUrl, privateKey: envPrivateKey, etherscanLinkPrefix } = loadConnections({
 		network,
-		useFork,
-		specifiedProviderUrl,
+		useFork
 	});
+
+	if (!providerUrl) {
+		if (!envProviderUrl) {
+			throw new Error('Missing .env key of PROVIDER_URL. Please add and retry.');
+		}
+
+		providerUrl = envProviderUrl;
+	}
 
 	// if not specified, or in a local network, override the private key passed as a CLI option, with the one specified in .env
 	if (network !== 'local' || !privateKey) {

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -159,9 +159,13 @@ const deploy = async ({
 	// now get the latest time a Solidity file was edited
 	const latestSolTimestamp = getLatestSolTimestamp(CONTRACTS_FOLDER);
 
-	const { providerUrl: envProviderUrl, privateKey: envPrivateKey, etherscanLinkPrefix } = loadConnections({
+	const {
+		providerUrl: envProviderUrl,
+		privateKey: envPrivateKey,
+		etherscanLinkPrefix,
+	} = loadConnections({
 		network,
-		useFork
+		useFork,
 	});
 
 	if (!providerUrl) {

--- a/publish/src/util.js
+++ b/publish/src/util.js
@@ -112,20 +112,18 @@ const getEtherscanLinkPrefix = network => {
 	return `https://${network !== 'mainnet' ? network + '.' : ''}etherscan.io`;
 };
 
-const loadConnections = ({ network, useFork, specifiedProviderUrl }) => {
-	if (!specifiedProviderUrl && network !== 'local' && !process.env.PROVIDER_URL) {
-		throw Error('Missing .env key of PROVIDER_URL. Please add and retry.');
-	}
-
+const loadConnections = ({ network, useFork }) => {
 	// Note: If using a fork, providerUrl will need to be 'localhost', even if the target network is not 'local'.
 	// This is because the fork command is assumed to be running at 'localhost:8545'.
 	let providerUrl;
-	if (specifiedProviderUrl) {
-		providerUrl = specifiedProviderUrl;
-	} else if (network === 'local' || useFork) {
+	if (network === 'local' || useFork) {
 		providerUrl = 'http://127.0.0.1:8545';
 	} else {
-		providerUrl = process.env.PROVIDER_URL.replace('network', network);
+		if (process.env.PROVIDER_URL_MAINNET) {
+			providerUrl = process.env.PROVIDER_URL_MAINNET;
+		} else {
+			providerUrl = process.env.PROVIDER_URL.replace('network', network);
+		}
 	}
 
 	const privateKey =
@@ -137,6 +135,7 @@ const loadConnections = ({ network, useFork, specifiedProviderUrl }) => {
 			: `https://api-${network}.etherscan.io/api`;
 
 	const etherscanLinkPrefix = getEtherscanLinkPrefix(network);
+
 	return { providerUrl, privateKey, etherscanUrl, etherscanLinkPrefix };
 };
 


### PR DESCRIPTION
Adds a new PROVIDER_URL_MAINNET to .env. Scripts like deploy, fork, etc will use this provider instead of PROVIDER_URL if available.

Should be handy for using a specialized provider for mainnet in CI production tests.