### PR TITLE
Fixes compilation issues with MintableSynthetix on L2

### DIFF
--- a/contracts/MintableSynthetix.sol
+++ b/contracts/MintableSynthetix.sol
@@ -43,6 +43,37 @@ contract MintableSynthetix is Synthetix {
         return requireAndGetAddress(CONTRACT_SYNTHETIX_BRIDGE, "Resolver is missing SynthetixBridgeToBase address");
     }
 
+    /* ========== MUTATIVE FUNCTIONS ========== */
+
+    function exchangeWithTracking(
+        bytes32 sourceCurrencyKey,
+        uint sourceAmount,
+        bytes32 destinationCurrencyKey,
+        address originator,
+        bytes32 trackingCode
+    ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {}
+
+    function exchangeOnBehalfWithTracking(
+        address exchangeForAddress,
+        bytes32 sourceCurrencyKey,
+        uint sourceAmount,
+        bytes32 destinationCurrencyKey,
+        address originator,
+        bytes32 trackingCode
+    ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {}
+
+    function exchangeWithVirtual(
+        bytes32 sourceCurrencyKey,
+        uint sourceAmount,
+        bytes32 destinationCurrencyKey,
+        bytes32 trackingCode
+    )
+        external
+        exchangeActive(sourceCurrencyKey, destinationCurrencyKey)
+        optionalProxy
+        returns (uint amountReceived, IVirtualSynth vSynth)
+    {}
+
     /* ========== RESTRICTED FUNCTIONS ========== */
 
     function mintSecondary(address account, uint amount) external onlyBridge {

--- a/contracts/MintableSynthetix.sol
+++ b/contracts/MintableSynthetix.sol
@@ -27,7 +27,11 @@ contract MintableSynthetix is Synthetix {
     }
 
     function onlyAllowFromBridge() internal view {
-        require(msg.sender == synthetixBridge(), "Can only be invoked by the SynthetixBridgeToBase contract");
+        require(
+            msg.sender ==
+                requireAndGetAddress(CONTRACT_SYNTHETIX_BRIDGE, "Resolver is missing SynthetixBridgeToBase address"),
+            "Can only be invoked by the SynthetixBridgeToBase contract"
+        );
     }
 
     /* ========== MODIFIERS =================== */
@@ -35,12 +39,6 @@ contract MintableSynthetix is Synthetix {
     modifier onlyBridge() {
         onlyAllowFromBridge();
         _;
-    }
-
-    /* ========== VIEWS ======================= */
-
-    function synthetixBridge() internal view returns (address) {
-        return requireAndGetAddress(CONTRACT_SYNTHETIX_BRIDGE, "Resolver is missing SynthetixBridgeToBase address");
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */
@@ -51,7 +49,7 @@ contract MintableSynthetix is Synthetix {
         bytes32 destinationCurrencyKey,
         address originator,
         bytes32 trackingCode
-    ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {}
+    ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) returns (uint amountReceived) {}
 
     function exchangeOnBehalfWithTracking(
         address exchangeForAddress,
@@ -60,19 +58,14 @@ contract MintableSynthetix is Synthetix {
         bytes32 destinationCurrencyKey,
         address originator,
         bytes32 trackingCode
-    ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {}
+    ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) returns (uint amountReceived) {}
 
     function exchangeWithVirtual(
         bytes32 sourceCurrencyKey,
         uint sourceAmount,
         bytes32 destinationCurrencyKey,
         bytes32 trackingCode
-    )
-        external
-        exchangeActive(sourceCurrencyKey, destinationCurrencyKey)
-        optionalProxy
-        returns (uint amountReceived, IVirtualSynth vSynth)
-    {}
+    ) external returns (uint amountReceived, IVirtualSynth vSynth) {}
 
     /* ========== RESTRICTED FUNCTIONS ========== */
 
@@ -91,4 +84,12 @@ contract MintableSynthetix is Synthetix {
         emitTransfer(account, address(0), amount);
         totalSupply = totalSupply.sub(amount);
     }
+
+    /* ========== EVENTS ========== */
+
+    function emitExchangeTracking(
+        bytes32 trackingCode,
+        bytes32 toCurrencyKey,
+        uint256 toAmount
+    ) external onlyExchanger {}
 }

--- a/publish/ovm-ignore.json
+++ b/publish/ovm-ignore.json
@@ -1,14 +1,54 @@
-[
-	"BinaryOption",
-	"BinaryOptionMarket",
-	"BinaryOptionMarketData",
-	"BinaryOptionMarketFactory",
-	"BinaryOptionMarketManager",
-	"EtherCollateral",
-	"EtherCollateralsUSD",
-	"ExchangerWithVirtualSynth",
-	"FakeTradingRewards",
-	"MockBinaryOptionMarket",
-	"MockBinaryOptionMarketManager",
-	"TestableBinaryOptionMarket"
-]
+{
+	"BinaryOption": {
+		"compile": false,
+		"ignore": false
+	},
+	"BinaryOptionMarket": {
+		"compile": false,
+		"ignore": false
+	},
+	"BinaryOptionMarketData": {
+		"compile": false,
+		"ignore": false
+	},
+	"BinaryOptionMarketFactory": {
+		"compile": false,
+		"ignore": false
+	},
+	"BinaryOptionMarketManager": {
+		"compile": false,
+		"ignore": false
+	},
+	"EtherCollateral": {
+		"compile": false,
+		"ignore": false
+	},
+	"EtherCollateralsUSD": {
+		"compile": false,
+		"ignore": false
+	},
+	"ExchangerWithVirtualSynth": {
+		"compile": false,
+		"ignore": false
+	},
+	"FakeTradingRewards": {
+		"compile": false,
+		"ignore": false
+	},
+	"MockBinaryOptionMarket": {
+		"compile": false,
+		"ignore": false
+	},
+	"MockBinaryOptionMarketManager": {
+		"compile": false,
+		"ignore": false
+	},
+	"TestableBinaryOptionMarket": {
+		"compile": false,
+		"ignore": false
+	},
+	"Synthetix": {
+		"compile": true,
+		"ignore": true
+	}
+}

--- a/publish/src/commands/build.js
+++ b/publish/src/commands/build.js
@@ -61,7 +61,8 @@ const build = async ({
 		const contractPaths = Object.keys(contracts);
 		contractPaths.map(contractPath => {
 			const filename = path.basename(contractPath, '.sol');
-			const isIgnored = ovmIgnored.some(ignored => filename === ignored);
+			const ignoredEntry = ovmIgnored[filename];
+			const isIgnored = ignoredEntry && !ignoredEntry.compile;
 
 			if (isIgnored) {
 				console.log(gray(`    > ${filename}`));
@@ -122,7 +123,7 @@ const build = async ({
 		const toWrite = path.join(compiledPath, contractName);
 		const filePath = `${toWrite}.json`;
 		const prevSizeIfAny = fs.existsSync(filePath)
-			? await sizeOfContracts({
+			? sizeOfContracts({
 					contractToObjectMap: { [filePath]: require(filePath).evm.deployedBytecode.object },
 			  })[0]
 			: undefined;


### PR DESCRIPTION
Optimism's latest compiler, `@eth-optimism/solc 0.5.16-alpha.6`, produces slightly larger contract sizes. As a result, MintableSynthetix is ~106%. This PR attempts to remedy this by:
* Allowing oversized contracts in the inheritance chain if they're not intended for direct deployment. E.g. if MintableSynthetix inherits Synthetix, and sizeOf(MintableSynthetix) < sizeOf(Synthetix), and MintableSynthetix is the deployment target, then `ovm-ignore.json` can be used to indicate that we want to compile Synthetix, but exclude it from the oversize checks.
* Stubbing some methods in MintableSynthetix, that _probably_ not needed in L2.