### PR TITLE
Fix lint pre-commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
 	},
 	"husky": {
 		"hooks": {
-			"pre-commit": "./hooks/circleci && pretty-quick --staged --verbose"
+			"pre-commit": "./hooks/circleci && npm run lint && pretty-quick --staged"
 		}
 	},
 	"repository": {


### PR DESCRIPTION
A recent PR attempted to speed up our lint pre-commit hook: https://github.com/Synthetixio/synthetix/pull/890

Unfortunately, it assumed that `pretty-quick` performed eslint linting, but it does not. Reverting that change here.

An older approach is still viable: https://github.com/Synthetixio/synthetix/pull/884