### PR TITLE
Fixes coverage on CI on hardhat refactor

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,6 +222,7 @@ jobs:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:

--- a/.circleci/src/jobs/job-unit-tests-coverage.yml
+++ b/.circleci/src/jobs/job-unit-tests-coverage.yml
@@ -1,5 +1,6 @@
 # Measures unit and spec test coverage
 {{> job-header.yml}}
+resource_class: large
 steps:
   - checkout
   - attach_workspace:


### PR DESCRIPTION
We recently removed the xlarge resource class from the CI's coverage job. This caused the job to fail with error 147, which means out of memory. A setting of large seems to work.