### PR TITLE
sip99

### DIFF
--- a/publish/assets.json
+++ b/publish/assets.json
@@ -279,7 +279,7 @@
 		"asset": "OIL",
 		"category": "commodity",
 		"sign": "$",
-		"description": "Brent Crude Oil"
+		"description": "Perpetual Oil Futures"
 	},
 	"FTSE100": {
 		"asset": "FTSE100",

--- a/publish/deployed/mainnet/feeds.json
+++ b/publish/deployed/mainnet/feeds.json
@@ -57,5 +57,5 @@
 		"feed": "0x5c4939a2ab3A2a9f93A518d81d4f8D0Bc6a68980"
 	},
 	"XAG": {"asset": "XAG", "feed": "0x379589227b15F1a12195D3f2d90bBc9F31f95235"},
-	"OIL": {"asset": "OIL", "feed": "0xb70ba475F1a6b5396e46d9b2a5f7081080Dc9d09"}
+	"OIL": {"asset": "OIL", "feed": "0xf3584F4dd3b467e73C2339EfD008665a70A4185c"}
 }

--- a/publish/deployed/mainnet/synths.json
+++ b/publish/deployed/mainnet/synths.json
@@ -380,9 +380,9 @@
 		"asset": "OIL",
 		"subclass": "PurgeableSynth",
 		"inverted": {
-			"entryPoint": 44.9459,
-			"upperLimit": 67.4189,
-			"lowerLimit": 22.473
+			"entryPoint": 45.087,
+			"upperLimit": 67.630,
+			"lowerLimit": 22.543
 		}
 	}
 ]


### PR DESCRIPTION
- Update the OIL feeds.json for mainnet to use the proxy above in develop
- Update the iOIL inverse rates in synths.json for mainnet to suit the current OIL price
- Update OIL in assets.json to not say Brent Crude Oil  but rather Perpetual Oil Futures
