### PR TITLE
Adds a command that deploys an OVM pair of instances on local chains

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,6 +113,7 @@
 		"prettier": "^1.14.2",
 		"prettier-plugin-solidity": "1.0.0-alpha.51",
 		"pretty-quick": "3.1.0",
+		"rlp": "^2.2.6",
 		"semver": "7.3.2",
 		"solc": "0.5.16",
 		"solhint": "^2.3.0",

--- a/publish/index.js
+++ b/publish/index.js
@@ -25,5 +25,6 @@ require('./src/commands/fork').cmd(program);
 require('./src/commands/prepare-deploy').cmd(program);
 require('./src/commands/prepare-deploy-detect-diff').cmd(program);
 require('./src/commands/connect-bridge').cmd(program);
+require('./src/commands/deploy-ovm-pair').cmd(program);
 
 program.parse(process.argv);

--- a/publish/src/Deployer.js
+++ b/publish/src/Deployer.js
@@ -148,35 +148,33 @@ class Deployer {
 		let deployedContract;
 
 		const areBytesSafeForOVM = bytes => {
-			for (let i = 0; i < bytes.length; i+=2) {
-  			const curByte = bytes.substr(i, 2)
-  			const opNum = parseInt(curByte, 16)
+			for (let i = 0; i < bytes.length; i += 2) {
+				const curByte = bytes.substr(i, 2);
+				const opNum = parseInt(curByte, 16);
 
-  			// opNum is >=0x60 and <0x80
-  			if(opNum >= 96 && opNum < 128) {
-    			i += 2 * (opNum - 95) //For PUSH##, OpNum - 0x5f = ##
-    			continue;
-  			}
+				// opNum is >=0x60 and <0x80
+				if (opNum >= 96 && opNum < 128) {
+					i += 2 * (opNum - 95); // For PUSH##, OpNum - 0x5f = ##
+					continue;
+				}
 
-  			if(curByte === '5b') {
-    			return false;
-  			}
+				if (curByte === '5b') {
+					return false;
+				}
 
-  			return true;
+				return true;
 			}
 		};
 
 		const getEncodedDeploymentParameters = ({ abi, params }) => {
-			let encodedParams = '0x';
-
 			const constructorABI = abi.find(item => item.type === 'constructor');
 			if (!constructorABI) {
-				return encodedParams;
+				return '0x';
 			}
 
 			const inputs = constructorABI.inputs;
 			if (!inputs || inputs.length === 0) {
-				return encodedParams;
+				return '0x';
 			}
 
 			const types = inputs.map(input => input.type);
@@ -237,7 +235,7 @@ class Deployer {
 				const code = await this.web3.eth.getCode(deployedContract.options.address);
 
 				if (code.length === 2) {
-					throw new Error('Contract deployment resulted in a contract with no bytecode');
+					throw new Error(`Contract deployment resulted in a contract with no bytecode: ${code}`);
 				}
 			}
 

--- a/publish/src/Deployer.js
+++ b/publish/src/Deployer.js
@@ -148,12 +148,22 @@ class Deployer {
 		let deployedContract;
 
 		const areBytesSafeForOVM = bytes => {
-			const idx = bytes.toLowerCase().indexOf('5b');
+			for (let i = 0; i < bytes.length; i+=2) {
+  			const curByte = bytes.substr(i, 2)
+  			const opNum = parseInt(curByte, 16)
 
-			const containsJumpdestOpcode = idx >= 0;
-			const isOpcodeAtAnEvenLoc = idx % 2 === 0;
+  			// opNum is >=0x60 and <0x80
+  			if(opNum >= 96 && opNum < 128) {
+    			i += 2 * (opNum - 95) //For PUSH##, OpNum - 0x5f = ##
+    			continue;
+  			}
 
-			return !(containsJumpdestOpcode && isOpcodeAtAnEvenLoc);
+  			if(curByte === '5b') {
+    			return false;
+  			}
+
+  			return true;
+			}
 		};
 
 		const getEncodedDeploymentParameters = ({ abi, params }) => {

--- a/publish/src/commands/connect-bridge.js
+++ b/publish/src/commands/connect-bridge.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const Web3 = require('web3');
-const { gray, red, yellow } = require('chalk');
+const { gray, red, yellow, green } = require('chalk');
 const { wrap, toBytes32 } = require('../../..');
 const {
 	ensureNetwork,
@@ -163,6 +163,8 @@ const connectLayer = async ({
 	} else {
 		console.log(yellow('  > Skipping, since this is a DRY RUN'));
 	}
+
+	console.log(green('All good!'));
 };
 
 const setupInstance = async ({

--- a/publish/src/commands/connect-bridge.js
+++ b/publish/src/commands/connect-bridge.js
@@ -155,11 +155,11 @@ const connectLayer = async ({
 
 		console.log(yellow(`  > AddressResolver.importAddresses([${ids}], [${addresses}])`));
 		tx = await AddressResolver.methods.importAddresses(ids, addresses).send(params);
-		console.log(JSON.stringify(tx, null, 2));
+		console.log(gray(`    > tx hash: ${tx.transactionHash}`));
 
 		console.log(yellow('  > SynthetixBridge.rebuildCache()...'));
 		tx = await SynthetixBridge.methods.rebuildCache().send(params);
-		console.log(JSON.stringify(tx, null, 2));
+		console.log(gray(`    > tx hash: ${tx.transactionHash}`));
 	} else {
 		console.log(yellow('  > Skipping, since this is a DRY RUN'));
 	}

--- a/publish/src/commands/connect-bridge.js
+++ b/publish/src/commands/connect-bridge.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const Web3 = require('web3');
-const { gray, red, yellow, green } = require('chalk');
+const { gray, red, yellow } = require('chalk');
 const { wrap, toBytes32 } = require('../../..');
 const {
 	ensureNetwork,
@@ -163,8 +163,6 @@ const connectLayer = async ({
 	} else {
 		console.log(yellow('  > Skipping, since this is a DRY RUN'));
 	}
-
-	console.log(green('All good!'));
 };
 
 const setupInstance = async ({

--- a/publish/src/commands/connect-bridge.js
+++ b/publish/src/commands/connect-bridge.js
@@ -13,6 +13,7 @@ const {
 const connectBridge = async ({
 	l1Network,
 	l2Network,
+	l1ProviderUrl,
 	l2ProviderUrl,
 	l1DeploymentPath,
 	l2DeploymentPath,
@@ -38,6 +39,7 @@ const connectBridge = async ({
 		account: accountL1,
 	} = await setupInstance({
 		network: l1Network,
+		providerUrl: l1ProviderUrl,
 		deploymentPath: l1DeploymentPath,
 		privateKey: l1PrivateKey,
 		useFork: l1UseFork,
@@ -149,10 +151,10 @@ const connectLayer = async ({
 	};
 
 	if (!dryRun) {
-		console.log(yellow('  > AddressResolver.importAddresses()...'));
-		tx = await AddressResolver.methods
-			.importAddresses(names.map(toBytes32), addresses)
-			.send(params);
+		const ids = names.map(toBytes32);
+
+		console.log(yellow(`  > AddressResolver.importAddresses([${ids}], [${addresses}])`));
+		tx = await AddressResolver.methods.importAddresses(ids, addresses).send(params);
 		console.log(JSON.stringify(tx, null, 2));
 
 		console.log(yellow('  > SynthetixBridge.rebuildCache()...'));
@@ -189,8 +191,9 @@ const setupInstance = async ({
 
 	let account;
 	if (privateKey) {
+		const idx = web3.eth.accounts.wallet.length;
 		web3.eth.accounts.wallet.add(privateKey);
-		web3.eth.defaultAccount = web3.eth.accounts.wallet[0].address;
+		web3.eth.defaultAccount = web3.eth.accounts.wallet[idx].address;
 		account = web3.eth.defaultAccount;
 	}
 	console.log(gray('  > account:', account));
@@ -290,6 +293,7 @@ module.exports = {
 			.description('Configures the bridge between an L1-L2 instance pair.')
 			.option('--l1-network <value>', 'The name of the target L1 network', 'goerli')
 			.option('--l2-network <value>', 'The name of the target L2 network', 'goerli')
+			.option('--l1-provider-url <value>', 'The L1 provider to use', undefined)
 			.option('--l2-provider-url <value>', 'The L2 provider to use', 'https://goerli.optimism.io')
 			.option('--l1-deployment-path <value>', 'The path of the L1 deployment to target')
 			.option('--l2-deployment-path <value>', 'The path of the L2 deployment to target')

--- a/publish/src/commands/deploy-ovm-pair.js
+++ b/publish/src/commands/deploy-ovm-pair.js
@@ -37,7 +37,7 @@ const getMessengers = async () => {
 	};
 };
 
-const deployInstance = async ({ useOvm, providerUrl }) => {
+const deployInstance = async ({ useOvm }) => {
 	await commands.build({ useOvm });
 
 	await commands.deploy({

--- a/publish/src/commands/deploy-ovm-pair.js
+++ b/publish/src/commands/deploy-ovm-pair.js
@@ -1,0 +1,72 @@
+const axios = require('axios');
+const { red } = require('chalk');
+const commands = {
+	build: require('./build').build,
+	deploy: require('./deploy').deploy,
+	connectBridge: require('./connect-bridge').connectBridge,
+};
+
+const L1_PROVIDER_URL = 'http://localhost:9545';
+const L2_PROVIDER_URL = 'http://localhost:8545';
+const DATA_PROVIDER_URL = 'http://localhost:8080';
+
+const deployOvmPair = async () => {
+	await deployInstance({ useOvm: false });
+	await deployInstance({ useOvm: true });
+
+	const { l1Messenger, l2Messenger } = await getMessengers();
+	await commands.connectBridge({
+		l1Network: 'local',
+		l2Network: 'local',
+		l1ProviderUrl: L1_PROVIDER_URL,
+		l2ProviderUrl: L2_PROVIDER_URL,
+		l1Messenger,
+		l2Messenger,
+	});
+};
+
+const getMessengers = async () => {
+	const response = await axios.get(`${DATA_PROVIDER_URL}/addresses.json`);
+	const addresses = response.data;
+
+	// These might appear to be inverted, but their not.
+	// Optimism uses a slightly different naming convention.
+	return {
+		l1Messenger: addresses['OVM_L2CrossDomainMessenger'],
+		l2Messenger: addresses['OVM_L1CrossDomainMessenger'],
+	};
+};
+
+const deployInstance = async ({ useOvm, providerUrl }) => {
+	await commands.build({ useOvm });
+
+	await commands.deploy({
+		network: 'local',
+		freshDeploy: true,
+		yes: true,
+		providerUrl: useOvm ? L1_PROVIDER_URL : L2_PROVIDER_URL,
+		gasPrice: 0,
+		useOvm,
+		methodCallGasLimit: 2500000,
+		contractDeploymentGasLimit: 11000000,
+	});
+};
+
+module.exports = {
+	deployOvmPair,
+	cmd: program =>
+		program
+			.command('deploy-ovm-pair')
+			.description(
+				'Deploys a pair of L1 and L2 instances on local running chains started with `optimism-integration`, and connects them together. To be used exclusively for local testing.'
+			)
+			.action(async (...args) => {
+				try {
+					await deployOvmPair(...args);
+				} catch (err) {
+					console.error(red(err));
+					console.log(err.stack);
+					process.exitCode = 1;
+				}
+			}),
+};

--- a/publish/src/commands/deploy-ovm-pair.js
+++ b/publish/src/commands/deploy-ovm-pair.js
@@ -1,5 +1,4 @@
 const axios = require('axios');
-const ethers = require('ethers');
 const { red } = require('chalk');
 const commands = {
 	build: require('./build').build,
@@ -12,12 +11,9 @@ const L2_PROVIDER_URL = 'http://localhost:8545';
 const DATA_PROVIDER_URL = 'http://localhost:8080';
 
 const deployOvmPair = async () => {
-	// This is the mnemonic used by optimism-integration.
-	// Using a mnemonic here allows us to choose one of those addresses by index
-	const mnemonic =
-		'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
-	const masterKey = ethers.utils.HDNode.fromMnemonic(mnemonic);
-	const privateKey = masterKey.derivePath(`m/44'/60'/0'/0/${42}`);
+	// This private key is #4 displayed when starting optimism-integration.
+	// When used on a fresh L2 chain, it passes all safety checks.
+	const privateKey = '0xea8b000efb33c49d819e8d6452f681eed55cdf7de47d655887fc0e318906f2e7';
 
 	await deployInstance({ useOvm: false, privateKey });
 	await deployInstance({ useOvm: true, privateKey });
@@ -33,11 +29,14 @@ const deployOvmPair = async () => {
 		l2Messenger,
 		l1PrivateKey: privateKey,
 		l2PrivateKey: privateKey,
+		l1GasPrice: 0,
+		l2GasPrice: 0,
+		gasLimit: 8000000,
 	});
 };
 
 const deployInstance = async ({ useOvm, privateKey }) => {
-	// await commands.build({ useOvm });
+	await commands.build({ useOvm });
 
 	await commands.deploy({
 		network: 'local',

--- a/publish/src/commands/deploy-ovm-pair.js
+++ b/publish/src/commands/deploy-ovm-pair.js
@@ -17,7 +17,7 @@ const deployOvmPair = async () => {
 	const mnemonic =
 		'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
 	const masterKey = ethers.utils.HDNode.fromMnemonic(mnemonic);
-	const privateKey = masterKey.derivePath(`m/44'/60'/0'/0/${14}`);
+	const privateKey = masterKey.derivePath(`m/44'/60'/0'/0/${15}`);
 
 	// await deployInstance({ useOvm: false, privateKey });
 	await deployInstance({ useOvm: true, privateKey });

--- a/publish/src/commands/deploy-ovm-pair.js
+++ b/publish/src/commands/deploy-ovm-pair.js
@@ -17,23 +17,23 @@ const deployOvmPair = async () => {
 	const mnemonic =
 		'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about';
 	const masterKey = ethers.utils.HDNode.fromMnemonic(mnemonic);
-	const privateKey = masterKey.derivePath(`m/44'/60'/0'/0/${15}`);
+	const privateKey = masterKey.derivePath(`m/44'/60'/0'/0/${42}`);
 
-	// await deployInstance({ useOvm: false, privateKey });
+	await deployInstance({ useOvm: false, privateKey });
 	await deployInstance({ useOvm: true, privateKey });
 
-	// const { l1Messenger, l2Messenger } = await getMessengers();
+	const { l1Messenger, l2Messenger } = await getMessengers();
 
-	// await commands.connectBridge({
-	// 	l1Network: 'local',
-	// 	l2Network: 'local',
-	// 	l1ProviderUrl: L1_PROVIDER_URL,
-	// 	l2ProviderUrl: L2_PROVIDER_URL,
-	// 	l1Messenger,
-	// 	l2Messenger,
-	// 	l1PrivateKey: privateKey,
-	// 	l2PrivateKey: privateKey,
-	// });
+	await commands.connectBridge({
+		l1Network: 'local',
+		l2Network: 'local',
+		l1ProviderUrl: L1_PROVIDER_URL,
+		l2ProviderUrl: L2_PROVIDER_URL,
+		l1Messenger,
+		l2Messenger,
+		l1PrivateKey: privateKey,
+		l2PrivateKey: privateKey,
+	});
 };
 
 const deployInstance = async ({ useOvm, privateKey }) => {
@@ -44,7 +44,7 @@ const deployInstance = async ({ useOvm, privateKey }) => {
 		freshDeploy: true,
 		yes: true,
 		providerUrl: useOvm ? L2_PROVIDER_URL : L1_PROVIDER_URL,
-		// gasPrice: '0',
+		gasPrice: '0',
 		useOvm,
 		methodCallGasLimit: '3500000',
 		contractDeploymentGasLimit: useOvm ? '11000000' : '9500000',

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -43,6 +43,18 @@ const DEFAULTS = {
 	buildPath: path.join(__dirname, '..', '..', '..', BUILD_FOLDER),
 };
 
+function splitArrayIntoChunks(array, chunkSize) {
+	const chunks = [];
+	for (let i = 0; i < array.length; i += chunkSize) {
+		const chunk = array.slice(i, i + chunkSize);
+		if (chunk.length > 0) {
+			chunks.push(chunk);
+		}
+	}
+
+	return chunks;
+}
+
 const deploy = async ({
 	addNewSynths,
 	gasPrice = DEFAULTS.gasPrice,
@@ -1277,22 +1289,37 @@ const deploy = async ({
 	console.log(gray('Addresses are correctly set up, continuing...'));
 
 	// now ensure all resolvers are set
-	await runStep({
-		gasLimit: 7e6, // higher gas required
-		contract: `AddressResolver`,
-		target: addressResolver,
-		write: 'rebuildCaches',
-		writeArg: [
-			contractsWithRebuildableCache.map(
-				([
-					,
-					{
-						options: { address },
-					},
-				]) => address
-			),
-		],
-	});
+	// NOTE: If using OVM, split the array of addresses to cache,
+	// since things spend signifficantly more gas in OVM
+	const addressesToCache = contractsWithRebuildableCache.map(
+		([
+			,
+			{
+				options: { address },
+			},
+		]) => address
+	);
+	if (useOvm) {
+		const chunks = splitArrayIntoChunks(addressesToCache, 5);
+		for (let i = 0; i < chunks.length; i++) {
+			const chunk = chunks[i];
+			await runStep({
+				gasLimit: 7e6, // higher gas required
+				contract: `AddressResolver`,
+				target: addressResolver,
+				write: 'rebuildCaches',
+				writeArg: [chunk],
+			});
+		}
+	} else {
+		await runStep({
+			gasLimit: 7e6, // higher gas required
+			contract: `AddressResolver`,
+			target: addressResolver,
+			write: 'rebuildCaches',
+			writeArg: [addressesToCache],
+		});
+	}
 
 	console.log(gray('Double check all contracts with rebuildCache() are rebuilt...'));
 	for (const [contract, target] of contractsWithRebuildableCache) {

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -1300,7 +1300,7 @@ const deploy = async ({
 		]) => address
 	);
 	if (useOvm) {
-		const chunks = splitArrayIntoChunks(addressesToCache, 5);
+		const chunks = splitArrayIntoChunks(addressesToCache, 4);
 		for (let i = 0; i < chunks.length; i++) {
 			const chunk = chunks[i];
 			await runStep({


### PR DESCRIPTION
Assuming that docker is used to start a local L1 chain and a local L2 chain using https://github.com/ethereum-optimism/optimism-integration, this PR adds a `deploy-ovm-pair` command that deploys and connects a pair of instances to be used for local production tests.

The PR also introduces OVM safety checking in the deployment process, to ensure that no dangerous `5b` or `JUMPDEST` opcodes exist in appended deployment constructor parameters.

Another interesting addition of the PR, is the ability for the deployment script to split addresses being imported in the AddressResolver into chunks. This was needed for OVM to avoid that call to exceed the block limit.

To try the script out:
1. `git clone git@github.com:ethereum-optimism/optimism-integration.git`
2. `cd optimism-integration`
3. `docker-compose pull`
4. `./up.sh`
5. Wait 30 seconds or so for the chains to kick off
6. `cd ~/synthetix` (or wherever)
7. `node publish deploy-ovm-pair`