### PR TITLE
Reduced circleci usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,7 +185,6 @@ jobs:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
-    resource_class: large
     steps:
       - checkout
       - attach_workspace:
@@ -223,7 +222,6 @@ jobs:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
-    resource_class: xlarge
     steps:
       - checkout
       - attach_workspace:
@@ -251,7 +249,6 @@ jobs:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
-    resource_class: large
     steps:
       - checkout
       - attach_workspace:
@@ -279,7 +276,6 @@ jobs:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
-    resource_class: large
     steps:
       - checkout
       - attach_workspace:
@@ -406,16 +402,6 @@ workflows:
           network: mainnet
           requires:
             - job-prepare
-      - job-prod-tests:
-          name: job-prod-tests-rinkeby
-          network: rinkeby
-          requires:
-            - job-prepare
-      - job-prod-tests:
-          name: job-prod-tests-kovan
-          network: kovan
-          requires:
-            - job-prepare
       - job-diff-prod-tests-local:
           name: job-diff-prod-tests-local
           requires:
@@ -450,22 +436,6 @@ workflows:
               only: /.*(staging|master).*/
           requires:
             - job-prepare
-      - job-prod-tests:
-          name: job-prod-tests-rinkeby
-          network: rinkeby
-          filters:
-            branches:
-              only: /.*(staging|master).*/
-          requires:
-            - job-prepare
-      - job-prod-tests:
-          name: job-prod-tests-kovan
-          network: kovan
-          filters:
-            branches:
-              only: /.*(staging|master).*/
-          requires:
-            - job-prepare
       - job-diff-prod-tests-local:
           name: job-diff-prod-tests-local
           filters:
@@ -483,22 +453,6 @@ workflows:
       - job-diff-prod-tests:
           name: job-diff-prod-tests-mainnet
           network: mainnet
-          filters:
-            branches:
-              only: /.*(staging|master).*/
-          requires:
-            - job-prepare
-      - job-diff-prod-tests:
-          name: job-diff-prod-tests-rinkeby
-          network: rinkeby
-          filters:
-            branches:
-              only: /.*(staging|master).*/
-          requires:
-            - job-prepare
-      - job-diff-prod-tests:
-          name: job-diff-prod-tests-kovan
-          network: kovan
           filters:
             branches:
               only: /.*(staging|master).*/

--- a/.circleci/src/jobs/job-test-deploy-script.yml
+++ b/.circleci/src/jobs/job-test-deploy-script.yml
@@ -1,6 +1,5 @@
 # Validates that the deploy command is working as expected
 {{> job-header.yml}}
-resource_class: large
 steps:
   - checkout
   - attach_workspace:

--- a/.circleci/src/jobs/job-unit-tests-coverage.yml
+++ b/.circleci/src/jobs/job-unit-tests-coverage.yml
@@ -1,6 +1,5 @@
 # Measures unit and spec test coverage
 {{> job-header.yml}}
-resource_class: xlarge
 steps:
   - checkout
   - attach_workspace:

--- a/.circleci/src/jobs/job-unit-tests-legacy.yml
+++ b/.circleci/src/jobs/job-unit-tests-legacy.yml
@@ -1,6 +1,5 @@
 # Runs unit tests against legacy contracts
 {{> job-header.yml}}
-resource_class: large
 steps:
   - checkout
   - attach_workspace:

--- a/.circleci/src/jobs/job-unit-tests.yml
+++ b/.circleci/src/jobs/job-unit-tests.yml
@@ -1,6 +1,5 @@
 # Runs all unit and spec tests
 {{> job-header.yml}}
-resource_class: large
 steps:
   - checkout
   - attach_workspace:

--- a/.circleci/src/workflows/workflow-scheduled.yml
+++ b/.circleci/src/workflows/workflow-scheduled.yml
@@ -21,14 +21,6 @@ jobs:
       name: job-prod-tests-mainnet
       network: mainnet
       {{> require-prepare.yml}}
-  - job-prod-tests:
-      name: job-prod-tests-rinkeby
-      network: rinkeby
-      {{> require-prepare.yml}}
-  - job-prod-tests:
-      name: job-prod-tests-kovan
-      network: kovan
-      {{> require-prepare.yml}}
 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Differential local production tests

--- a/.circleci/src/workflows/workflow-staging.yml
+++ b/.circleci/src/workflows/workflow-staging.yml
@@ -24,16 +24,6 @@ jobs:
       network: mainnet
       {{> filter-staging.yml}}
       {{> require-prepare.yml}}
-  - job-prod-tests:
-      name: job-prod-tests-rinkeby
-      network: rinkeby
-      {{> filter-staging.yml}}
-      {{> require-prepare.yml}}
-  - job-prod-tests:
-      name: job-prod-tests-kovan
-      network: kovan
-      {{> filter-staging.yml}}
-      {{> require-prepare.yml}}
 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Differential local production tests
@@ -53,15 +43,5 @@ jobs:
   - job-diff-prod-tests:
       name: job-diff-prod-tests-mainnet
       network: mainnet
-      {{> filter-staging.yml}}
-      {{> require-prepare.yml}}
-  - job-diff-prod-tests:
-      name: job-diff-prod-tests-rinkeby
-      network: rinkeby
-      {{> filter-staging.yml}}
-      {{> require-prepare.yml}}
-  - job-diff-prod-tests:
-      name: job-diff-prod-tests-kovan
-      network: kovan
       {{> filter-staging.yml}}
       {{> require-prepare.yml}}


### PR DESCRIPTION
Atm, hardhat forking only works for mainnet. Additionally, we want to reduce the CI load, so forking tests will only be done on mainnet.

This PR also removes circleci `resource_class` usages.