### PR TITLE
Enables production tests on local environments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -427,6 +427,11 @@ workflows:
           network: kovan
           requires:
             - job-prepare
+      - job-production-tests:
+          name: job-production-tests-mainnet
+          network: mainnet
+          requires:
+            - job-prepare
       - job-production-tests-local:
           filters:
             branches:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,9 +133,8 @@ jobs:
           at: .
       - run: node publish build
       - cmd-local-start
-      - run: node publish deploy --network local --fresh-deploy --private-key 0xc5e8f61d1ab959b397eecc0a37a6517b8e67a0e7cf1f4bce5591f3ed80199122 --yes --use-ovm --ignore-safety-checks --ignore-custom-parameters
+      - run: node publish deploy --network local --fresh-deploy --private-key 0xc5e8f61d1ab959b397eecc0a37a6517b8e67a0e7cf1f4bce5591f3ed80199122 --yes --use-ovm --ignore-safety-checks --ignore-custom-parameters --deployment-path ./publish/deployed/local-ovm
       - run: npm run test:prod -- --deployment-path ./publish/deployed/local-ovm
-      - run: npm run test:prod
     working_directory: ~/repo
   job-static-analysis:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,13 @@ commands:
           background: true
           command: node publish fork --network << parameters.network >> <<# parameters.reset >> --reset <</ parameters.reset >>
       - cmd-wait-for-rpc
+  cmd-local-start:
+    description: Starts a local ganache chain
+    steps:
+      - run:
+          background: true
+          command: npx buidler node
+      - cmd-wait-for-rpc
   cmd-wait-for-rpc:
     steps:
       - run: sleep 5
@@ -113,7 +120,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: node publish build
-      - run: npx buidler node
+      - cmd-local-start
       - run: node publish deploy --network local --fresh-deploy --private-key 0xc5e8f61d1ab959b397eecc0a37a6517b8e67a0e7cf1f4bce5591f3ed80199122 --yes
       - run: npm run test:prod
     working_directory: ~/repo
@@ -125,7 +132,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: node publish build
-      - run: npx buidler node
+      - cmd-local-start
       - run: node publish deploy --network local --fresh-deploy --private-key 0xc5e8f61d1ab959b397eecc0a37a6517b8e67a0e7cf1f4bce5591f3ed80199122 --yes --use-ovm --ignore-safety-checks --ignore-custom-parameters
       - run: npm run test:prod -- --deployment-path ./publish/deployed/local-ovm
       - run: npm run test:prod

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,31 @@ jobs:
       - store_artifacts:
           path: test-gas-used-prod.log
     working_directory: ~/repo
+  job-production-tests-local:
+    docker:
+      - image: circleci/node:12.18
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: node publish build
+      - run: npx buidler node
+      - run: node publish deploy --network local --fresh-deploy --private-key 0xc5e8f61d1ab959b397eecc0a37a6517b8e67a0e7cf1f4bce5591f3ed80199122 --yes
+      - run: npm run test:prod
+    working_directory: ~/repo
+  job-production-tests-local-ovm:
+    docker:
+      - image: circleci/node:12.18
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run: node publish build
+      - run: npx buidler node
+      - run: node publish deploy --network local --fresh-deploy --private-key 0xc5e8f61d1ab959b397eecc0a37a6517b8e67a0e7cf1f4bce5591f3ed80199122 --yes --use-ovm --ignore-safety-checks --ignore-custom-parameters
+      - run: npm run test:prod -- --deployment-path ./publish/deployed/local-ovm
+      - run: npm run test:prod
+    working_directory: ~/repo
   job-static-analysis:
     docker:
       - image: trailofbits/eth-security-toolbox
@@ -351,6 +376,14 @@ workflows:
           network: mainnet
           requires:
             - job-prepare
+      - job-production-tests-local:
+          name: job-production-tests-local
+          requires:
+            - job-prepare
+      - job-production-tests-local-ovm:
+          name: job-production-tests-local-ovm
+          requires:
+            - job-prepare
     triggers:
       - schedule:
           cron: "* 0 * * *"
@@ -392,6 +425,20 @@ workflows:
               only: /.*(staging|master).*/
           name: job-validate-deployments-kovan
           network: kovan
+          requires:
+            - job-prepare
+      - job-production-tests-local:
+          filters:
+            branches:
+              only: /.*(staging|master).*/
+          name: job-production-tests-local
+          requires:
+            - job-prepare
+      - job-production-tests-local-ovm:
+          filters:
+            branches:
+              only: /.*(staging|master).*/
+          name: job-production-tests-local-ovm
           requires:
             - job-prepare
       - job-production-tests-differential:

--- a/.circleci/src/commands/cmd-local-start.yml
+++ b/.circleci/src/commands/cmd-local-start.yml
@@ -1,0 +1,7 @@
+# Starts a local chain
+description: Starts a local ganache chain
+steps:
+  - run:
+      command: npx buidler node
+      background: true
+  - cmd-wait-for-rpc

--- a/.circleci/src/jobs/job-production-tests-differential.yml
+++ b/.circleci/src/jobs/job-production-tests-differential.yml
@@ -1,4 +1,4 @@
-# Simulates a deployment in a form, and runs production tests against it
+# Simulates a deployment in a fork, and runs production tests against it
 working_directory: ~/repo
 docker:
   - image: circleci/node:12.18

--- a/.circleci/src/jobs/job-production-tests-local-ovm.yml
+++ b/.circleci/src/jobs/job-production-tests-local-ovm.yml
@@ -9,7 +9,7 @@ steps:
   # Compile
   - run: node publish build
   # Start local chain
-  - run: npx buidler node
+  - cmd-local-start
   # Deploy
   - run: node publish deploy --network local --fresh-deploy --private-key 0xc5e8f61d1ab959b397eecc0a37a6517b8e67a0e7cf1f4bce5591f3ed80199122 --yes --use-ovm --ignore-safety-checks --ignore-custom-parameters
   # Run production tests

--- a/.circleci/src/jobs/job-production-tests-local-ovm.yml
+++ b/.circleci/src/jobs/job-production-tests-local-ovm.yml
@@ -1,0 +1,17 @@
+# Simulates a deployment of an ovm configuration in a local chain, and runs production tests against it
+working_directory: ~/repo
+docker:
+  - image: circleci/node:12.18
+steps:
+  - checkout
+  - attach_workspace:
+      at: .
+  # Compile
+  - run: node publish build
+  # Start local chain
+  - run: npx buidler node
+  # Deploy
+  - run: node publish deploy --network local --fresh-deploy --private-key 0xc5e8f61d1ab959b397eecc0a37a6517b8e67a0e7cf1f4bce5591f3ed80199122 --yes --use-ovm --ignore-safety-checks --ignore-custom-parameters
+  # Run production tests
+  - run: npm run test:prod -- --deployment-path ./publish/deployed/local-ovm
+  - run: npm run test:prod

--- a/.circleci/src/jobs/job-production-tests-local-ovm.yml
+++ b/.circleci/src/jobs/job-production-tests-local-ovm.yml
@@ -11,7 +11,6 @@ steps:
   # Start local chain
   - cmd-local-start
   # Deploy
-  - run: node publish deploy --network local --fresh-deploy --private-key 0xc5e8f61d1ab959b397eecc0a37a6517b8e67a0e7cf1f4bce5591f3ed80199122 --yes --use-ovm --ignore-safety-checks --ignore-custom-parameters
+  - run: node publish deploy --network local --fresh-deploy --private-key 0xc5e8f61d1ab959b397eecc0a37a6517b8e67a0e7cf1f4bce5591f3ed80199122 --yes --use-ovm --ignore-safety-checks --ignore-custom-parameters --deployment-path ./publish/deployed/local-ovm
   # Run production tests
   - run: npm run test:prod -- --deployment-path ./publish/deployed/local-ovm
-  - run: npm run test:prod

--- a/.circleci/src/jobs/job-production-tests-local.yml
+++ b/.circleci/src/jobs/job-production-tests-local.yml
@@ -1,0 +1,16 @@
+# Simulates a deployment in a local chain, and runs production tests against it
+working_directory: ~/repo
+docker:
+  - image: circleci/node:12.18
+steps:
+  - checkout
+  - attach_workspace:
+      at: .
+  # Compile
+  - run: node publish build
+  # Start local chain
+  - run: npx buidler node
+  # Deploy
+  - run: node publish deploy --network local --fresh-deploy --private-key 0xc5e8f61d1ab959b397eecc0a37a6517b8e67a0e7cf1f4bce5591f3ed80199122 --yes
+  # Run production tests
+  - run: npm run test:prod

--- a/.circleci/src/jobs/job-production-tests-local.yml
+++ b/.circleci/src/jobs/job-production-tests-local.yml
@@ -9,7 +9,7 @@ steps:
   # Compile
   - run: node publish build
   # Start local chain
-  - run: npx buidler node
+  - cmd-local-start
   # Deploy
   - run: node publish deploy --network local --fresh-deploy --private-key 0xc5e8f61d1ab959b397eecc0a37a6517b8e67a0e7cf1f4bce5591f3ed80199122 --yes
   # Run production tests

--- a/.circleci/src/workflows/workflow-scheduled.yml
+++ b/.circleci/src/workflows/workflow-scheduled.yml
@@ -19,3 +19,13 @@ jobs:
       network: mainnet
       requires:
         - job-prepare
+  # ~~~~~~~~~~~~ Differential production tests on LOCAL ~~~~~~~~~~~~~
+  - job-production-tests-local:
+      name: job-production-tests-local
+      requires:
+        - job-prepare
+  # ~~~~~~~~~~~~ Differential production tests on LOCAL with OVM config ~~~~~~~~~~~~~
+  - job-production-tests-local-ovm:
+      name: job-production-tests-local-ovm
+      requires:
+        - job-prepare

--- a/.circleci/src/workflows/workflow-staging.yml
+++ b/.circleci/src/workflows/workflow-staging.yml
@@ -38,6 +38,12 @@ jobs:
         - job-prepare
   # ~~~~~~~~~~~~ Deployment validation on ROPSTEN ~~~~~~~~~~~~~
   # Disabled because of recent attack to ropsten.
+  # ~~~~~~~~~~~~ Production tests on MAINNET ~~~~~~~~~~~~~
+  - job-production-tests:
+      name: job-production-tests-mainnet
+      network: mainnet
+      requires:
+        - job-prepare
   # ~~~~~~~~~~~~ Differential production tests on LOCAL ~~~~~~~~~~~~~
   - job-production-tests-local:
       name: job-production-tests-local

--- a/.circleci/src/workflows/workflow-staging.yml
+++ b/.circleci/src/workflows/workflow-staging.yml
@@ -38,6 +38,22 @@ jobs:
         - job-prepare
   # ~~~~~~~~~~~~ Deployment validation on ROPSTEN ~~~~~~~~~~~~~
   # Disabled because of recent attack to ropsten.
+  # ~~~~~~~~~~~~ Differential production tests on LOCAL ~~~~~~~~~~~~~
+  - job-production-tests-local:
+      name: job-production-tests-local
+      filters:
+        branches:
+          only: /.*(staging|master).*/
+      requires:
+        - job-prepare
+  # ~~~~~~~~~~~~ Differential production tests on LOCAL with OVM config ~~~~~~~~~~~~~
+  - job-production-tests-local-ovm:
+      name: job-production-tests-local-ovm
+      filters:
+        branches:
+          only: /.*(staging|master).*/
+      requires:
+        - job-prepare
   # ~~~~~~~~~~~~ Differential production tests on MAINNET ~~~~~~~~~~~~~
   - job-production-tests-differential:
       name: job-production-tests-differential-mainnet

--- a/buidler.config.js
+++ b/buidler.config.js
@@ -127,12 +127,14 @@ task('test:prod', 'run poduction tests against a running fork')
 	.addFlag('optimizer', 'Compile with the optimizer')
 	.addFlag('gas', 'Compile gas usage')
 	.addOptionalParam('gasOutputFile', 'Gas reporter output file')
+	.addOptionalParam('deploymentPath', 'Deployed data path')
 	.addOptionalVariadicPositionalParam('testFiles', 'An optional list of files to test', [])
 	.setAction(async (taskArguments, bre) => {
 		if (bre.network.name !== 'localhost') {
 			throw new Error('Prod testing needs to be run with --network localhost');
 		}
 
+		bre.config.deploymentPath = taskArguments.deploymentPath;
 		bre.config.paths.tests = './test/prod/';
 
 		// Prod tests use forking, which means some txs could last minutes.

--- a/index.js
+++ b/index.js
@@ -354,7 +354,11 @@ const getUsers = ({ network = 'mainnet', user, useOvm = false } = {}) => {
 		ropsten: Object.assign({}, base),
 		goerli: Object.assign({}, base),
 		'goerli-ovm': Object.assign({}, base),
+		local: Object.assign({}, base),
 	};
+
+	// Deterministic account #0 when using `npx buidler node`
+	map.local.owner = '0xc783df8a850f42e7F7e57013759C285caa701eB6';
 
 	const users = Object.entries(
 		map[getFolderNameForNetwork({ network, useOvm })]

--- a/publish/deployed/local-ovm/config.json
+++ b/publish/deployed/local-ovm/config.json
@@ -127,5 +127,8 @@
 	},
 	"SynthsETH": {
 		"deploy": true
+	},
+	"SynthetixBridgeToBase": {
+		"deploy": true
 	}
 }

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -62,6 +62,7 @@ const deploy = async ({
 	freshDeploy,
 	manageNonces,
 	ignoreSafetyChecks,
+	ignoreCustomParameters,
 } = {}) => {
 	ensureNetwork(network);
 	deploymentPath = deploymentPath || getDeploymentPathForNetwork({ network, useOvm });
@@ -120,6 +121,10 @@ const deploy = async ({
 
 	const getDeployParameter = async name => {
 		const defaultParam = defaults[name];
+		if (ignoreCustomParameters) {
+			return defaultParam;
+		}
+
 		let effectiveValue = defaultParam;
 
 		const param = (params || []).find(p => p.name === name);
@@ -1838,6 +1843,11 @@ module.exports = {
 			.option(
 				'-i, --ignore-safety-checks',
 				'Ignores some validations regarding paths, compiler versions, etc.',
+				false
+			)
+			.option(
+				'--ignore-custom-parameters',
+				'Ignores deployment parameters specified in params.json',
 				false
 			)
 			.option(

--- a/test/prod/EtherCollateral.prod.js
+++ b/test/prod/EtherCollateral.prod.js
@@ -8,6 +8,7 @@ const {
 	connectContracts,
 	ensureAccountHasEther,
 	skipWaitingPeriod,
+	bootstrapLocal,
 } = require('./utils');
 
 contract('EtherCollateral (prod tests)', accounts => {
@@ -22,6 +23,10 @@ contract('EtherCollateral (prod tests)', accounts => {
 
 	before('prepare', async () => {
 		network = await detectNetworkName();
+
+		if (network === 'local') {
+			await bootstrapLocal();
+		}
 
 		({ EtherCollateral, SynthsETH, AddressResolver } = await connectContracts({
 			network,

--- a/test/prod/EtherCollateral.prod.js
+++ b/test/prod/EtherCollateral.prod.js
@@ -1,5 +1,7 @@
-const { contract } = require('@nomiclabs/buidler');
-const { getUsers } = require('../../index.js');
+const fs = require('fs');
+const path = require('path');
+const { contract, config } = require('@nomiclabs/buidler');
+const { wrap } = require('../../index.js');
 const { web3 } = require('@nomiclabs/buidler');
 const { assert } = require('../contracts/common');
 const { toUnit } = require('../utils')();
@@ -17,13 +19,19 @@ contract('EtherCollateral (prod tests)', accounts => {
 
 	let owner;
 
-	let network;
+	let network, deploymentPath;
 
 	let EtherCollateral, AddressResolver, Depot;
 	let SynthsETH, SynthsUSD;
 
-	before('prepare', async () => {
+	before('prepare', async function() {
 		network = await detectNetworkName();
+		const { getUsers, getPathToNetwork } = wrap({ network, fs, path });
+
+		deploymentPath = config.deploymentPath || getPathToNetwork(network);
+		if (deploymentPath.includes('ovm')) {
+			return this.skip();
+		}
 
 		if (network === 'local') {
 			await bootstrapLocal();

--- a/test/prod/EtherCollateral.prod.js
+++ b/test/prod/EtherCollateral.prod.js
@@ -53,13 +53,13 @@ contract('EtherCollateral (prod tests)', accounts => {
 		[owner] = getUsers({ network }).map(user => user.address);
 
 		await ensureAccountHasEther({
-			amount: toUnit('10'),
+			amount: toUnit('1'),
 			account: owner,
 			fromAccount: accounts[7],
 			network,
 		});
 		await ensureAccountHassUSD({
-			amount: toUnit('1000'),
+			amount: toUnit('100'),
 			account: owner,
 			fromAccount: owner,
 			network,
@@ -101,10 +101,12 @@ contract('EtherCollateral (prod tests)', accounts => {
 
 		describe('closing a loan', () => {
 			before('ensure depot has sUSD', async () => {
-				const amount = toUnit('200');
+				if (network === 'local') {
+					const amount = toUnit('20');
 
-				await SynthsUSD.approve(Depot.address, amount);
-				await Depot.depositSynths(amount);
+					await SynthsUSD.approve(Depot.address, amount);
+					await Depot.depositSynths(amount);
+				}
 			});
 
 			before('close loan', async () => {

--- a/test/prod/EtherCollateral.prod.js
+++ b/test/prod/EtherCollateral.prod.js
@@ -43,8 +43,8 @@ contract('EtherCollateral (prod tests)', accounts => {
 				{ contractName: 'EtherCollateral' },
 				{ contractName: 'Depot' },
 				{ contractName: 'AddressResolver' },
-				{ contractName: 'ProxysETH', abiName: 'Synth', alias: 'SynthsETH' },
-				{ contractName: 'ProxyERC20sUSD', abiName: 'Synth', alias: 'SynthsUSD' },
+				{ contractName: 'SynthsETH', abiName: 'Synth' },
+				{ contractName: 'SynthsUSD', abiName: 'Synth' },
 			],
 		}));
 
@@ -59,8 +59,8 @@ contract('EtherCollateral (prod tests)', accounts => {
 			network,
 		});
 		await ensureAccountHassUSD({
-			amount: toUnit('100'),
-			account: owner,
+			amount: toUnit('1000'),
+			account: user1,
 			fromAccount: owner,
 			network,
 		});
@@ -100,16 +100,22 @@ contract('EtherCollateral (prod tests)', accounts => {
 		});
 
 		describe('closing a loan', () => {
-			before('ensure depot has sUSD', async () => {
+			before(async () => {
 				if (network === 'local') {
-					const amount = toUnit('20');
+					const amount = toUnit('100');
 
-					await SynthsUSD.approve(Depot.address, amount);
-					await Depot.depositSynths(amount);
+					const balance = await SynthsUSD.balanceOf(Depot.address);
+					if (balance.lt(amount)) {
+						await SynthsUSD.approve(Depot.address, amount, {
+							from: user1,
+						});
+
+						await Depot.depositSynths(amount, {
+							from: user1,
+						});
+					}
 				}
-			});
 
-			before('close loan', async () => {
 				ethBalance = await web3.eth.getBalance(user1);
 				sEthBalance = await SynthsETH.balanceOf(user1);
 

--- a/test/prod/EtherCollateral.prod.js
+++ b/test/prod/EtherCollateral.prod.js
@@ -34,7 +34,7 @@ contract('EtherCollateral (prod tests)', accounts => {
 		}
 
 		if (network === 'local') {
-			await bootstrapLocal();
+			await bootstrapLocal({ deploymentPath });
 		}
 
 		({ EtherCollateral, SynthsETH, SynthsUSD, AddressResolver, Depot } = await connectContracts({

--- a/test/prod/ExchangeRates.prod.js
+++ b/test/prod/ExchangeRates.prod.js
@@ -1,5 +1,7 @@
-const { contract } = require('@nomiclabs/buidler');
-const { getUsers } = require('../../index.js');
+const fs = require('fs');
+const path = require('path');
+const { contract, config } = require('@nomiclabs/buidler');
+const { wrap } = require('../../index.js');
 const { assert } = require('../contracts/common');
 const { toUnit, fastForward } = require('../utils')();
 const {
@@ -18,19 +20,23 @@ contract('ExchangeRates (prod tests)', accounts => {
 
 	let owner;
 
-	let network;
+	let network, deploymentPath;
 
 	let ExchangeRates, AddressResolver, SystemSettings, Exchanger;
 
 	before('prepare', async () => {
 		network = await detectNetworkName();
+		const { getUsers, getPathToNetwork } = wrap({ network, fs, path });
+
+		deploymentPath = config.deploymentPath || getPathToNetwork(network);
 
 		if (network === 'local') {
-			await bootstrapLocal();
+			await bootstrapLocal({ deploymentPath });
 		}
 
 		({ ExchangeRates, AddressResolver, SystemSettings, Exchanger } = await connectContracts({
 			network,
+			deploymentPath,
 			requests: [
 				{ contractName: 'ExchangeRates' },
 				{ contractName: 'AddressResolver' },
@@ -39,7 +45,7 @@ contract('ExchangeRates (prod tests)', accounts => {
 			],
 		}));
 
-		await skipWaitingPeriod({ network });
+		await skipWaitingPeriod({ network, deploymentPath });
 
 		[owner] = getUsers({ network }).map(user => user.address);
 
@@ -48,12 +54,14 @@ contract('ExchangeRates (prod tests)', accounts => {
 			account: owner,
 			fromAccount: accounts[7],
 			network,
+			deploymentPath,
 		});
 		await ensureAccountHassUSD({
 			amount: toUnit('1000'),
 			account: user,
 			fromAccount: owner,
 			network,
+			deploymentPath,
 		});
 	});
 
@@ -72,6 +80,7 @@ contract('ExchangeRates (prod tests)', accounts => {
 		before(async () => {
 			await exchangeSynths({
 				network,
+				deploymentPath,
 				account: user,
 				fromCurrency: 'sUSD',
 				toCurrency: 'sETH',

--- a/test/prod/ExchangeRates.prod.js
+++ b/test/prod/ExchangeRates.prod.js
@@ -9,6 +9,7 @@ const {
 	ensureAccountHassUSD,
 	exchangeSynths,
 	skipWaitingPeriod,
+	bootstrapLocal,
 } = require('./utils');
 const { toBytes32 } = require('../..');
 
@@ -23,6 +24,10 @@ contract('ExchangeRates (prod tests)', accounts => {
 
 	before('prepare', async () => {
 		network = await detectNetworkName();
+
+		if (network === 'local') {
+			await bootstrapLocal();
+		}
 
 		({ ExchangeRates, AddressResolver, SystemSettings, Exchanger } = await connectContracts({
 			network,

--- a/test/prod/Synthetix.prod.js
+++ b/test/prod/Synthetix.prod.js
@@ -87,8 +87,8 @@ contract('Synthetix (prod tests)', accounts => {
 
 			assert.isFalse(debtLedgerLength > 0 && totalIssuedSynths === 0);
 		});
-
 	});
+
 	describe('erc20 functionality', () => {
 		addSnapshotBeforeRestoreAfter();
 

--- a/test/prod/Synthetix.prod.js
+++ b/test/prod/Synthetix.prod.js
@@ -186,14 +186,15 @@ contract('Synthetix (prod tests)', accounts => {
 			const user1BalanceBeforesUSD = await SynthsUSD.balanceOf(user1);
 			const user1BalanceBeforesETH = await SynthsETH.balanceOf(user1);
 
-			await Synthetix.exchange(toBytes32('sETH'), user1BalanceBeforesETH, toBytes32('sUSD'), {
+			const amount = toUnit('1');
+			await Synthetix.exchange(toBytes32('sETH'), amount, toBytes32('sUSD'), {
 				from: user1,
 			});
 
 			const user1BalanceAftersUSD = await SynthsUSD.balanceOf(user1);
 			const user1BalanceAftersETH = await SynthsETH.balanceOf(user1);
 
-			assert.bnEqual(user1BalanceAftersETH, toUnit('0'));
+			assert.bnEqual(user1BalanceAftersETH, user1BalanceBeforesETH.sub(amount));
 			assert.bnGt(user1BalanceAftersUSD, user1BalanceBeforesUSD);
 		});
 	});

--- a/test/prod/Synthetix.prod.js
+++ b/test/prod/Synthetix.prod.js
@@ -87,8 +87,8 @@ contract('Synthetix (prod tests)', accounts => {
 
 			assert.isFalse(debtLedgerLength > 0 && totalIssuedSynths === 0);
 		});
-	});
 
+	});
 	describe('erc20 functionality', () => {
 		addSnapshotBeforeRestoreAfter();
 

--- a/test/prod/Synthetix.prod.js
+++ b/test/prod/Synthetix.prod.js
@@ -12,6 +12,7 @@ const {
 	skipWaitingPeriod,
 	skipStakeTime,
 	writeSetting,
+	bootstrapLocal,
 } = require('./utils');
 
 contract('Synthetix (prod tests)', accounts => {
@@ -26,6 +27,10 @@ contract('Synthetix (prod tests)', accounts => {
 
 	before('prepare', async () => {
 		network = await detectNetworkName();
+
+		if (network === 'local') {
+			await bootstrapLocal();
+		}
 
 		({ Synthetix, SynthetixState, SynthsUSD, SynthsETH, AddressResolver } = await connectContracts({
 			network,

--- a/test/prod/Synthetix.prod.js
+++ b/test/prod/Synthetix.prod.js
@@ -176,7 +176,7 @@ contract('Synthetix (prod tests)', accounts => {
 			const user1BalanceAftersUSD = await SynthsUSD.balanceOf(user1);
 			const user1BalanceAftersETH = await SynthsETH.balanceOf(user1);
 
-			assert.bnEqual(user1BalanceAftersUSD, user1BalanceBeforesUSD.sub(amount));
+			assert.bnLt(user1BalanceAftersUSD, user1BalanceBeforesUSD);
 			assert.bnGt(user1BalanceAftersETH, user1BalanceBeforesETH);
 		});
 
@@ -194,7 +194,7 @@ contract('Synthetix (prod tests)', accounts => {
 			const user1BalanceAftersUSD = await SynthsUSD.balanceOf(user1);
 			const user1BalanceAftersETH = await SynthsETH.balanceOf(user1);
 
-			assert.bnEqual(user1BalanceAftersETH, user1BalanceBeforesETH.sub(amount));
+			assert.bnLt(user1BalanceAftersETH, user1BalanceBeforesETH);
 			assert.bnGt(user1BalanceAftersUSD, user1BalanceBeforesUSD);
 		});
 	});

--- a/test/prod/Synthetix.prod.js
+++ b/test/prod/Synthetix.prod.js
@@ -55,21 +55,21 @@ contract('Synthetix (prod tests)', accounts => {
 		[owner] = getUsers({ network }).map(user => user.address);
 
 		await ensureAccountHasEther({
-			amount: toUnit('10'),
+			amount: toUnit('1'),
 			account: owner,
 			fromAccount: accounts[7],
 			network,
 			deploymentPath,
 		});
 		await ensureAccountHassUSD({
-			amount: toUnit('1000'),
+			amount: toUnit('100'),
 			account: user1,
 			fromAccount: owner,
 			network,
 			deploymentPath,
 		});
 		await ensureAccountHasSNX({
-			amount: toUnit('1000'),
+			amount: toUnit('100'),
 			account: user1,
 			fromAccount: owner,
 			network,
@@ -105,7 +105,7 @@ contract('Synthetix (prod tests)', accounts => {
 			const user1BalanceBefore = await Synthetix.balanceOf(user1);
 			const user2BalanceBefore = await Synthetix.balanceOf(user2);
 
-			const amount = toUnit('100');
+			const amount = toUnit('10');
 			await Synthetix.transfer(user2, amount, {
 				from: user1,
 			});
@@ -134,7 +134,7 @@ contract('Synthetix (prod tests)', accounts => {
 		it('can issue sUSD', async () => {
 			const user1BalanceBefore = await SynthsUSD.balanceOf(user1);
 
-			const amount = toUnit('100');
+			const amount = toUnit('10');
 			await Synthetix.issueSynths(amount, {
 				from: user1,
 			});
@@ -155,7 +155,7 @@ contract('Synthetix (prod tests)', accounts => {
 
 			const user1BalanceAfter = await SynthsUSD.balanceOf(user1);
 
-			assert.bnEqual(user1BalanceAfter, toUnit('0'));
+			assert.bnLt(user1BalanceAfter, user1BalanceBefore);
 		});
 	});
 
@@ -168,7 +168,7 @@ contract('Synthetix (prod tests)', accounts => {
 			const user1BalanceBeforesUSD = await SynthsUSD.balanceOf(user1);
 			const user1BalanceBeforesETH = await SynthsETH.balanceOf(user1);
 
-			const amount = toUnit('100');
+			const amount = toUnit('10');
 			await Synthetix.exchange(toBytes32('sUSD'), amount, toBytes32('sETH'), {
 				from: user1,
 			});

--- a/test/prod/TradingRewards.prod.js
+++ b/test/prod/TradingRewards.prod.js
@@ -35,7 +35,7 @@ contract('TradingRewards (prod tests)', accounts => {
 		}
 
 		if (network === 'local') {
-			await bootstrapLocal();
+			await bootstrapLocal({ deploymentPath });
 		}
 
 		({ TradingRewards, AddressResolver, SystemSettings } = await connectContracts({
@@ -132,6 +132,7 @@ contract('TradingRewards (prod tests)', accounts => {
 			before(async () => {
 				({ exchangeLogs } = await exchangeSynths({
 					network,
+					withTradingRewards: true,
 					account: user,
 					fromCurrency: 'sUSD',
 					toCurrency: 'sETH',

--- a/test/prod/TradingRewards.prod.js
+++ b/test/prod/TradingRewards.prod.js
@@ -9,6 +9,7 @@ const {
 	ensureAccountHassUSD,
 	exchangeSynths,
 	skipWaitingPeriod,
+	bootstrapLocal,
 } = require('./utils');
 
 contract('TradingRewards (prod tests)', accounts => {
@@ -24,6 +25,10 @@ contract('TradingRewards (prod tests)', accounts => {
 
 	before('prepare', async () => {
 		network = await detectNetworkName();
+
+		if (network === 'local') {
+			await bootstrapLocal();
+		}
 
 		({ TradingRewards, AddressResolver, SystemSettings } = await connectContracts({
 			network,

--- a/test/prod/TradingRewards.prod.js
+++ b/test/prod/TradingRewards.prod.js
@@ -1,5 +1,7 @@
-const { contract } = require('@nomiclabs/buidler');
-const { getUsers } = require('../../index.js');
+const fs = require('fs');
+const path = require('path');
+const { contract, config } = require('@nomiclabs/buidler');
+const { wrap } = require('../../index.js');
 const { assert, addSnapshotBeforeRestoreAfter } = require('../contracts/common');
 const { toUnit } = require('../utils')();
 const {
@@ -17,14 +19,20 @@ contract('TradingRewards (prod tests)', accounts => {
 
 	let owner;
 
-	let network;
+	let network, deploymentPath;
 
 	let TradingRewards, AddressResolver, SystemSettings;
 
 	let exchangeLogs;
 
-	before('prepare', async () => {
+	before('prepare', async function() {
 		network = await detectNetworkName();
+		const { getUsers, getPathToNetwork } = wrap({ network, fs, path });
+
+		deploymentPath = config.deploymentPath || getPathToNetwork(network);
+		if (deploymentPath.includes('ovm')) {
+			return this.skip();
+		}
 
 		if (network === 'local') {
 			await bootstrapLocal();

--- a/test/prod/TradingRewards.prod.js
+++ b/test/prod/TradingRewards.prod.js
@@ -53,13 +53,13 @@ contract('TradingRewards (prod tests)', accounts => {
 		[owner] = getUsers({ network }).map(user => user.address);
 
 		await ensureAccountHasEther({
-			amount: toUnit('10'),
+			amount: toUnit('1'),
 			account: owner,
 			fromAccount: accounts[7],
 			network,
 		});
 		await ensureAccountHassUSD({
-			amount: toUnit('1000'),
+			amount: toUnit('100'),
 			account: user,
 			fromAccount: owner,
 			network,
@@ -100,7 +100,7 @@ contract('TradingRewards (prod tests)', accounts => {
 					account: user,
 					fromCurrency: 'sUSD',
 					toCurrency: 'sETH',
-					amount: toUnit('10'),
+					amount: toUnit('1'),
 				}));
 			});
 
@@ -136,7 +136,7 @@ contract('TradingRewards (prod tests)', accounts => {
 					account: user,
 					fromCurrency: 'sUSD',
 					toCurrency: 'sETH',
-					amount: toUnit('10'),
+					amount: toUnit('1'),
 				}));
 			});
 

--- a/test/prod/utils/bootstrapLocal.js
+++ b/test/prod/utils/bootstrapLocal.js
@@ -53,7 +53,7 @@ async function mockBridge() {
 	});
 
 	const mockAddress = '0x0000000000000000000000000000000000000001';
-	AddressResolver.importAddresses(
+	await AddressResolver.importAddresses(
 		['ovm:SynthetixBridgeToBase', 'base:SynthetixBridgeToOptimism', 'ext:Messenger'].map(toBytes32),
 		[mockAddress, mockAddress, mockAddress]
 	);
@@ -72,7 +72,10 @@ async function bootstrapLocal({ deploymentPath: _deploymentPath }) {
 
 	await simulateExchangeRates();
 	await takeDebtSnapshot();
-	await mockBridge();
+
+	if (deploymentPath.includes('ovm')) {
+		await mockBridge();
+	}
 }
 
 module.exports = {

--- a/test/prod/utils/bootstrapLocal.js
+++ b/test/prod/utils/bootstrapLocal.js
@@ -14,6 +14,8 @@ async function simulateExchangeRates() {
 
 	let currencyKeys = await Issuer.availableCurrencyKeys();
 	currencyKeys = currencyKeys.filter(key => key !== toBytes32('sUSD'));
+	const additionalKeys = ['ETH'].map(toBytes32); // The Depot uses the key "ETH" as opposed to "sETH" for its ether price
+	currencyKeys.push(...additionalKeys);
 
 	const ExchangeRates = await connectContract({
 		network,

--- a/test/prod/utils/bootstrapLocal.js
+++ b/test/prod/utils/bootstrapLocal.js
@@ -45,11 +45,34 @@ async function takeDebtSnapshot() {
 	await DebtCache.takeDebtSnapshot();
 }
 
+async function mockBridge() {
+	const AddressResolver = await connectContract({
+		network,
+		deploymentPath,
+		contractName: 'AddressResolver',
+	});
+
+	const mockAddress = '0x0000000000000000000000000000000000000001';
+	AddressResolver.importAddresses(
+		['ovm:SynthetixBridgeToBase', 'base:SynthetixBridgeToOptimism', 'ext:Messenger'].map(toBytes32),
+		[mockAddress, mockAddress, mockAddress]
+	);
+
+	const SynthetixBridgeToBase = await connectContract({
+		network,
+		deploymentPath,
+		contractName: 'SynthetixBridgeToBase',
+	});
+
+	await SynthetixBridgeToBase.setResolverAndSyncCache(AddressResolver.address);
+}
+
 async function bootstrapLocal({ deploymentPath: _deploymentPath }) {
 	deploymentPath = _deploymentPath;
 
 	await simulateExchangeRates();
 	await takeDebtSnapshot();
+	await mockBridge();
 }
 
 module.exports = {

--- a/test/prod/utils/bootstrapLocal.js
+++ b/test/prod/utils/bootstrapLocal.js
@@ -1,0 +1,49 @@
+const testUtils = require('../../utils/index');
+const { toBytes32 } = require('../../..');
+const { connectContract } = require('./connectContract');
+const { web3 } = require('@nomiclabs/buidler');
+const { toWei } = require('web3-utils');
+
+const network = 'local';
+
+async function simulateExchangeRates() {
+	const Issuer = await connectContract({
+		network,
+		contractName: 'Issuer',
+	});
+
+	let currencyKeys = await Issuer.availableCurrencyKeys();
+	currencyKeys = currencyKeys.filter(key => key !== toBytes32('sUSD'));
+
+	const ExchangeRates = await connectContract({
+		network,
+		contractName: 'ExchangeRates',
+	});
+
+	const { currentTime } = testUtils({ web3 });
+	const now = await currentTime();
+
+	await ExchangeRates.updateRates(
+		currencyKeys,
+		currencyKeys.map(() => toWei('1')),
+		now
+	);
+}
+
+async function takeDebtSnapshot() {
+	const DebtCache = await connectContract({
+		network,
+		contractName: 'DebtCache',
+	});
+
+	await DebtCache.takeDebtSnapshot();
+}
+
+async function bootstrapLocal() {
+	await simulateExchangeRates();
+	await takeDebtSnapshot();
+}
+
+module.exports = {
+	bootstrapLocal,
+};

--- a/test/prod/utils/bootstrapLocal.js
+++ b/test/prod/utils/bootstrapLocal.js
@@ -5,10 +5,12 @@ const { web3 } = require('@nomiclabs/buidler');
 const { toWei } = require('web3-utils');
 
 const network = 'local';
+let deploymentPath;
 
 async function simulateExchangeRates() {
 	const Issuer = await connectContract({
 		network,
+		deploymentPath,
 		contractName: 'Issuer',
 	});
 
@@ -19,6 +21,7 @@ async function simulateExchangeRates() {
 
 	const ExchangeRates = await connectContract({
 		network,
+		deploymentPath,
 		contractName: 'ExchangeRates',
 	});
 
@@ -35,13 +38,16 @@ async function simulateExchangeRates() {
 async function takeDebtSnapshot() {
 	const DebtCache = await connectContract({
 		network,
+		deploymentPath,
 		contractName: 'DebtCache',
 	});
 
 	await DebtCache.takeDebtSnapshot();
 }
 
-async function bootstrapLocal() {
+async function bootstrapLocal({ deploymentPath: _deploymentPath }) {
+	deploymentPath = _deploymentPath;
+
 	await simulateExchangeRates();
 	await takeDebtSnapshot();
 }

--- a/test/prod/utils/connectContract.js
+++ b/test/prod/utils/connectContract.js
@@ -3,22 +3,23 @@ const path = require('path');
 const { artifacts } = require('@nomiclabs/buidler');
 const { wrap } = require('../../..');
 
-async function connectContract({ network, contractName, abiName = contractName }) {
+async function connectContract({ network, deploymentPath, contractName, abiName = contractName }) {
 	const { getTarget } = wrap({ network, fs, path });
-	const { address } = getTarget({ network, contract: contractName });
+	const { address } = getTarget({ network, deploymentPath, contract: contractName });
 
 	const Contract = artifacts.require(abiName);
 
 	return Contract.at(address);
 }
 
-async function connectContracts({ network, requests }) {
+async function connectContracts({ network, deploymentPath, requests }) {
 	const contracts = {};
 
 	await Promise.all(
 		requests.map(async ({ contractName, abiName = contractName, alias = contractName }) => {
 			contracts[alias] = await connectContract({
 				network,
+				deploymentPath,
 				contractName,
 				abiName,
 			});

--- a/test/prod/utils/connectContract.js
+++ b/test/prod/utils/connectContract.js
@@ -1,7 +1,10 @@
+const fs = require('fs');
+const path = require('path');
 const { artifacts } = require('@nomiclabs/buidler');
-const { getTarget } = require('../../..');
+const { wrap } = require('../../..');
 
 async function connectContract({ network, contractName, abiName = contractName }) {
+	const { getTarget } = wrap({ network, fs, path });
 	const { address } = getTarget({ network, contract: contractName });
 
 	const Contract = artifacts.require(abiName);

--- a/test/prod/utils/exchangeSynths.js
+++ b/test/prod/utils/exchangeSynths.js
@@ -1,24 +1,34 @@
 const { toBytes32 } = require('../../..');
-const { connectContract, connectContracts } = require('./connectContract');
+const { connectContract } = require('./connectContract');
 const { getDecodedLogs } = require('../../contracts/helpers');
 
-async function getExchangeLogs({ network, exchangeTx }) {
-	const { TradingRewards, Synthetix } = await connectContracts({
+async function getExchangeLogs({ network, deploymentPath, exchangeTx }) {
+	const Synthetix = await connectContract({
 		network,
-		requests: [{ contractName: 'TradingRewards' }, { contractName: 'Synthetix' }],
+		deploymentPath,
+		contractName: 'ProxyERC20',
+		abiName: 'Synthetix',
 	});
 
 	const logs = await getDecodedLogs({
 		hash: exchangeTx.tx,
-		contracts: [Synthetix, TradingRewards],
+		contracts: [Synthetix],
 	});
 
 	return logs.filter(log => log !== undefined);
 }
 
-async function exchangeSynths({ network, account, fromCurrency, toCurrency, amount }) {
+async function exchangeSynths({
+	network,
+	deploymentPath,
+	account,
+	fromCurrency,
+	toCurrency,
+	amount,
+}) {
 	const Synthetix = await connectContract({
 		network,
+		deploymentPath,
 		contractName: 'ProxyERC20',
 		abiName: 'Synthetix',
 	});
@@ -32,7 +42,7 @@ async function exchangeSynths({ network, account, fromCurrency, toCurrency, amou
 		}
 	);
 
-	const exchangeLogs = await getExchangeLogs({ network, exchangeTx });
+	const exchangeLogs = await getExchangeLogs({ network, deploymentPath, exchangeTx });
 
 	return { exchangeTx, exchangeLogs };
 }

--- a/test/prod/utils/getTokens.js
+++ b/test/prod/utils/getTokens.js
@@ -18,8 +18,8 @@ async function ensureAccountHasEther({ amount, account, fromAccount }) {
 	});
 }
 
-async function ensureAccountHasSNX({ network, amount, account, fromAccount }) {
-	const SNX = await connectContract({ network, contractName: 'ProxyERC20' });
+async function ensureAccountHasSNX({ network, deploymentPath, amount, account, fromAccount }) {
+	const SNX = await connectContract({ network, deploymentPath, contractName: 'ProxyERC20' });
 
 	const balance = toBN(await SNX.balanceOf(fromAccount));
 	if (balance.lt(amount)) {
@@ -33,16 +33,28 @@ async function ensureAccountHasSNX({ network, amount, account, fromAccount }) {
 	});
 }
 
-async function ensureAccountHassUSD({ network, amount, account, fromAccount }) {
-	const sUSD = await connectContract({ network, contractName: 'SynthsUSD', abiName: 'Synth' });
+async function ensureAccountHassUSD({ network, deploymentPath, amount, account, fromAccount }) {
+	const sUSD = await connectContract({
+		network,
+		deploymentPath,
+		contractName: 'SynthsUSD',
+		abiName: 'Synth',
+	});
 	const balance = toBN(await sUSD.transferableSynths(fromAccount));
 
 	if (balance.lt(amount)) {
 		const snxToTransfer = amount.mul(toBN('50'));
-		await ensureAccountHasSNX({ network, account, amount: snxToTransfer, fromAccount });
+		await ensureAccountHasSNX({
+			network,
+			deploymentPath,
+			account,
+			amount: snxToTransfer,
+			fromAccount,
+		});
 
 		const Synthetix = await connectContract({
 			network,
+			deploymentPath,
 			contractName: 'ProxyERC20',
 			abiName: 'Synthetix',
 		});
@@ -55,12 +67,13 @@ async function ensureAccountHassUSD({ network, amount, account, fromAccount }) {
 	}
 }
 
-async function ensureAccountHassETH({ network, amount, account, fromAccount }) {
+async function ensureAccountHassETH({ network, deploymentPath, amount, account, fromAccount }) {
 	const sUSDAmount = amount.mul(toBN('10'));
-	await ensureAccountHassUSD({ network, amount: sUSDAmount, account, fromAccount });
+	await ensureAccountHassUSD({ network, deploymentPath, amount: sUSDAmount, account, fromAccount });
 
 	const Synthetix = await connectContract({
 		network,
+		deploymentPath,
 		contractName: 'ProxyERC20',
 		abiName: 'Synthetix',
 	});

--- a/test/prod/utils/getTokens.js
+++ b/test/prod/utils/getTokens.js
@@ -38,7 +38,7 @@ async function ensureAccountHassUSD({ network, amount, account, fromAccount }) {
 	const balance = toBN(await sUSD.transferableSynths(fromAccount));
 
 	if (balance.lt(amount)) {
-		const snxToTransfer = amount.mul(toBN('10'));
+		const snxToTransfer = amount.mul(toBN('50'));
 		await ensureAccountHasSNX({ network, account, amount: snxToTransfer, fromAccount });
 
 		const Synthetix = await connectContract({

--- a/test/prod/utils/index.js
+++ b/test/prod/utils/index.js
@@ -4,6 +4,7 @@ const { ensureAccountHasEther, ensureAccountHasSNX, ensureAccountHassUSD } = req
 const { exchangeSynths } = require('./exchangeSynths');
 const { readSetting, writeSetting } = require('./systemSettings');
 const { skipWaitingPeriod, skipStakeTime } = require('./skipWaiting');
+const { bootstrapLocal } = require('./bootstrapLocal');
 
 module.exports = {
 	detectNetworkName,
@@ -17,4 +18,5 @@ module.exports = {
 	writeSetting,
 	skipWaitingPeriod,
 	skipStakeTime,
+	bootstrapLocal,
 };

--- a/test/prod/utils/skipWaiting.js
+++ b/test/prod/utils/skipWaiting.js
@@ -1,12 +1,12 @@
 const { fastForward } = require('../../utils')();
 const { readSetting } = require('./systemSettings');
 
-async function skipWaitingPeriod({ network }) {
-	await fastForward(await readSetting({ network, setting: 'waitingPeriodSecs' }));
+async function skipWaitingPeriod({ network, deploymentPath }) {
+	await fastForward(await readSetting({ network, deploymentPath, setting: 'waitingPeriodSecs' }));
 }
 
-async function skipStakeTime({ network }) {
-	await fastForward(await readSetting({ network, setting: 'minimumStakeTime' }));
+async function skipStakeTime({ network, deploymentPath }) {
+	await fastForward(await readSetting({ network, deploymentPath, setting: 'minimumStakeTime' }));
 }
 
 module.exports = {

--- a/test/prod/utils/systemSettings.js
+++ b/test/prod/utils/systemSettings.js
@@ -1,17 +1,19 @@
 const { connectContract } = require('./connectContract');
 
-async function readSetting({ network, setting }) {
+async function readSetting({ network, setting, deploymentPath }) {
 	const SystemSettings = await connectContract({
 		network,
+		deploymentPath,
 		contractName: 'SystemSettings',
 	});
 
 	return SystemSettings[setting]();
 }
 
-async function writeSetting({ network, setting, value, owner }) {
+async function writeSetting({ network, deploymentPath, setting, value, owner }) {
 	const SystemSettings = await connectContract({
 		network,
+		deploymentPath,
 		contractName: 'SystemSettings',
 	});
 


### PR DESCRIPTION
Allows starting a local chain with
`npx buidler node`

And running production tests against it:
`npm run test:prod`

The exact details of how to run the tests in each case can be found in the 2 new ci jobs that come in the PR:
`job-production-tests-local` and `job-production-tests-local-ovm`

The OVM tests compile regular EVM artifacts, but deploy an OVM configuration in the local chain. Note that this does not test the OVM bridge, simply that the deployed instance can perform basic production functionalities like transfer, exchange, etc.