### PR TITLE
RFC: Resolver cache overhaul

### DIFF
--- a/contracts/AddressResolver.sol
+++ b/contracts/AddressResolver.sol
@@ -2,9 +2,11 @@ pragma solidity ^0.5.16;
 
 // Inheritance
 import "./Owned.sol";
-
 import "./interfaces/IAddressResolver.sol";
+
+// Internal references
 import "./interfaces/IIssuer.sol";
+import "./MixinResolver.sol";
 
 
 // https://docs.synthetix.io/contracts/source/contracts/addressresolver
@@ -18,8 +20,16 @@ contract AddressResolver is Owned, IAddressResolver {
     function importAddresses(bytes32[] calldata names, address[] calldata destinations) external onlyOwner {
         require(names.length == destinations.length, "Input lengths must match");
 
+        // first add all destinations to the resolver
         for (uint i = 0; i < names.length; i++) {
             repository[names[i]] = destinations[i];
+        }
+
+        // then, attempt to update all caches as required
+        for (uint i = 0; i < names.length; i++) {
+            // solhint-disable avoid-low-level-calls
+            (bool success, ) = address(destinations[i]).call(abi.encodePacked(MixinResolver(0).invalidateCache.selector));
+            success; // supressing the compiler warning
         }
     }
 

--- a/contracts/AddressResolver.sol
+++ b/contracts/AddressResolver.sol
@@ -24,12 +24,12 @@ contract AddressResolver is Owned, IAddressResolver {
         for (uint i = 0; i < names.length; i++) {
             repository[names[i]] = destinations[i];
         }
+    }
 
+    function rebuildCaches(MixinResolver[] calldata destinations) external {
         // then, attempt to update all caches as required
-        for (uint i = 0; i < names.length; i++) {
-            // solhint-disable avoid-low-level-calls
-            (bool success, ) = address(destinations[i]).call(abi.encodePacked(MixinResolver(0).rebuildCache.selector));
-            success; // supressing the compiler warning
+        for (uint i = 0; i < destinations.length; i++) {
+            destinations[i].rebuildCache();
         }
     }
 

--- a/contracts/AddressResolver.sol
+++ b/contracts/AddressResolver.sol
@@ -28,7 +28,7 @@ contract AddressResolver is Owned, IAddressResolver {
         // then, attempt to update all caches as required
         for (uint i = 0; i < names.length; i++) {
             // solhint-disable avoid-low-level-calls
-            (bool success, ) = address(destinations[i]).call(abi.encodePacked(MixinResolver(0).invalidateCache.selector));
+            (bool success, ) = address(destinations[i]).call(abi.encodePacked(MixinResolver(0).rebuildCache.selector));
             success; // supressing the compiler warning
         }
     }

--- a/contracts/BinaryOptionMarket.sol
+++ b/contracts/BinaryOptionMarket.sol
@@ -124,19 +124,19 @@ contract BinaryOptionMarket is Owned, MixinResolver, IBinaryOptionMarket {
     /* ---------- External Contracts ---------- */
 
     function _systemStatus() internal view returns (ISystemStatus) {
-        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS, "Missing SystemStatus"));
+        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS));
     }
 
     function _exchangeRates() internal view returns (IExchangeRates) {
-        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES, "Missing ExchangeRates"));
+        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES));
     }
 
     function _sUSD() internal view returns (IERC20) {
-        return IERC20(requireAndGetAddress(CONTRACT_SYNTHSUSD, "Missing SynthsUSD"));
+        return IERC20(requireAndGetAddress(CONTRACT_SYNTHSUSD));
     }
 
     function _feePool() internal view returns (IFeePool) {
-        return IFeePool(requireAndGetAddress(CONTRACT_FEEPOOL, "Missing FeePool"));
+        return IFeePool(requireAndGetAddress(CONTRACT_FEEPOOL));
     }
 
     function _manager() internal view returns (BinaryOptionMarketManager) {

--- a/contracts/BinaryOptionMarket.sol
+++ b/contracts/BinaryOptionMarket.sol
@@ -79,6 +79,7 @@ contract BinaryOptionMarket is Owned, MixinResolver, IBinaryOptionMarket {
     constructor(
         address _owner,
         address _creator,
+        address _resolver,
         uint[2] memory _creatorLimits, // [capitalRequirement, skewLimit]
         bytes32 _oracleKey,
         uint _strikePrice,
@@ -86,11 +87,7 @@ contract BinaryOptionMarket is Owned, MixinResolver, IBinaryOptionMarket {
         uint[3] memory _times, // [biddingEnd, maturity, expiry]
         uint[2] memory _bids, // [longBid, shortBid]
         uint[3] memory _fees // [poolFee, creatorFee, refundFee]
-    )
-        public
-        Owned(_owner)
-        MixinResolver(_owner, addressesToCache) // The resolver is initially set to the owner, but it will be set correctly when the cache is synchronised
-    {
+    ) public Owned(_owner) MixinResolver(_resolver, addressesToCache) {
         creator = _creator;
         creatorLimits = BinaryOptionMarketManager.CreatorLimits(_creatorLimits[0], _creatorLimits[1]);
 

--- a/contracts/BinaryOptionMarketFactory.sol
+++ b/contracts/BinaryOptionMarketFactory.sol
@@ -49,6 +49,7 @@ contract BinaryOptionMarketFactory is Owned, MixinResolver {
             new BinaryOptionMarket(
                 manager,
                 creator,
+                address(resolver),
                 creatorLimits,
                 oracleKey,
                 strikePrice,

--- a/contracts/BinaryOptionMarketFactory.sol
+++ b/contracts/BinaryOptionMarketFactory.sol
@@ -27,7 +27,7 @@ contract BinaryOptionMarketFactory is Owned, MixinResolver {
     /* ---------- Related Contracts ---------- */
 
     function _manager() internal view returns (address) {
-        return requireAndGetAddress(CONTRACT_BINARYOPTIONMARKETMANAGER, "Missing BinaryOptionMarketManager address");
+        return requireAndGetAddress(CONTRACT_BINARYOPTIONMARKETMANAGER);
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */

--- a/contracts/BinaryOptionMarketManager.sol
+++ b/contracts/BinaryOptionMarketManager.sol
@@ -274,7 +274,6 @@ contract BinaryOptionMarketManager is Owned, Pausable, MixinResolver, IBinaryOpt
             bids,
             [fees.poolFee, fees.creatorFee, fees.refundFee]
         );
-        market.setResolverAndSyncCache(resolver);
         _activeMarkets.push(address(market));
 
         // The debt can't be incremented in the new market's constructor because until construction is complete,
@@ -317,12 +316,9 @@ contract BinaryOptionMarketManager is Owned, Pausable, MixinResolver, IBinaryOpt
 
     /* ---------- Upgrade and Administration ---------- */
 
-    function setResolverAndSyncCacheOnMarkets(AddressResolver _resolver, BinaryOptionMarket[] calldata marketsToSync)
-        external
-        onlyOwner
-    {
+    function invalidateMarketCaches(BinaryOptionMarket[] calldata marketsToSync) external {
         for (uint i = 0; i < marketsToSync.length; i++) {
-            marketsToSync[i].setResolverAndSyncCache(_resolver);
+            marketsToSync[i].invalidateCache();
         }
     }
 

--- a/contracts/BinaryOptionMarketManager.sol
+++ b/contracts/BinaryOptionMarketManager.sol
@@ -271,6 +271,7 @@ contract BinaryOptionMarketManager is Owned, Pausable, MixinResolver, IBinaryOpt
             bids,
             [fees.poolFee, fees.creatorFee, fees.refundFee]
         );
+        market.rebuildCache();
         _activeMarkets.push(address(market));
 
         // The debt can't be incremented in the new market's constructor because until construction is complete,
@@ -315,7 +316,7 @@ contract BinaryOptionMarketManager is Owned, Pausable, MixinResolver, IBinaryOpt
 
     function invalidateMarketCaches(BinaryOptionMarket[] calldata marketsToSync) external {
         for (uint i = 0; i < marketsToSync.length; i++) {
-            marketsToSync[i].invalidateCache();
+            marketsToSync[i].rebuildCache();
         }
     }
 

--- a/contracts/BinaryOptionMarketManager.sol
+++ b/contracts/BinaryOptionMarketManager.sol
@@ -105,22 +105,19 @@ contract BinaryOptionMarketManager is Owned, Pausable, MixinResolver, IBinaryOpt
     /* ---------- Related Contracts ---------- */
 
     function _systemStatus() internal view returns (ISystemStatus) {
-        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS, "Missing SystemStatus address"));
+        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS));
     }
 
     function _sUSD() internal view returns (IERC20) {
-        return IERC20(requireAndGetAddress(CONTRACT_SYNTHSUSD, "Missing SynthsUSD address"));
+        return IERC20(requireAndGetAddress(CONTRACT_SYNTHSUSD));
     }
 
     function _exchangeRates() internal view returns (IExchangeRates) {
-        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES, "Missing ExchangeRates"));
+        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES));
     }
 
     function _factory() internal view returns (BinaryOptionMarketFactory) {
-        return
-            BinaryOptionMarketFactory(
-                requireAndGetAddress(CONTRACT_BINARYOPTIONMARKETFACTORY, "Missing BinaryOptionMarketFactory address")
-            );
+        return BinaryOptionMarketFactory(requireAndGetAddress(CONTRACT_BINARYOPTIONMARKETFACTORY));
     }
 
     /* ---------- Market Information ---------- */

--- a/contracts/DebtCache.sol
+++ b/contracts/DebtCache.sol
@@ -62,28 +62,27 @@ contract DebtCache is Owned, MixinResolver, MixinSystemSettings, IDebtCache {
     /* ========== VIEWS ========== */
 
     function issuer() internal view returns (IIssuer) {
-        return IIssuer(requireAndGetAddress(CONTRACT_ISSUER, "Missing Issuer address"));
+        return IIssuer(requireAndGetAddress(CONTRACT_ISSUER));
     }
 
     function exchanger() internal view returns (IExchanger) {
-        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER, "Missing Exchanger address"));
+        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER));
     }
 
     function exchangeRates() internal view returns (IExchangeRates) {
-        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES, "Missing ExchangeRates address"));
+        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES));
     }
 
     function systemStatus() internal view returns (ISystemStatus) {
-        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS, "Missing SystemStatus address"));
+        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS));
     }
 
     function etherCollateral() internal view returns (IEtherCollateral) {
-        return IEtherCollateral(requireAndGetAddress(CONTRACT_ETHERCOLLATERAL, "Missing EtherCollateral address"));
+        return IEtherCollateral(requireAndGetAddress(CONTRACT_ETHERCOLLATERAL));
     }
 
     function etherCollateralsUSD() internal view returns (IEtherCollateralsUSD) {
-        return
-            IEtherCollateralsUSD(requireAndGetAddress(CONTRACT_ETHERCOLLATERAL_SUSD, "Missing EtherCollateralsUSD address"));
+        return IEtherCollateralsUSD(requireAndGetAddress(CONTRACT_ETHERCOLLATERAL_SUSD));
     }
 
     function debtSnapshotStaleTime() external view returns (uint) {

--- a/contracts/Depot.sol
+++ b/contracts/Depot.sol
@@ -501,15 +501,15 @@ contract Depot is Owned, Pausable, ReentrancyGuard, MixinResolver, IDepot {
     /* ========== INTERNAL VIEWS ========== */
 
     function synthsUSD() internal view returns (IERC20) {
-        return IERC20(requireAndGetAddress(CONTRACT_SYNTHSUSD, "Missing SynthsUSD address"));
+        return IERC20(requireAndGetAddress(CONTRACT_SYNTHSUSD));
     }
 
     function synthetix() internal view returns (IERC20) {
-        return IERC20(requireAndGetAddress(CONTRACT_SYNTHETIX, "Missing Synthetix address"));
+        return IERC20(requireAndGetAddress(CONTRACT_SYNTHETIX));
     }
 
     function exchangeRates() internal view returns (IExchangeRates) {
-        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES, "Missing ExchangeRates address"));
+        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES));
     }
 
     // ========== MODIFIERS ==========

--- a/contracts/EtherCollateral.sol
+++ b/contracts/EtherCollateral.sol
@@ -440,23 +440,23 @@ contract EtherCollateral is Owned, Pausable, ReentrancyGuard, MixinResolver, IEt
     /* ========== INTERNAL VIEWS ========== */
 
     function systemStatus() internal view returns (ISystemStatus) {
-        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS, "Missing SystemStatus address"));
+        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS));
     }
 
     function synthsETH() internal view returns (ISynth) {
-        return ISynth(requireAndGetAddress(CONTRACT_SYNTHSETH, "Missing SynthsETH address"));
+        return ISynth(requireAndGetAddress(CONTRACT_SYNTHSETH));
     }
 
     function synthsUSD() internal view returns (ISynth) {
-        return ISynth(requireAndGetAddress(CONTRACT_SYNTHSUSD, "Missing SynthsUSD address"));
+        return ISynth(requireAndGetAddress(CONTRACT_SYNTHSUSD));
     }
 
     function depot() internal view returns (IDepot) {
-        return IDepot(requireAndGetAddress(CONTRACT_DEPOT, "Missing Depot address"));
+        return IDepot(requireAndGetAddress(CONTRACT_DEPOT));
     }
 
     function exchangeRates() internal view returns (IExchangeRates) {
-        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES, "Missing ExchangeRates address"));
+        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES));
     }
 
     /* ========== MODIFIERS ========== */

--- a/contracts/EtherCollateralsUSD.sol
+++ b/contracts/EtherCollateralsUSD.sol
@@ -828,19 +828,19 @@ contract EtherCollateralsUSD is Owned, Pausable, ReentrancyGuard, MixinResolver,
     /* ========== INTERNAL VIEWS ========== */
 
     function systemStatus() internal view returns (ISystemStatus) {
-        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS, "Missing SystemStatus address"));
+        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS));
     }
 
     function synthsUSD() internal view returns (ISynth) {
-        return ISynth(requireAndGetAddress(CONTRACT_SYNTHSUSD, "Missing SynthsUSD address"));
+        return ISynth(requireAndGetAddress(CONTRACT_SYNTHSUSD));
     }
 
     function exchangeRates() internal view returns (IExchangeRates) {
-        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES, "Missing ExchangeRates address"));
+        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES));
     }
 
     function feePool() internal view returns (IFeePool) {
-        return IFeePool(requireAndGetAddress(CONTRACT_FEEPOOL, "Missing FeePool address"));
+        return IFeePool(requireAndGetAddress(CONTRACT_FEEPOOL));
     }
 
     /* ========== MODIFIERS ========== */

--- a/contracts/ExchangeRates.sol
+++ b/contracts/ExchangeRates.sol
@@ -443,7 +443,7 @@ contract ExchangeRates is Owned, MixinResolver, MixinSystemSettings, IExchangeRa
     /* ========== INTERNAL FUNCTIONS ========== */
 
     function exchanger() internal view returns (IExchanger) {
-        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER, "Missing Exchanger address"));
+        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER));
     }
 
     function getFlagsForRates(bytes32[] memory currencyKeys) internal view returns (bool[] memory flagList) {

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -122,39 +122,39 @@ contract Exchanger is Owned, MixinResolver, MixinSystemSettings, IExchanger {
     /* ========== VIEWS ========== */
 
     function systemStatus() internal view returns (ISystemStatus) {
-        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS, "Missing SystemStatus address"));
+        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS));
     }
 
     function exchangeState() internal view returns (IExchangeState) {
-        return IExchangeState(requireAndGetAddress(CONTRACT_EXCHANGESTATE, "Missing ExchangeState address"));
+        return IExchangeState(requireAndGetAddress(CONTRACT_EXCHANGESTATE));
     }
 
     function exchangeRates() internal view returns (IExchangeRates) {
-        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES, "Missing ExchangeRates address"));
+        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES));
     }
 
     function synthetix() internal view returns (ISynthetix) {
-        return ISynthetix(requireAndGetAddress(CONTRACT_SYNTHETIX, "Missing Synthetix address"));
+        return ISynthetix(requireAndGetAddress(CONTRACT_SYNTHETIX));
     }
 
     function feePool() internal view returns (IFeePool) {
-        return IFeePool(requireAndGetAddress(CONTRACT_FEEPOOL, "Missing FeePool address"));
+        return IFeePool(requireAndGetAddress(CONTRACT_FEEPOOL));
     }
 
     function tradingRewards() internal view returns (ITradingRewards) {
-        return ITradingRewards(requireAndGetAddress(CONTRACT_TRADING_REWARDS, "Missing TradingRewards address"));
+        return ITradingRewards(requireAndGetAddress(CONTRACT_TRADING_REWARDS));
     }
 
     function delegateApprovals() internal view returns (IDelegateApprovals) {
-        return IDelegateApprovals(requireAndGetAddress(CONTRACT_DELEGATEAPPROVALS, "Missing DelegateApprovals address"));
+        return IDelegateApprovals(requireAndGetAddress(CONTRACT_DELEGATEAPPROVALS));
     }
 
     function issuer() internal view returns (IIssuer) {
-        return IIssuer(requireAndGetAddress(CONTRACT_ISSUER, "Missing Issuer address"));
+        return IIssuer(requireAndGetAddress(CONTRACT_ISSUER));
     }
 
     function debtCache() internal view returns (IExchangerInternalDebtCache) {
-        return IExchangerInternalDebtCache(requireAndGetAddress(CONTRACT_DEBTCACHE, "Missing DebtCache address"));
+        return IExchangerInternalDebtCache(requireAndGetAddress(CONTRACT_DEBTCACHE));
     }
 
     function maxSecsLeftInWaitingPeriod(address account, bytes32 currencyKey) public view returns (uint) {

--- a/contracts/FeePool.sol
+++ b/contracts/FeePool.sol
@@ -111,52 +111,47 @@ contract FeePool is Owned, Proxyable, LimitedSetup, MixinResolver, MixinSystemSe
     /* ========== VIEWS ========== */
 
     function systemStatus() internal view returns (ISystemStatus) {
-        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS, "Missing SystemStatus address"));
+        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS));
     }
 
     function synthetix() internal view returns (ISynthetix) {
-        return ISynthetix(requireAndGetAddress(CONTRACT_SYNTHETIX, "Missing Synthetix address"));
+        return ISynthetix(requireAndGetAddress(CONTRACT_SYNTHETIX));
     }
 
     function feePoolState() internal view returns (FeePoolState) {
-        return FeePoolState(requireAndGetAddress(CONTRACT_FEEPOOLSTATE, "Missing FeePoolState address"));
+        return FeePoolState(requireAndGetAddress(CONTRACT_FEEPOOLSTATE));
     }
 
     function feePoolEternalStorage() internal view returns (FeePoolEternalStorage) {
-        return
-            FeePoolEternalStorage(
-                requireAndGetAddress(CONTRACT_FEEPOOLETERNALSTORAGE, "Missing FeePoolEternalStorage address")
-            );
+        return FeePoolEternalStorage(requireAndGetAddress(CONTRACT_FEEPOOLETERNALSTORAGE));
     }
 
     function exchanger() internal view returns (IExchanger) {
-        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER, "Missing Exchanger address"));
+        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER));
     }
 
     function etherCollateralsUSD() internal view returns (IEtherCollateralsUSD) {
-        return
-            IEtherCollateralsUSD(requireAndGetAddress(CONTRACT_ETH_COLLATERAL_SUSD, "Missing EtherCollateralsUSD address"));
+        return IEtherCollateralsUSD(requireAndGetAddress(CONTRACT_ETH_COLLATERAL_SUSD));
     }
 
     function issuer() internal view returns (IIssuer) {
-        return IIssuer(requireAndGetAddress(CONTRACT_ISSUER, "Missing Issuer address"));
+        return IIssuer(requireAndGetAddress(CONTRACT_ISSUER));
     }
 
     function synthetixState() internal view returns (ISynthetixState) {
-        return ISynthetixState(requireAndGetAddress(CONTRACT_SYNTHETIXSTATE, "Missing SynthetixState address"));
+        return ISynthetixState(requireAndGetAddress(CONTRACT_SYNTHETIXSTATE));
     }
 
     function rewardEscrow() internal view returns (IRewardEscrow) {
-        return IRewardEscrow(requireAndGetAddress(CONTRACT_REWARDESCROW, "Missing RewardEscrow address"));
+        return IRewardEscrow(requireAndGetAddress(CONTRACT_REWARDESCROW));
     }
 
     function delegateApprovals() internal view returns (IDelegateApprovals) {
-        return IDelegateApprovals(requireAndGetAddress(CONTRACT_DELEGATEAPPROVALS, "Missing DelegateApprovals address"));
+        return IDelegateApprovals(requireAndGetAddress(CONTRACT_DELEGATEAPPROVALS));
     }
 
     function rewardsDistribution() internal view returns (IRewardsDistribution) {
-        return
-            IRewardsDistribution(requireAndGetAddress(CONTRACT_REWARDSDISTRIBUTION, "Missing RewardsDistribution address"));
+        return IRewardsDistribution(requireAndGetAddress(CONTRACT_REWARDSDISTRIBUTION));
     }
 
     function issuanceRatio() external view returns (uint) {

--- a/contracts/FixedSupplySchedule.sol
+++ b/contracts/FixedSupplySchedule.sol
@@ -101,7 +101,7 @@ contract FixedSupplySchedule is Owned, MixinResolver, ISupplySchedule {
     // ========== VIEWS ==========
 
     function synthetix() internal view returns (ISynthetix) {
-        return ISynthetix(requireAndGetAddress(CONTRACT_SYNTHETIX, "Missing Synthetix address"));
+        return ISynthetix(requireAndGetAddress(CONTRACT_SYNTHETIX));
     }
 
     /**

--- a/contracts/Issuer.sol
+++ b/contracts/Issuer.sol
@@ -108,52 +108,51 @@ contract Issuer is Owned, MixinResolver, MixinSystemSettings, IIssuer {
     /* ========== VIEWS ========== */
 
     function synthetix() internal view returns (ISynthetix) {
-        return ISynthetix(requireAndGetAddress(CONTRACT_SYNTHETIX, "Missing Synthetix address"));
+        return ISynthetix(requireAndGetAddress(CONTRACT_SYNTHETIX));
     }
 
     function exchanger() internal view returns (IExchanger) {
-        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER, "Missing Exchanger address"));
+        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER));
     }
 
     function exchangeRates() internal view returns (IExchangeRates) {
-        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES, "Missing ExchangeRates address"));
+        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES));
     }
 
     function synthetixState() internal view returns (ISynthetixState) {
-        return ISynthetixState(requireAndGetAddress(CONTRACT_SYNTHETIXSTATE, "Missing SynthetixState address"));
+        return ISynthetixState(requireAndGetAddress(CONTRACT_SYNTHETIXSTATE));
     }
 
     function feePool() internal view returns (IFeePool) {
-        return IFeePool(requireAndGetAddress(CONTRACT_FEEPOOL, "Missing FeePool address"));
+        return IFeePool(requireAndGetAddress(CONTRACT_FEEPOOL));
     }
 
     function liquidations() internal view returns (ILiquidations) {
-        return ILiquidations(requireAndGetAddress(CONTRACT_LIQUIDATIONS, "Missing Liquidations address"));
+        return ILiquidations(requireAndGetAddress(CONTRACT_LIQUIDATIONS));
     }
 
     function delegateApprovals() internal view returns (IDelegateApprovals) {
-        return IDelegateApprovals(requireAndGetAddress(CONTRACT_DELEGATEAPPROVALS, "Missing DelegateApprovals address"));
+        return IDelegateApprovals(requireAndGetAddress(CONTRACT_DELEGATEAPPROVALS));
     }
 
     function etherCollateral() internal view returns (IEtherCollateral) {
-        return IEtherCollateral(requireAndGetAddress(CONTRACT_ETHERCOLLATERAL, "Missing EtherCollateral address"));
+        return IEtherCollateral(requireAndGetAddress(CONTRACT_ETHERCOLLATERAL));
     }
 
     function etherCollateralsUSD() internal view returns (IEtherCollateralsUSD) {
-        return
-            IEtherCollateralsUSD(requireAndGetAddress(CONTRACT_ETHERCOLLATERAL_SUSD, "Missing EtherCollateralsUSD address"));
+        return IEtherCollateralsUSD(requireAndGetAddress(CONTRACT_ETHERCOLLATERAL_SUSD));
     }
 
     function rewardEscrow() internal view returns (IRewardEscrow) {
-        return IRewardEscrow(requireAndGetAddress(CONTRACT_REWARDESCROW, "Missing RewardEscrow address"));
+        return IRewardEscrow(requireAndGetAddress(CONTRACT_REWARDESCROW));
     }
 
     function synthetixEscrow() internal view returns (IHasBalance) {
-        return IHasBalance(requireAndGetAddress(CONTRACT_SYNTHETIXESCROW, "Missing SynthetixEscrow address"));
+        return IHasBalance(requireAndGetAddress(CONTRACT_SYNTHETIXESCROW));
     }
 
     function debtCache() internal view returns (IIssuerInternalDebtCache) {
-        return IIssuerInternalDebtCache(requireAndGetAddress(CONTRACT_DEBTCACHE, "Missing DebtCache address"));
+        return IIssuerInternalDebtCache(requireAndGetAddress(CONTRACT_DEBTCACHE));
     }
 
     function issuanceRatio() external view returns (uint) {

--- a/contracts/Liquidations.sol
+++ b/contracts/Liquidations.sol
@@ -58,27 +58,24 @@ contract Liquidations is Owned, MixinResolver, MixinSystemSettings, ILiquidation
 
     /* ========== VIEWS ========== */
     function synthetix() internal view returns (ISynthetix) {
-        return ISynthetix(requireAndGetAddress(CONTRACT_SYNTHETIX, "Missing Synthetix address"));
+        return ISynthetix(requireAndGetAddress(CONTRACT_SYNTHETIX));
     }
 
     function systemStatus() internal view returns (ISystemStatus) {
-        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS, "Missing SystemStatus address"));
+        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS));
     }
 
     function issuer() internal view returns (IIssuer) {
-        return IIssuer(requireAndGetAddress(CONTRACT_ISSUER, "Missing Issuer address"));
+        return IIssuer(requireAndGetAddress(CONTRACT_ISSUER));
     }
 
     function exchangeRates() internal view returns (IExchangeRates) {
-        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES, "Missing ExchangeRates address"));
+        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES));
     }
 
     // refactor to synthetix storage eternal storage contract once that's ready
     function eternalStorageLiquidations() internal view returns (EternalStorage) {
-        return
-            EternalStorage(
-                requireAndGetAddress(CONTRACT_ETERNALSTORAGE_LIQUIDATIONS, "Missing EternalStorageLiquidations address")
-            );
+        return EternalStorage(requireAndGetAddress(CONTRACT_ETERNALSTORAGE_LIQUIDATIONS));
     }
 
     function issuanceRatio() external view returns (uint) {

--- a/contracts/MintableSynthetix.sol
+++ b/contracts/MintableSynthetix.sol
@@ -40,7 +40,7 @@ contract MintableSynthetix is Synthetix {
     /* ========== VIEWS ======================= */
 
     function synthetixBridge() internal view returns (address) {
-        return requireAndGetAddress(CONTRACT_SYNTHETIX_BRIDGE, "Resolver is missing SynthetixBridgeToBase address");
+        return requireAndGetAddress(CONTRACT_SYNTHETIX_BRIDGE);
     }
 
     /* ========== RESTRICTED FUNCTIONS ========== */

--- a/contracts/MixinResolver.sol
+++ b/contracts/MixinResolver.sol
@@ -37,7 +37,10 @@ contract MixinResolver {
         for (uint i = 0; i < resolverAddressesRequired.length; i++) {
             bytes32 name = resolverAddressesRequired[i];
             // Note: can only be invoked once the resolver has all the targets needed added
-            addressCache[name] = resolver.requireAndGetAddress(name, "Resolver missing target");
+            addressCache[name] = resolver.requireAndGetAddress(
+                name,
+                string(abi.encodePacked("Resolver missing target: ", name))
+            );
         }
     }
 
@@ -63,9 +66,9 @@ contract MixinResolver {
         addressCache[name] = resolver.getAddress(name);
     }
 
-    function requireAndGetAddress(bytes32 name, string memory reason) internal view returns (address) {
+    function requireAndGetAddress(bytes32 name) internal view returns (address) {
         address _foundAddress = addressCache[name];
-        require(_foundAddress != address(0), reason);
+        require(_foundAddress != address(0), string(abi.encodePacked("Missing ", name, " address")));
         return _foundAddress;
     }
 }

--- a/contracts/MixinResolver.sol
+++ b/contracts/MixinResolver.sol
@@ -31,8 +31,8 @@ contract MixinResolver {
         // Do not sync the cache as addresses may not be in the resolver yet
     }
 
-    /* ========== RESTRICTED FUNCTIONS ========== */
-    function invalidateCache() external {
+    /* ========== PUBLIC FUNCTIONS ========== */
+    function rebuildCache() external {
         // The resolver must call this function whenver it updates its state
         for (uint i = 0; i < resolverAddressesRequired.length; i++) {
             bytes32 name = resolverAddressesRequired[i];

--- a/contracts/MixinSystemSettings.sol
+++ b/contracts/MixinSystemSettings.sol
@@ -32,7 +32,7 @@ contract MixinSystemSettings is MixinResolver {
     }
 
     function flexibleStorage() internal view returns (IFlexibleStorage) {
-        return IFlexibleStorage(requireAndGetAddress(CONTRACT_FLEXIBLESTORAGE, "Missing FlexibleStorage address"));
+        return IFlexibleStorage(requireAndGetAddress(CONTRACT_FLEXIBLESTORAGE));
     }
 
     function getTradingRewardsEnabled() internal view returns (bool) {

--- a/contracts/MultiCollateralSynth.sol
+++ b/contracts/MultiCollateralSynth.sol
@@ -29,7 +29,7 @@ contract MultiCollateralSynth is Synth {
     /* ========== VIEWS ======================= */
 
     function multiCollateral() internal view returns (address) {
-        return requireAndGetAddress(multiCollateralKey, "Resolver is missing multiCollateral address");
+        return requireAndGetAddress(multiCollateralKey);
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */

--- a/contracts/PurgeableSynth.sol
+++ b/contracts/PurgeableSynth.sol
@@ -37,7 +37,7 @@ contract PurgeableSynth is Synth {
     /* ========== VIEWS ========== */
 
     function exchangeRates() internal view returns (IExchangeRates) {
-        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES, "Missing ExchangeRates address"));
+        return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES));
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */

--- a/contracts/Synth.sol
+++ b/contracts/Synth.sol
@@ -176,19 +176,19 @@ contract Synth is Owned, IERC20, ExternStateToken, MixinResolver, ISynth {
 
     /* ========== VIEWS ========== */
     function systemStatus() internal view returns (ISystemStatus) {
-        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS, "Missing SystemStatus address"));
+        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS));
     }
 
     function feePool() internal view returns (IFeePool) {
-        return IFeePool(requireAndGetAddress(CONTRACT_FEEPOOL, "Missing FeePool address"));
+        return IFeePool(requireAndGetAddress(CONTRACT_FEEPOOL));
     }
 
     function exchanger() internal view returns (IExchanger) {
-        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER, "Missing Exchanger address"));
+        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER));
     }
 
     function issuer() internal view returns (IIssuer) {
-        return IIssuer(requireAndGetAddress(CONTRACT_ISSUER, "Missing Issuer address"));
+        return IIssuer(requireAndGetAddress(CONTRACT_ISSUER));
     }
 
     function _ensureCanTransfer(address from, uint value) internal view {

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -63,28 +63,27 @@ contract Synthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
     /* ========== VIEWS ========== */
 
     function synthetixState() internal view returns (ISynthetixState) {
-        return ISynthetixState(requireAndGetAddress(CONTRACT_SYNTHETIXSTATE, "Missing SynthetixState address"));
+        return ISynthetixState(requireAndGetAddress(CONTRACT_SYNTHETIXSTATE));
     }
 
     function systemStatus() internal view returns (ISystemStatus) {
-        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS, "Missing SystemStatus address"));
+        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS));
     }
 
     function exchanger() internal view returns (IExchanger) {
-        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER, "Missing Exchanger address"));
+        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER));
     }
 
     function issuer() internal view returns (IIssuer) {
-        return IIssuer(requireAndGetAddress(CONTRACT_ISSUER, "Missing Issuer address"));
+        return IIssuer(requireAndGetAddress(CONTRACT_ISSUER));
     }
 
     function supplySchedule() internal view returns (SupplySchedule) {
-        return SupplySchedule(requireAndGetAddress(CONTRACT_SUPPLYSCHEDULE, "Missing SupplySchedule address"));
+        return SupplySchedule(requireAndGetAddress(CONTRACT_SUPPLYSCHEDULE));
     }
 
     function rewardsDistribution() internal view returns (IRewardsDistribution) {
-        return
-            IRewardsDistribution(requireAndGetAddress(CONTRACT_REWARDSDISTRIBUTION, "Missing RewardsDistribution address"));
+        return IRewardsDistribution(requireAndGetAddress(CONTRACT_REWARDSDISTRIBUTION));
     }
 
     function debtBalanceOf(address account, bytes32 currencyKey) external view returns (uint) {

--- a/contracts/SynthetixBridgeToBase.sol
+++ b/contracts/SynthetixBridgeToBase.sol
@@ -34,15 +34,15 @@ contract SynthetixBridgeToBase is Owned, MixinResolver, ISynthetixBridgeToBase {
     // ========== INTERNALS ============
 
     function messenger() internal view returns (iOVM_BaseCrossDomainMessenger) {
-        return iOVM_BaseCrossDomainMessenger(requireAndGetAddress(CONTRACT_EXT_MESSENGER, "Missing Messenger address"));
+        return iOVM_BaseCrossDomainMessenger(requireAndGetAddress(CONTRACT_EXT_MESSENGER));
     }
 
     function synthetix() internal view returns (ISynthetix) {
-        return ISynthetix(requireAndGetAddress(CONTRACT_SYNTHETIX, "Missing Synthetix address"));
+        return ISynthetix(requireAndGetAddress(CONTRACT_SYNTHETIX));
     }
 
     function synthetixBridgeToOptimism() internal view returns (address) {
-        return requireAndGetAddress(CONTRACT_BASE_SYNTHETIXBRIDGETOOPTIMISM, "Missing Bridge address");
+        return requireAndGetAddress(CONTRACT_BASE_SYNTHETIXBRIDGETOOPTIMISM);
     }
 
     function onlyAllowFromOptimism() internal view {

--- a/contracts/SynthetixBridgeToOptimism.sol
+++ b/contracts/SynthetixBridgeToOptimism.sol
@@ -44,27 +44,27 @@ contract SynthetixBridgeToOptimism is Owned, MixinResolver, ISynthetixBridgeToOp
     // ========== INTERNALS ============
 
     function messenger() internal view returns (iOVM_BaseCrossDomainMessenger) {
-        return iOVM_BaseCrossDomainMessenger(requireAndGetAddress(CONTRACT_EXT_MESSENGER, "Missing Messenger address"));
+        return iOVM_BaseCrossDomainMessenger(requireAndGetAddress(CONTRACT_EXT_MESSENGER));
     }
 
     function synthetix() internal view returns (ISynthetix) {
-        return ISynthetix(requireAndGetAddress(CONTRACT_SYNTHETIX, "Missing Synthetix address"));
+        return ISynthetix(requireAndGetAddress(CONTRACT_SYNTHETIX));
     }
 
     function synthetixERC20() internal view returns (IERC20) {
-        return IERC20(requireAndGetAddress(CONTRACT_SYNTHETIX, "Missing Synthetix address"));
+        return IERC20(requireAndGetAddress(CONTRACT_SYNTHETIX));
     }
 
     function issuer() internal view returns (IIssuer) {
-        return IIssuer(requireAndGetAddress(CONTRACT_ISSUER, "Missing Issuer address"));
+        return IIssuer(requireAndGetAddress(CONTRACT_ISSUER));
     }
 
     function rewardsDistribution() internal view returns (address) {
-        return requireAndGetAddress(CONTRACT_REWARDSDISTRIBUTION, "Missing RewardsDistribution address");
+        return requireAndGetAddress(CONTRACT_REWARDSDISTRIBUTION);
     }
 
     function synthetixBridgeToBase() internal view returns (address) {
-        return requireAndGetAddress(CONTRACT_OVM_SYNTHETIXBRIDGETOBASE, "Missing Bridge address");
+        return requireAndGetAddress(CONTRACT_OVM_SYNTHETIXBRIDGETOBASE);
     }
 
     function isActive() internal view {

--- a/contracts/TradingRewards.sol
+++ b/contracts/TradingRewards.sol
@@ -62,11 +62,11 @@ contract TradingRewards is ITradingRewards, ReentrancyGuard, Owned, Pausable, Mi
     /* ========== VIEWS ========== */
 
     function synthetix() internal view returns (IERC20) {
-        return IERC20(requireAndGetAddress(CONTRACT_SYNTHETIX, "Missing Synthetix address"));
+        return IERC20(requireAndGetAddress(CONTRACT_SYNTHETIX));
     }
 
     function exchanger() internal view returns (IExchanger) {
-        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER, "Missing Exchanger address"));
+        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER));
     }
 
     function getAvailableRewards() external view returns (uint) {

--- a/contracts/test-helpers/MockBinaryOptionMarketManager.sol
+++ b/contracts/test-helpers/MockBinaryOptionMarketManager.sol
@@ -31,6 +31,7 @@ contract MockBinaryOptionMarketManager {
             bids,
             fees
         );
+        market.rebuildCache();
     }
 
     function decrementTotalDeposited(uint) external pure {

--- a/contracts/test-helpers/MockBinaryOptionMarketManager.sol
+++ b/contracts/test-helpers/MockBinaryOptionMarketManager.sol
@@ -22,6 +22,7 @@ contract MockBinaryOptionMarketManager {
         market = new BinaryOptionMarket(
             address(this),
             creator,
+            address(resolver),
             creatorLimits,
             oracleKey,
             strikePrice,
@@ -30,7 +31,6 @@ contract MockBinaryOptionMarketManager {
             bids,
             fees
         );
-        market.setResolverAndSyncCache(resolver);
     }
 
     function decrementTotalDeposited(uint) external pure {

--- a/contracts/test-helpers/TestableBinaryOptionMarket.sol
+++ b/contracts/test-helpers/TestableBinaryOptionMarket.sol
@@ -7,6 +7,7 @@ contract TestableBinaryOptionMarket is BinaryOptionMarket {
     constructor(
         address _owner,
         address _creator,
+        address _resolver,
         uint[2] memory _creatorLimits,
         bytes32 _oracleKey,
         uint256 _strikePrice,
@@ -16,7 +17,18 @@ contract TestableBinaryOptionMarket is BinaryOptionMarket {
         uint[3] memory _fees
     )
         public
-        BinaryOptionMarket(_owner, _creator, _creatorLimits, _oracleKey, _strikePrice, _refundsEnabled, _times, _bids, _fees)
+        BinaryOptionMarket(
+            _owner,
+            _creator,
+            _resolver,
+            _creatorLimits,
+            _oracleKey,
+            _strikePrice,
+            _refundsEnabled,
+            _times,
+            _bids,
+            _fees
+        )
     {}
 
     function updatePrices(

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -1212,7 +1212,7 @@ const deploy = async ({
 		// could still be a target of something which does
 
 		await runStep({
-			gasLimit: 4e6, // higher gas required
+			gasLimit: 5e6, // higher gas required
 			contract: `AddressResolver`,
 			target: addressResolver,
 			write: 'importAddresses',
@@ -1223,7 +1223,7 @@ const deploy = async ({
 		});
 
 		await runStep({
-			gasLimit: 7e6, // higher gas required
+			gasLimit: 9e6, // higher gas required
 			contract: `AddressResolver`,
 			target: addressResolver,
 			write: 'rebuildCaches',

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -1212,13 +1212,34 @@ const deploy = async ({
 		// could still be a target of something which does
 
 		await runStep({
-			gasLimit: 9e6, // higher gas required
+			gasLimit: 4e6, // higher gas required
 			contract: `AddressResolver`,
 			target: addressResolver,
 			write: 'importAddresses',
 			writeArg: [
 				Object.keys(deployer.deployedContracts).map(contract => toBytes32(contract)),
 				Object.values(deployer.deployedContracts).map(({ options: { address } }) => address),
+			],
+		});
+
+		await runStep({
+			gasLimit: 7e6, // higher gas required
+			contract: `AddressResolver`,
+			target: addressResolver,
+			write: 'rebuildCaches',
+			writeArg: [
+				Object.entries(deployer.deployedContracts)
+					.filter(([, target]) =>
+						target.options.jsonInterface.find(({ name }) => name === 'rebuildCache')
+					)
+					.map(
+						([
+							,
+							{
+								options: { address },
+							},
+						]) => address
+					),
 			],
 		});
 

--- a/publish/src/util.js
+++ b/publish/src/util.js
@@ -215,6 +215,7 @@ const performTransactionalStep = async ({
 	if (owner === account) {
 		// perform action
 		let hash;
+		let gasUsed = 0;
 		if (dryRun) {
 			_dryRunCounter++;
 			hash = '0x' + _dryRunCounter.toString().padStart(64, '0');
@@ -230,7 +231,9 @@ const performTransactionalStep = async ({
 			}
 
 			const txn = await target.methods[write](...argumentsForWriteFunction).send(params);
+
 			hash = txn.transactionHash;
+			gasUsed = txn.gasUsed;
 
 			if (nonceManager) {
 				nonceManager.incrementNonce();
@@ -238,7 +241,13 @@ const performTransactionalStep = async ({
 		}
 
 		console.log(
-			green(`${dryRun ? '[DRY RUN] ' : ''}Successfully completed ${action} in hash: ${hash}`)
+			green(
+				`${
+					dryRun ? '[DRY RUN] ' : ''
+				}Successfully completed ${action} in hash: ${hash}. Gas used: ${(gasUsed / 1e6).toFixed(
+					2
+				)}m `
+			)
 		);
 
 		return hash;

--- a/test/contracts/BinaryOptionMarket.js
+++ b/test/contracts/BinaryOptionMarket.js
@@ -88,6 +88,7 @@ contract('BinaryOptionMarket @gas-skip @ovm-skip', accounts => {
 	};
 
 	const deployMarket = async ({
+		resolver,
 		endOfBidding,
 		maturity,
 		expiry,
@@ -107,6 +108,7 @@ contract('BinaryOptionMarket @gas-skip @ovm-skip', accounts => {
 			args: [
 				accounts[0],
 				creator,
+				resolver,
 				[capitalRequirement, skewLimit],
 				oracleKey,
 				strikePrice,

--- a/test/contracts/BinaryOptionMarketData.js
+++ b/test/contracts/BinaryOptionMarketData.js
@@ -29,6 +29,7 @@ contract('BinaryOptionMarketData @gas-skip @ovm-skip', accounts => {
 			args: [
 				accounts[0], // manager
 				accounts[1], // creator
+				addressResolver.address,
 				[toUnit(2), toUnit(0.05)], // Capital requirement, skew limit
 				toBytes32('sAUD'), // oracle key
 				toUnit(1), // strike price
@@ -38,7 +39,7 @@ contract('BinaryOptionMarketData @gas-skip @ovm-skip', accounts => {
 				[toUnit(0.01), toUnit(0.02), toUnit(0.03)], // pool, creator, refund fees
 			],
 		});
-		await market.setResolverAndSyncCache(addressResolver.address);
+		await market.rebuildCache();
 
 		dataContract = await setupContract({
 			accounts,

--- a/test/contracts/BinaryOptionMarketManager.js
+++ b/test/contracts/BinaryOptionMarketManager.js
@@ -12,7 +12,7 @@ const {
 	divideDecimalRound,
 } = require('../utils')();
 const { toBytes32 } = require('../..');
-const { setupContract, setupAllContracts, mockGenericContractFnc } = require('./setup');
+const { setupContract, setupAllContracts } = require('./setup');
 const {
 	setStatus,
 	ensureOnlyExpectedMutativeFunctions,

--- a/test/contracts/DebtCache.js
+++ b/test/contracts/DebtCache.js
@@ -352,7 +352,6 @@ contract('DebtCache', async accounts => {
 				await addressResolver.importAddresses([debtCacheName], [newDebtCache.address], {
 					from: owner,
 				});
-				await newDebtCache.setResolverAndSyncCache(addressResolver.address, { from: owner });
 
 				assert.bnEqual(await newDebtCache.cachedDebt(), toUnit('0'));
 				assert.bnEqual(await newDebtCache.cachedSynthDebt(sUSD), toUnit('0'));
@@ -366,7 +365,7 @@ contract('DebtCache', async accounts => {
 				assert.isTrue(info.isStale);
 				assert.isTrue(await newDebtCache.cacheStale());
 
-				await issuer.setResolverAndSyncCache(addressResolver.address, { from: owner });
+				await issuer.rebuildCache();
 				assert.isTrue((await issuer.collateralisationRatioAndAnyRatesInvalid(account1))[1]);
 			});
 
@@ -706,7 +705,6 @@ contract('DebtCache', async accounts => {
 				await addressResolver.importAddresses([debtCacheName], [newDebtCache.address], {
 					from: owner,
 				});
-				await newDebtCache.setResolverAndSyncCache(addressResolver.address, { from: owner });
 
 				await newDebtCache.takeDebtSnapshot();
 				const issued = (await newDebtCache.cacheInfo())[0];
@@ -865,7 +863,7 @@ contract('DebtCache', async accounts => {
 				await addressResolver.importAddresses([issuerName], [account1], {
 					from: owner,
 				});
-				await debtCache.setResolverAndSyncCache(addressResolver.address, { from: owner });
+				await debtCache.rebuildCache();
 			});
 
 			describe('when the debt cache is valid', () => {
@@ -960,11 +958,8 @@ contract('DebtCache', async accounts => {
 					}
 				);
 
-				await Promise.all([
-					issuer.setResolverAndSyncCache(addressResolver.address, { from: owner }),
-					exchanger.setResolverAndSyncCache(addressResolver.address, { from: owner }),
-					realtimeDebtCache.setResolverAndSyncCache(addressResolver.address, { from: owner }),
-				]);
+				// rebuild the caches of those addresses not just added to the adress resolver
+				await Promise.all([issuer.rebuildCache(), exchanger.rebuildCache()]);
 			});
 
 			it('Cached values report current numbers without cache resynchronisation', async () => {

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -2698,7 +2698,7 @@ contract('Exchanger (spec tests)', async accounts => {
 				await resolver.importAddresses([toBytes32('ExchangeRates')], [account1], {
 					from: owner,
 				});
-				await exchanger.setResolverAndSyncCache(resolver.address, { from: owner });
+				await exchanger.rebuildCache();
 			});
 			it('reverts when invoked by ExchangeRates with a 0 rate', async () => {
 				await assert.revert(

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -784,7 +784,6 @@ const setupAllContracts = async ({
 
 	// now invoke AddressResolver to set all addresses
 	if (returnObj['AddressResolver']) {
-		// TODO - this should only import the ones set as required in contracts
 		await returnObj['AddressResolver'].importAddresses(
 			Object.keys(returnObj).map(toBytes32),
 			Object.values(returnObj).map(entry =>
@@ -796,26 +795,6 @@ const setupAllContracts = async ({
 			}
 		);
 	}
-
-	// now set resolver and sync cache for all contracts that need it
-	await Promise.all(
-		Object.entries(returnObj)
-			// keep items not in mocks
-			.filter(([name]) => !(name in mocks))
-			// and only those with the setResolver function
-			.filter(([, instance]) => !!instance.setResolverAndSyncCache)
-			.map(([contract, instance]) => {
-				return instance
-					.setResolverAndSyncCache(returnObj['AddressResolver'].address, { from: owner })
-					.catch(err => {
-						if (/Resolver missing target/.test(err.toString())) {
-							throw Error(`Cannot resolve all resolver requirements for ${contract}`);
-						} else {
-							throw err;
-						}
-					});
-			})
-	);
 
 	// if deploying a real Synthetix, then we add the synths
 	if (returnObj['Issuer'] && !mocks['Issuer']) {

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -784,6 +784,10 @@ const setupAllContracts = async ({
 
 	// now invoke AddressResolver to set all addresses
 	if (returnObj['AddressResolver']) {
+		if (process.env.DEBUG) {
+			log(`Importing into AddressResolver:\n\t - ${Object.keys(returnObj).join('\n\t - ')}`);
+		}
+
 		await returnObj['AddressResolver'].importAddresses(
 			Object.keys(returnObj).map(toBytes32),
 			Object.values(returnObj).map(entry =>

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -798,6 +798,12 @@ const setupAllContracts = async ({
 				from: owner,
 			}
 		);
+
+		await returnObj['AddressResolver'].rebuildCaches(
+			Object.values(returnObj)
+				.filter(entry => 'rebuildCache' in entry)
+				.map(({ address }) => address)
+		);
 	}
 
 	// if deploying a real Synthetix, then we add the synths


### PR DESCRIPTION
**Goal**
To reduce the load on deploys - processing many `setResolverAndSyncCache` calls is simply not scalable. 

**Solidity Improvements**
* `AddressResolver.importAddresses()` now invokes the protected `invalidateCache()` function (protected to prevent griefing) for each `MixinResolver` target, where implemented
* `AddressResolver.importAddresses()` emits an event `AddressImported` for each address added
* `MixinResolver` has flag `isCacheValid`. When not valid, the view `requireAndGetAddress()` will revert (ensuring cache's are always up to date). This ensures caches are always rebuilt after imports otherwise the system will fail
* `MixinResolver` has a `rebuildCache()` function (publicly available) for the contract to rebuild it's cache and flip the cache flag
* `AddressResolver.rebuildCaches` is exposed (and non-protected), for use on deployment to batch up
* `MixinResolver` no longer needs the `Owner` pattern
* `MixinResolver.requireAndGetAddress()` uses `abi.encodePacked` for string concatenation and a simpler API.

**Deployment Improvements**
* All targets added to the `AddressResolver`
* All targets that have `MixinResolver.rebuildCache` exposed, will be added to a batched `AddressResolver.rebuildCaches` invocation

**Stats**
* `AddressResolver.importAddresses(all 140 local targets)` takes approximately **4.8m gas**
* `AddressResolver.rebuildCaches(all 47 local contracts with MixinResolver)` takes approximately **7.8m gas**

**Known Issues**
* `SynthetixBridge*` contracts will fail on `rebuildCache()` for those contracts with `:` in them. One potential solution is add checks to `rebuildCache` that will pass on anything with a `:` in it (a bit more gas intensive as it would have to loop over each character in the `bytes` array). c @i-stam @ajsantander 