### PR TITLE
Disable coverage in ci until its fixed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -346,12 +346,6 @@ workflows:
               only: /.*(develop|staging|master).*/
           requires:
             - job-prepare
-      - job-unit-tests-coverage:
-          filters:
-            branches:
-              only: /.*(develop|staging|master).*/
-          requires:
-            - job-prepare
       - job-unit-tests-gas-report:
           filters:
             branches:

--- a/.circleci/src/workflows/workflow-develop.yml
+++ b/.circleci/src/workflows/workflow-develop.yml
@@ -4,9 +4,9 @@ jobs:
   - job-unit-tests:
       {{> filter-develop.yml}}
       {{> require-prepare.yml}}
-  - job-unit-tests-coverage:
-      {{> filter-develop.yml}}
-      {{> require-prepare.yml}}
+  # - job-unit-tests-coverage:
+  #     {{> filter-develop.yml}}
+  #     {{> require-prepare.yml}}
   - job-unit-tests-gas-report:
       {{> filter-develop.yml}}
       {{> require-prepare.yml}}


### PR DESCRIPTION
Atm, coverage is not working with buidler. We're working on a fix in the hardhat migration, but it may take a while for that to be ready. Until then, we should disable it so that we don't have to sudo merge PRs.