### PR TITLE
Remove solhint warning

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -32,6 +32,7 @@
 		"func-name-mixedcase": "warn",
 		"contract-name-camelcase": "warn",
 		"multiple-sends": "warn",
-		"reentrancy": "warn"
+		"reentrancy": "warn",
+		"max-states-count": ["warn", 17]
 	}
 }


### PR DESCRIPTION
Adds a rule to .solhint.json, to allow 17 state declaration counts and remove the warning being emitted in contracts/EtherCollateralsUSD.sol

<img width="683" alt="Screen Shot 2020-11-06 at 14 38 10" src="https://user-images.githubusercontent.com/550409/98397194-ba8f9d00-203d-11eb-83f9-0cd0f43bd23a.png">
