### PR TITLE
Develop more advanced ovm ignore

### DIFF
--- a/contracts/MintableSynthetix.sol
+++ b/contracts/MintableSynthetix.sol
@@ -27,11 +27,7 @@ contract MintableSynthetix is Synthetix {
     }
 
     function onlyAllowFromBridge() internal view {
-        require(
-            msg.sender ==
-                requireAndGetAddress(CONTRACT_SYNTHETIX_BRIDGE, "Resolver is missing SynthetixBridgeToBase address"),
-            "Can only be invoked by the SynthetixBridgeToBase contract"
-        );
+        require(msg.sender == synthetixBridge(), "Can only be invoked by the SynthetixBridgeToBase contract");
     }
 
     /* ========== MODIFIERS =================== */
@@ -41,31 +37,11 @@ contract MintableSynthetix is Synthetix {
         _;
     }
 
-    /* ========== MUTATIVE FUNCTIONS ========== */
+    /* ========== VIEWS ======================= */
 
-    function exchangeWithTracking(
-        bytes32 sourceCurrencyKey,
-        uint sourceAmount,
-        bytes32 destinationCurrencyKey,
-        address originator,
-        bytes32 trackingCode
-    ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) returns (uint amountReceived) {}
-
-    function exchangeOnBehalfWithTracking(
-        address exchangeForAddress,
-        bytes32 sourceCurrencyKey,
-        uint sourceAmount,
-        bytes32 destinationCurrencyKey,
-        address originator,
-        bytes32 trackingCode
-    ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) returns (uint amountReceived) {}
-
-    function exchangeWithVirtual(
-        bytes32 sourceCurrencyKey,
-        uint sourceAmount,
-        bytes32 destinationCurrencyKey,
-        bytes32 trackingCode
-    ) external returns (uint amountReceived, IVirtualSynth vSynth) {}
+    function synthetixBridge() internal view returns (address) {
+        return requireAndGetAddress(CONTRACT_SYNTHETIX_BRIDGE, "Resolver is missing SynthetixBridgeToBase address");
+    }
 
     /* ========== RESTRICTED FUNCTIONS ========== */
 
@@ -84,12 +60,4 @@ contract MintableSynthetix is Synthetix {
         emitTransfer(account, address(0), amount);
         totalSupply = totalSupply.sub(amount);
     }
-
-    /* ========== EVENTS ========== */
-
-    function emitExchangeTracking(
-        bytes32 trackingCode,
-        bytes32 toCurrencyKey,
-        uint256 toAmount
-    ) external onlyExchanger {}
 }

--- a/contracts/MintableSynthetix.sol
+++ b/contracts/MintableSynthetix.sol
@@ -43,6 +43,37 @@ contract MintableSynthetix is Synthetix {
         return requireAndGetAddress(CONTRACT_SYNTHETIX_BRIDGE, "Resolver is missing SynthetixBridgeToBase address");
     }
 
+    /* ========== MUTATIVE FUNCTIONS ========== */
+
+    function exchangeWithTracking(
+        bytes32 sourceCurrencyKey,
+        uint sourceAmount,
+        bytes32 destinationCurrencyKey,
+        address originator,
+        bytes32 trackingCode
+    ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {}
+
+    function exchangeOnBehalfWithTracking(
+        address exchangeForAddress,
+        bytes32 sourceCurrencyKey,
+        uint sourceAmount,
+        bytes32 destinationCurrencyKey,
+        address originator,
+        bytes32 trackingCode
+    ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {}
+
+    function exchangeWithVirtual(
+        bytes32 sourceCurrencyKey,
+        uint sourceAmount,
+        bytes32 destinationCurrencyKey,
+        bytes32 trackingCode
+    )
+        external
+        exchangeActive(sourceCurrencyKey, destinationCurrencyKey)
+        optionalProxy
+        returns (uint amountReceived, IVirtualSynth vSynth)
+    {}
+
     /* ========== RESTRICTED FUNCTIONS ========== */
 
     function mintSecondary(address account, uint amount) external onlyBridge {

--- a/contracts/MintableSynthetix.sol
+++ b/contracts/MintableSynthetix.sol
@@ -27,7 +27,11 @@ contract MintableSynthetix is Synthetix {
     }
 
     function onlyAllowFromBridge() internal view {
-        require(msg.sender == synthetixBridge(), "Can only be invoked by the SynthetixBridgeToBase contract");
+        require(
+            msg.sender ==
+                requireAndGetAddress(CONTRACT_SYNTHETIX_BRIDGE, "Resolver is missing SynthetixBridgeToBase address"),
+            "Can only be invoked by the SynthetixBridgeToBase contract"
+        );
     }
 
     /* ========== MODIFIERS =================== */
@@ -35,12 +39,6 @@ contract MintableSynthetix is Synthetix {
     modifier onlyBridge() {
         onlyAllowFromBridge();
         _;
-    }
-
-    /* ========== VIEWS ======================= */
-
-    function synthetixBridge() internal view returns (address) {
-        return requireAndGetAddress(CONTRACT_SYNTHETIX_BRIDGE, "Resolver is missing SynthetixBridgeToBase address");
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */
@@ -51,7 +49,7 @@ contract MintableSynthetix is Synthetix {
         bytes32 destinationCurrencyKey,
         address originator,
         bytes32 trackingCode
-    ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {}
+    ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) returns (uint amountReceived) {}
 
     function exchangeOnBehalfWithTracking(
         address exchangeForAddress,
@@ -60,19 +58,14 @@ contract MintableSynthetix is Synthetix {
         bytes32 destinationCurrencyKey,
         address originator,
         bytes32 trackingCode
-    ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {}
+    ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) returns (uint amountReceived) {}
 
     function exchangeWithVirtual(
         bytes32 sourceCurrencyKey,
         uint sourceAmount,
         bytes32 destinationCurrencyKey,
         bytes32 trackingCode
-    )
-        external
-        exchangeActive(sourceCurrencyKey, destinationCurrencyKey)
-        optionalProxy
-        returns (uint amountReceived, IVirtualSynth vSynth)
-    {}
+    ) external returns (uint amountReceived, IVirtualSynth vSynth) {}
 
     /* ========== RESTRICTED FUNCTIONS ========== */
 
@@ -91,4 +84,12 @@ contract MintableSynthetix is Synthetix {
         emitTransfer(account, address(0), amount);
         totalSupply = totalSupply.sub(amount);
     }
+
+    /* ========== EVENTS ========== */
+
+    function emitExchangeTracking(
+        bytes32 trackingCode,
+        bytes32 toCurrencyKey,
+        uint256 toAmount
+    ) external onlyExchanger {}
 }

--- a/publish/deployed/mainnet/config.json
+++ b/publish/deployed/mainnet/config.json
@@ -2,16 +2,16 @@
 	"AddressResolver": {
 		"deploy": false
 	},
-	"BinaryOptionMarketData": {
-		"deploy": false
-	},
 	"BinaryOptionMarketFactory": {
 		"deploy": false
 	},
 	"BinaryOptionMarketManager": {
 		"deploy": false
 	},
-	"DappMaintenance": {
+	"BinaryOptionMarketData": {
+		"deploy": false
+	},
+	"ReadProxyAddressResolver": {
 		"deploy": false
 	},
 	"DebtCache": {
@@ -29,190 +29,34 @@
 	"EscrowChecker": {
 		"deploy": false
 	},
-	"EternalStorageLiquidations": {
-		"deploy": false
-	},
 	"EtherCollateral": {
-		"deploy": false
-	},
-	"EtherCollateralsUSD": {
 		"deploy": false
 	},
 	"ExchangeRates": {
 		"deploy": false
 	},
-	"ExchangeState": {
+	"Exchanger": {
 		"deploy": false
 	},
-	"Exchanger": {
+	"ExchangeState": {
 		"deploy": false
 	},
 	"FeePool": {
 		"deploy": false
 	},
-	"FeePoolEternalStorage": {
-		"deploy": false
-	},
 	"FeePoolState": {
 		"deploy": false
 	},
-	"FlexibleStorage": {
+	"FeePoolEternalStorage": {
 		"deploy": false
 	},
 	"Issuer": {
 		"deploy": false
 	},
+	"EternalStorageLiquidations": {
+		"deploy": false
+	},
 	"Liquidations": {
-		"deploy": false
-	},
-	"Math": {
-		"deploy": false
-	},
-	"ProxyERC20": {
-		"deploy": false
-	},
-	"ProxyERC20sUSD": {
-		"deploy": false
-	},
-	"ProxyFeePool": {
-		"deploy": false
-	},
-	"ProxySynthetix": {
-		"deploy": false
-	},
-	"ProxyiADA": {
-		"deploy": false
-	},
-	"ProxyiBCH": {
-		"deploy": false
-	},
-	"ProxyiBNB": {
-		"deploy": false
-	},
-	"ProxyiBTC": {
-		"deploy": false
-	},
-	"ProxyiCEX": {
-		"deploy": false
-	},
-	"ProxyiDASH": {
-		"deploy": false
-	},
-	"ProxyiDEFI": {
-		"deploy": false
-	},
-	"ProxyiEOS": {
-		"deploy": false
-	},
-	"ProxyiETC": {
-		"deploy": false
-	},
-	"ProxyiETH": {
-		"deploy": false
-	},
-	"ProxyiLINK": {
-		"deploy": false
-	},
-	"ProxyiLTC": {
-		"deploy": false
-	},
-	"ProxyiOIL": {
-		"deploy": false
-	},
-	"ProxyiTRX": {
-		"deploy": false
-	},
-	"ProxyiXMR": {
-		"deploy": false
-	},
-	"ProxyiXRP": {
-		"deploy": false
-	},
-	"ProxyiXTZ": {
-		"deploy": false
-	},
-	"ProxysADA": {
-		"deploy": false
-	},
-	"ProxysAUD": {
-		"deploy": false
-	},
-	"ProxysBCH": {
-		"deploy": false
-	},
-	"ProxysBNB": {
-		"deploy": false
-	},
-	"ProxysBTC": {
-		"deploy": false
-	},
-	"ProxysCEX": {
-		"deploy": false
-	},
-	"ProxysCHF": {
-		"deploy": false
-	},
-	"ProxysDASH": {
-		"deploy": false
-	},
-	"ProxysDEFI": {
-		"deploy": false
-	},
-	"ProxysEOS": {
-		"deploy": false
-	},
-	"ProxysETC": {
-		"deploy": false
-	},
-	"ProxysETH": {
-		"deploy": false
-	},
-	"ProxysEUR": {
-		"deploy": false
-	},
-	"ProxysFTSE": {
-		"deploy": false
-	},
-	"ProxysGBP": {
-		"deploy": false
-	},
-	"ProxysJPY": {
-		"deploy": false
-	},
-	"ProxysLINK": {
-		"deploy": false
-	},
-	"ProxysLTC": {
-		"deploy": false
-	},
-	"ProxysNIKKEI": {
-		"deploy": false
-	},
-	"ProxysOIL": {
-		"deploy": false
-	},
-	"ProxysTRX": {
-		"deploy": false
-	},
-	"ProxysUSD": {
-		"deploy": false
-	},
-	"ProxysXAG": {
-		"deploy": false
-	},
-	"ProxysXAU": {
-		"deploy": false
-	},
-	"ProxysXMR": {
-		"deploy": false
-	},
-	"ProxysXRP": {
-		"deploy": false
-	},
-	"ProxysXTZ": {
-		"deploy": false
-	},
-	"ReadProxyAddressResolver": {
 		"deploy": false
 	},
 	"RewardEscrow": {
@@ -221,13 +65,7 @@
 	"RewardsDistribution": {
 		"deploy": false
 	},
-	"SafeDecimalMath": {
-		"deploy": false
-	},
 	"SupplySchedule": {
-		"deploy": false
-	},
-	"SynthUtil": {
 		"deploy": false
 	},
 	"Synthetix": {
@@ -239,280 +77,442 @@
 	"SynthetixState": {
 		"deploy": false
 	},
-	"SynthiADA": {
+	"SystemStatus": {
 		"deploy": false
 	},
-	"SynthiBCH": {
+	"SynthUtil": {
 		"deploy": false
 	},
-	"SynthiBNB": {
-		"deploy": false
-	},
-	"SynthiBTC": {
-		"deploy": false
-	},
-	"SynthiCEX": {
-		"deploy": false
-	},
-	"SynthiDASH": {
-		"deploy": false
-	},
-	"SynthiDEFI": {
-		"deploy": false
-	},
-	"SynthiEOS": {
-		"deploy": false
-	},
-	"SynthiETC": {
-		"deploy": false
-	},
-	"SynthiETH": {
-		"deploy": false
-	},
-	"SynthiLINK": {
-		"deploy": false
-	},
-	"SynthiLTC": {
-		"deploy": false
-	},
-	"SynthiOIL": {
-		"deploy": false
-	},
-	"SynthiTRX": {
-		"deploy": false
-	},
-	"SynthiXMR": {
-		"deploy": false
-	},
-	"SynthiXRP": {
-		"deploy": false
-	},
-	"SynthiXTZ": {
-		"deploy": false
-	},
-	"SynthsADA": {
-		"deploy": false
-	},
-	"SynthsAUD": {
-		"deploy": false
-	},
-	"SynthsBCH": {
-		"deploy": false
-	},
-	"SynthsBNB": {
-		"deploy": false
-	},
-	"SynthsBTC": {
-		"deploy": false
-	},
-	"SynthsCEX": {
-		"deploy": false
-	},
-	"SynthsCHF": {
-		"deploy": false
-	},
-	"SynthsDASH": {
-		"deploy": false
-	},
-	"SynthsDEFI": {
-		"deploy": false
-	},
-	"SynthsEOS": {
-		"deploy": false
-	},
-	"SynthsETC": {
-		"deploy": false
-	},
-	"SynthsETH": {
-		"deploy": false
-	},
-	"SynthsEUR": {
-		"deploy": false
-	},
-	"SynthsFTSE": {
-		"deploy": false
-	},
-	"SynthsGBP": {
-		"deploy": false
-	},
-	"SynthsJPY": {
-		"deploy": false
-	},
-	"SynthsLINK": {
-		"deploy": false
-	},
-	"SynthsLTC": {
-		"deploy": false
-	},
-	"SynthsNIKKEI": {
-		"deploy": false
-	},
-	"SynthsOIL": {
-		"deploy": false
-	},
-	"SynthsTRX": {
+	"DappMaintenance": {
 		"deploy": false
 	},
 	"SynthsUSD": {
 		"deploy": false
 	},
-	"SynthsXAG": {
+	"SynthsEUR": {
+		"deploy": false
+	},
+	"SynthsJPY": {
+		"deploy": false
+	},
+	"SynthsAUD": {
+		"deploy": false
+	},
+	"SynthsGBP": {
+		"deploy": false
+	},
+	"SynthsCHF": {
 		"deploy": false
 	},
 	"SynthsXAU": {
 		"deploy": false
 	},
-	"SynthsXMR": {
+	"SynthsXAG": {
 		"deploy": false
 	},
-	"SynthsXRP": {
+	"SynthsBTC": {
 		"deploy": false
 	},
-	"SynthsXTZ": {
+	"ProxyERC20": {
 		"deploy": false
 	},
-	"SystemSettings": {
+	"ProxyFeePool": {
 		"deploy": false
 	},
-	"SystemStatus": {
+	"ProxySynthetix": {
+		"deploy": false
+	},
+	"ProxysUSD": {
+		"deploy": false
+	},
+	"ProxysEUR": {
+		"deploy": false
+	},
+	"ProxysJPY": {
+		"deploy": false
+	},
+	"ProxysAUD": {
+		"deploy": false
+	},
+	"ProxysGBP": {
+		"deploy": false
+	},
+	"ProxysCHF": {
+		"deploy": false
+	},
+	"ProxysXAU": {
+		"deploy": false
+	},
+	"ProxysXAG": {
+		"deploy": false
+	},
+	"ProxysBTC": {
+		"deploy": false
+	},
+	"SafeDecimalMath": {
+		"deploy": false
+	},
+	"Math": {
 		"deploy": false
 	},
 	"TokenStateSynthetix": {
 		"deploy": false
 	},
-	"TokenStateiADA": {
-		"deploy": false
-	},
-	"TokenStateiBCH": {
-		"deploy": false
-	},
-	"TokenStateiBNB": {
-		"deploy": false
-	},
-	"TokenStateiBTC": {
-		"deploy": false
-	},
-	"TokenStateiCEX": {
-		"deploy": false
-	},
-	"TokenStateiDASH": {
-		"deploy": false
-	},
-	"TokenStateiDEFI": {
-		"deploy": false
-	},
-	"TokenStateiEOS": {
-		"deploy": false
-	},
-	"TokenStateiETC": {
-		"deploy": false
-	},
-	"TokenStateiETH": {
-		"deploy": false
-	},
-	"TokenStateiLINK": {
-		"deploy": false
-	},
-	"TokenStateiLTC": {
-		"deploy": false
-	},
-	"TokenStateiOIL": {
-		"deploy": false
-	},
-	"TokenStateiTRX": {
-		"deploy": false
-	},
-	"TokenStateiXMR": {
-		"deploy": false
-	},
-	"TokenStateiXRP": {
-		"deploy": false
-	},
-	"TokenStateiXTZ": {
-		"deploy": false
-	},
-	"TokenStatesADA": {
-		"deploy": false
-	},
-	"TokenStatesAUD": {
-		"deploy": false
-	},
-	"TokenStatesBCH": {
-		"deploy": false
-	},
-	"TokenStatesBNB": {
-		"deploy": false
-	},
-	"TokenStatesBTC": {
-		"deploy": false
-	},
-	"TokenStatesCEX": {
-		"deploy": false
-	},
-	"TokenStatesCHF": {
-		"deploy": false
-	},
-	"TokenStatesDASH": {
-		"deploy": false
-	},
-	"TokenStatesDEFI": {
-		"deploy": false
-	},
-	"TokenStatesEOS": {
-		"deploy": false
-	},
-	"TokenStatesETC": {
-		"deploy": false
-	},
-	"TokenStatesETH": {
+	"TokenStatesUSD": {
 		"deploy": false
 	},
 	"TokenStatesEUR": {
 		"deploy": false
 	},
-	"TokenStatesFTSE": {
+	"TokenStatesJPY": {
+		"deploy": false
+	},
+	"TokenStatesAUD": {
 		"deploy": false
 	},
 	"TokenStatesGBP": {
 		"deploy": false
 	},
-	"TokenStatesJPY": {
-		"deploy": false
-	},
-	"TokenStatesLINK": {
-		"deploy": false
-	},
-	"TokenStatesLTC": {
-		"deploy": false
-	},
-	"TokenStatesNIKKEI": {
-		"deploy": false
-	},
-	"TokenStatesOIL": {
-		"deploy": false
-	},
-	"TokenStatesTRX": {
-		"deploy": false
-	},
-	"TokenStatesUSD": {
-		"deploy": false
-	},
-	"TokenStatesXAG": {
+	"TokenStatesCHF": {
 		"deploy": false
 	},
 	"TokenStatesXAU": {
 		"deploy": false
 	},
-	"TokenStatesXMR": {
+	"TokenStatesXAG": {
 		"deploy": false
 	},
-	"TokenStatesXRP": {
+	"TokenStatesBTC": {
+		"deploy": false
+	},
+	"TokenStatesETH": {
+		"deploy": false
+	},
+	"ProxysETH": {
+		"deploy": false
+	},
+	"SynthsETH": {
+		"deploy": false
+	},
+	"TokenStatesBNB": {
+		"deploy": false
+	},
+	"ProxysBNB": {
+		"deploy": false
+	},
+	"SynthsBNB": {
+		"deploy": false
+	},
+	"TokenStatesTRX": {
+		"deploy": false
+	},
+	"ProxysTRX": {
+		"deploy": false
+	},
+	"SynthsTRX": {
 		"deploy": false
 	},
 	"TokenStatesXTZ": {
 		"deploy": false
 	},
+	"ProxysXTZ": {
+		"deploy": false
+	},
+	"SynthsXTZ": {
+		"deploy": false
+	},
+	"TokenStateiBTC": {
+		"deploy": false
+	},
+	"ProxyiBTC": {
+		"deploy": false
+	},
+	"SynthiBTC": {
+		"deploy": false
+	},
+	"TokenStateiETH": {
+		"deploy": false
+	},
+	"ProxyiETH": {
+		"deploy": false
+	},
+	"SynthiETH": {
+		"deploy": false
+	},
+	"TokenStateiBNB": {
+		"deploy": false
+	},
+	"ProxyiBNB": {
+		"deploy": false
+	},
+	"SynthiBNB": {
+		"deploy": false
+	},
+	"TokenStateiTRX": {
+		"deploy": false
+	},
+	"ProxyiTRX": {
+		"deploy": false
+	},
+	"SynthiTRX": {
+		"deploy": false
+	},
+	"TokenStateiXTZ": {
+		"deploy": false
+	},
+	"ProxyiXTZ": {
+		"deploy": false
+	},
+	"SynthiXTZ": {
+		"deploy": false
+	},
+	"TokenStatesCEX": {
+		"deploy": false
+	},
+	"ProxysCEX": {
+		"deploy": false
+	},
+	"SynthsCEX": {
+		"deploy": false
+	},
+	"TokenStateiCEX": {
+		"deploy": false
+	},
+	"ProxyiCEX": {
+		"deploy": false
+	},
+	"SynthiCEX": {
+		"deploy": false
+	},
+	"ProxyERC20sUSD": {
+		"deploy": false
+	},
+	"TokenStatesXRP": {
+		"deploy": false
+	},
+	"ProxysXRP": {
+		"deploy": false
+	},
+	"SynthsXRP": {
+		"deploy": false
+	},
+	"TokenStatesLTC": {
+		"deploy": false
+	},
+	"ProxysLTC": {
+		"deploy": false
+	},
+	"SynthsLTC": {
+		"deploy": false
+	},
+	"TokenStatesLINK": {
+		"deploy": false
+	},
+	"ProxysLINK": {
+		"deploy": false
+	},
+	"SynthsLINK": {
+		"deploy": false
+	},
+	"TokenStatesDEFI": {
+		"deploy": false
+	},
+	"ProxysDEFI": {
+		"deploy": false
+	},
+	"SynthsDEFI": {
+		"deploy": false
+	},
+	"TokenStateiXRP": {
+		"deploy": false
+	},
+	"ProxyiXRP": {
+		"deploy": false
+	},
+	"SynthiXRP": {
+		"deploy": false
+	},
+	"TokenStateiLINK": {
+		"deploy": false
+	},
+	"ProxyiLINK": {
+		"deploy": false
+	},
+	"SynthiLINK": {
+		"deploy": false
+	},
+	"TokenStateiLTC": {
+		"deploy": false
+	},
+	"ProxyiLTC": {
+		"deploy": false
+	},
+	"SynthiLTC": {
+		"deploy": false
+	},
+	"TokenStateiDEFI": {
+		"deploy": false
+	},
+	"ProxyiDEFI": {
+		"deploy": false
+	},
+	"SynthiDEFI": {
+		"deploy": false
+	},
+	"TokenStatesEOS": {
+		"deploy": false
+	},
+	"ProxysEOS": {
+		"deploy": false
+	},
+	"SynthsEOS": {
+		"deploy": false
+	},
+	"TokenStatesBCH": {
+		"deploy": false
+	},
+	"ProxysBCH": {
+		"deploy": false
+	},
+	"SynthsBCH": {
+		"deploy": false
+	},
+	"TokenStatesETC": {
+		"deploy": false
+	},
+	"ProxysETC": {
+		"deploy": false
+	},
+	"SynthsETC": {
+		"deploy": false
+	},
+	"TokenStatesDASH": {
+		"deploy": false
+	},
+	"ProxysDASH": {
+		"deploy": false
+	},
+	"SynthsDASH": {
+		"deploy": false
+	},
+	"TokenStatesXMR": {
+		"deploy": false
+	},
+	"ProxysXMR": {
+		"deploy": false
+	},
+	"SynthsXMR": {
+		"deploy": false
+	},
+	"TokenStatesADA": {
+		"deploy": false
+	},
+	"ProxysADA": {
+		"deploy": false
+	},
+	"SynthsADA": {
+		"deploy": false
+	},
+	"TokenStatesFTSE": {
+		"deploy": false
+	},
+	"ProxysFTSE": {
+		"deploy": false
+	},
+	"SynthsFTSE": {
+		"deploy": false
+	},
+	"TokenStatesNIKKEI": {
+		"deploy": false
+	},
+	"ProxysNIKKEI": {
+		"deploy": false
+	},
+	"SynthsNIKKEI": {
+		"deploy": false
+	},
+	"TokenStateiEOS": {
+		"deploy": false
+	},
+	"ProxyiEOS": {
+		"deploy": false
+	},
+	"SynthiEOS": {
+		"deploy": false
+	},
+	"TokenStateiBCH": {
+		"deploy": false
+	},
+	"ProxyiBCH": {
+		"deploy": false
+	},
+	"SynthiBCH": {
+		"deploy": false
+	},
+	"TokenStateiETC": {
+		"deploy": false
+	},
+	"ProxyiETC": {
+		"deploy": false
+	},
+	"SynthiETC": {
+		"deploy": false
+	},
+	"TokenStateiDASH": {
+		"deploy": false
+	},
+	"ProxyiDASH": {
+		"deploy": false
+	},
+	"SynthiDASH": {
+		"deploy": false
+	},
+	"TokenStateiXMR": {
+		"deploy": false
+	},
+	"ProxyiXMR": {
+		"deploy": false
+	},
+	"SynthiXMR": {
+		"deploy": false
+	},
+	"TokenStateiADA": {
+		"deploy": false
+	},
+	"ProxyiADA": {
+		"deploy": false
+	},
+	"SynthiADA": {
+		"deploy": false
+	},
+	"FlexibleStorage": {
+		"deploy": false
+	},
+	"SystemSettings": {
+		"deploy": false
+	},
 	"TradingRewards": {
+		"deploy": false
+	},
+	"EtherCollateralsUSD": {
+		"deploy": false
+	},
+	"TokenStatesOIL": {
+		"deploy": false
+	},
+	"ProxysOIL": {
+		"deploy": false
+	},
+	"SynthsOIL": {
+		"deploy": false
+	},
+	"TokenStateiOIL": {
+		"deploy": false
+	},
+	"ProxyiOIL": {
+		"deploy": false
+	},
+	"SynthiOIL": {
 		"deploy": false
 	}
 }

--- a/publish/ovm-ignore.json
+++ b/publish/ovm-ignore.json
@@ -1,14 +1,54 @@
-[
-	"BinaryOption",
-	"BinaryOptionMarket",
-	"BinaryOptionMarketData",
-	"BinaryOptionMarketFactory",
-	"BinaryOptionMarketManager",
-	"EtherCollateral",
-	"EtherCollateralsUSD",
-	"ExchangerWithVirtualSynth",
-	"FakeTradingRewards",
-	"MockBinaryOptionMarket",
-	"MockBinaryOptionMarketManager",
-	"TestableBinaryOptionMarket"
-]
+{
+	"BinaryOption": {
+		"compile": false,
+		"ignore": false
+	},
+	"BinaryOptionMarket": {
+		"compile": false,
+		"ignore": false
+	},
+	"BinaryOptionMarketData": {
+		"compile": false,
+		"ignore": false
+	},
+	"BinaryOptionMarketFactory": {
+		"compile": false,
+		"ignore": false
+	},
+	"BinaryOptionMarketManager": {
+		"compile": false,
+		"ignore": false
+	},
+	"EtherCollateral": {
+		"compile": false,
+		"ignore": false
+	},
+	"EtherCollateralsUSD": {
+		"compile": false,
+		"ignore": false
+	},
+	"ExchangerWithVirtualSynth": {
+		"compile": false,
+		"ignore": false
+	},
+	"FakeTradingRewards": {
+		"compile": false,
+		"ignore": false
+	},
+	"MockBinaryOptionMarket": {
+		"compile": false,
+		"ignore": false
+	},
+	"MockBinaryOptionMarketManager": {
+		"compile": false,
+		"ignore": false
+	},
+	"TestableBinaryOptionMarket": {
+		"compile": false,
+		"ignore": false
+	},
+	"Synthetix": {
+		"compile": true,
+		"ignore": true
+	}
+}

--- a/publish/src/commands/build.js
+++ b/publish/src/commands/build.js
@@ -61,7 +61,8 @@ const build = async ({
 		const contractPaths = Object.keys(contracts);
 		contractPaths.map(contractPath => {
 			const filename = path.basename(contractPath, '.sol');
-			const isIgnored = ovmIgnored.some(ignored => filename === ignored);
+			const ignoredEntry = ovmIgnored[filename];
+			const isIgnored = ignoredEntry && !ignoredEntry.compile;
 
 			if (isIgnored) {
 				console.log(gray(`    > ${filename}`));
@@ -122,7 +123,7 @@ const build = async ({
 		const toWrite = path.join(compiledPath, contractName);
 		const filePath = `${toWrite}.json`;
 		const prevSizeIfAny = fs.existsSync(filePath)
-			? await sizeOfContracts({
+			? sizeOfContracts({
 					contractToObjectMap: { [filePath]: require(filePath).evm.deployedBytecode.object },
 			  })[0]
 			: undefined;


### PR DESCRIPTION
Allowing oversized contracts in the inheritance chain if they're not intended for direct deployment.

E.g. if MintableSynthetix inherits Synthetix, and sizeOf(MintableSynthetix) < sizeOf(Synthetix), and MintableSynthetix is the deployment target, then ovm-ignore.json can be used to indicate that we want to compile Synthetix, but exclude it from the oversize checks.