### PR TITLE
Improved linting in pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	},
 	"husky": {
 		"hooks": {
-			"pre-commit": "./hooks/circleci && npm run lint && pretty-quick --staged"
+			"pre-commit": "./hooks/circleci && pretty-quick --staged --verbose"
 		}
 	},
 	"repository": {


### PR DESCRIPTION
After @justinjmoses' comment in a previous attempt to speed up linting in the pre-commit hook, I understood how `pretty-quick` works.

We don't need to run `npm run lint` in the hook. Running `pretty-quick --staged --verbose` (notice the extra `--verbose` is more than enough) and is incredibly fast.