### PR TITLE
Add circleci paths to prettierignore for pretty-quick

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,5 @@
 build
 .coverage_*
 coverage
+.circleci/src
+.circleci/config.template.yml

--- a/.pretty-quick-ignore
+++ b/.pretty-quick-ignore
@@ -1,1 +1,0 @@
-.circleci/src/


### PR DESCRIPTION
When pretty-quick was moved from a bash script to package.json, I forgot to add `--ignore-path .pretty-quick-ignore`, which was causing pretty-quick to fail in the lint hook, on any circleci file change.

This fixes that, but also in a simpler way, dropping `.pretty-quick-ignore` in favor of `.prettierignore` and adding all yaml/mustache templates there.