### PR TITLE
Always return named parameter for resolverAddressesRequired()

### DIFF
--- a/contracts/DebtCache.sol
+++ b/contracts/DebtCache.sol
@@ -56,7 +56,7 @@ contract DebtCache is Owned, MixinSystemSettings, IDebtCache {
         newAddresses[3] = CONTRACT_SYSTEMSTATUS;
         newAddresses[4] = CONTRACT_ETHERCOLLATERAL;
         newAddresses[5] = CONTRACT_ETHERCOLLATERAL_SUSD;
-        return combineArrays(existingAddresses, newAddresses);
+        addresses = combineArrays(existingAddresses, newAddresses);
     }
 
     function issuer() internal view returns (IIssuer) {

--- a/contracts/ExchangeRates.sol
+++ b/contracts/ExchangeRates.sol
@@ -216,7 +216,7 @@ contract ExchangeRates is Owned, MixinSystemSettings, IExchangeRates {
         bytes32[] memory existingAddresses = MixinSystemSettings.resolverAddressesRequired();
         bytes32[] memory newAddresses = new bytes32[](1);
         newAddresses[0] = CONTRACT_EXCHANGER;
-        return combineArrays(existingAddresses, newAddresses);
+        addresses = combineArrays(existingAddresses, newAddresses);
     }
 
     // SIP-75 View to determine if freezeRate can be called safely

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -116,7 +116,7 @@ contract Exchanger is Owned, MixinSystemSettings, IExchanger {
         newAddresses[6] = CONTRACT_DELEGATEAPPROVALS;
         newAddresses[7] = CONTRACT_ISSUER;
         newAddresses[8] = CONTRACT_DEBTCACHE;
-        return combineArrays(existingAddresses, newAddresses);
+        addresses = combineArrays(existingAddresses, newAddresses);
     }
 
     function systemStatus() internal view returns (ISystemStatus) {

--- a/contracts/FeePool.sol
+++ b/contracts/FeePool.sol
@@ -102,7 +102,7 @@ contract FeePool is Owned, Proxyable, LimitedSetup, MixinSystemSettings, IFeePoo
         newAddresses[8] = CONTRACT_DELEGATEAPPROVALS;
         newAddresses[9] = CONTRACT_ETH_COLLATERAL_SUSD;
         newAddresses[10] = CONTRACT_REWARDSDISTRIBUTION;
-        return combineArrays(existingAddresses, newAddresses);
+        addresses = combineArrays(existingAddresses, newAddresses);
     }
 
     function systemStatus() internal view returns (ISystemStatus) {

--- a/contracts/Issuer.sol
+++ b/contracts/Issuer.sol
@@ -99,7 +99,7 @@ contract Issuer is Owned, MixinSystemSettings, IIssuer {
         newAddresses[9] = CONTRACT_SYNTHETIXESCROW;
         newAddresses[10] = CONTRACT_LIQUIDATIONS;
         newAddresses[11] = CONTRACT_DEBTCACHE;
-        return combineArrays(existingAddresses, newAddresses);
+        addresses = combineArrays(existingAddresses, newAddresses);
     }
 
     function synthetix() internal view returns (ISynthetix) {

--- a/contracts/Liquidations.sol
+++ b/contracts/Liquidations.sol
@@ -52,7 +52,7 @@ contract Liquidations is Owned, MixinSystemSettings, ILiquidations {
         newAddresses[2] = CONTRACT_ETERNALSTORAGE_LIQUIDATIONS;
         newAddresses[3] = CONTRACT_ISSUER;
         newAddresses[4] = CONTRACT_EXRATES;
-        return combineArrays(existingAddresses, newAddresses);
+        addresses = combineArrays(existingAddresses, newAddresses);
     }
 
     function synthetix() internal view returns (ISynthetix) {

--- a/contracts/MintableSynthetix.sol
+++ b/contracts/MintableSynthetix.sol
@@ -40,7 +40,7 @@ contract MintableSynthetix is BaseSynthetix {
         bytes32[] memory existingAddresses = BaseSynthetix.resolverAddressesRequired();
         bytes32[] memory newAddresses = new bytes32[](1);
         newAddresses[0] = CONTRACT_SYNTHETIX_BRIDGE;
-        return combineArrays(existingAddresses, newAddresses);
+        addresses = combineArrays(existingAddresses, newAddresses);
     }
 
     function synthetixBridge() internal view returns (address) {

--- a/contracts/MultiCollateralSynth.sol
+++ b/contracts/MultiCollateralSynth.sol
@@ -30,7 +30,7 @@ contract MultiCollateralSynth is Synth {
         bytes32[] memory existingAddresses = Synth.resolverAddressesRequired();
         bytes32[] memory newAddresses = new bytes32[](1);
         newAddresses[0] = multiCollateralKey;
-        return combineArrays(existingAddresses, newAddresses);
+        addresses = combineArrays(existingAddresses, newAddresses);
     }
 
     function multiCollateral() internal view returns (address) {

--- a/contracts/PurgeableSynth.sol
+++ b/contracts/PurgeableSynth.sol
@@ -37,7 +37,7 @@ contract PurgeableSynth is Synth {
         bytes32[] memory existingAddresses = Synth.resolverAddressesRequired();
         bytes32[] memory newAddresses = new bytes32[](1);
         newAddresses[0] = CONTRACT_EXRATES;
-        return combineArrays(existingAddresses, newAddresses);
+        addresses = combineArrays(existingAddresses, newAddresses);
     }
 
     function exchangeRates() internal view returns (IExchangeRates) {

--- a/contracts/SynthetixBridgeToBase.sol
+++ b/contracts/SynthetixBridgeToBase.sol
@@ -60,12 +60,12 @@ contract SynthetixBridgeToBase is Owned, MixinSystemSettings, ISynthetixBridgeTo
 
     function resolverAddressesRequired() public view returns (bytes32[] memory addresses) {
         bytes32[] memory existingAddresses = MixinSystemSettings.resolverAddressesRequired();
-        addresses = new bytes32[](4);
-        addresses[0] = CONTRACT_EXT_MESSENGER;
-        addresses[1] = CONTRACT_SYNTHETIX;
-        addresses[2] = CONTRACT_BASE_SYNTHETIXBRIDGETOOPTIMISM;
-        addresses[3] = CONTRACT_ISSUER;
-        addresses = combineArrays(existingAddresses, addresses);
+        bytes32[] memory newAddresses = new bytes32[](4);
+        newAddresses[0] = CONTRACT_EXT_MESSENGER;
+        newAddresses[1] = CONTRACT_SYNTHETIX;
+        newAddresses[2] = CONTRACT_BASE_SYNTHETIXBRIDGETOOPTIMISM;
+        newAddresses[3] = CONTRACT_ISSUER;
+        addresses = combineArrays(existingAddresses, newAddresses);
     }
 
     // ========== PUBLIC FUNCTIONS =========

--- a/contracts/SynthetixBridgeToBase.sol
+++ b/contracts/SynthetixBridgeToBase.sol
@@ -58,9 +58,9 @@ contract SynthetixBridgeToBase is Owned, MixinSystemSettings, ISynthetixBridgeTo
 
     // ========== VIEWS ==========
 
-    function resolverAddressesRequired() public view returns (bytes32[] memory) {
+    function resolverAddressesRequired() public view returns (bytes32[] memory addresses) {
         bytes32[] memory existingAddresses = MixinSystemSettings.resolverAddressesRequired();
-        bytes32[] memory addresses = new bytes32[](4);
+        addresses = new bytes32[](4);
         addresses[0] = CONTRACT_EXT_MESSENGER;
         addresses[1] = CONTRACT_SYNTHETIX;
         addresses[2] = CONTRACT_BASE_SYNTHETIXBRIDGETOOPTIMISM;

--- a/contracts/SynthetixBridgeToBase.sol
+++ b/contracts/SynthetixBridgeToBase.sol
@@ -65,7 +65,7 @@ contract SynthetixBridgeToBase is Owned, MixinSystemSettings, ISynthetixBridgeTo
         addresses[1] = CONTRACT_SYNTHETIX;
         addresses[2] = CONTRACT_BASE_SYNTHETIXBRIDGETOOPTIMISM;
         addresses[3] = CONTRACT_ISSUER;
-        return combineArrays(existingAddresses, addresses);
+        addresses = combineArrays(existingAddresses, addresses);
     }
 
     // ========== PUBLIC FUNCTIONS =========

--- a/contracts/SynthetixBridgeToOptimism.sol
+++ b/contracts/SynthetixBridgeToOptimism.sol
@@ -74,9 +74,9 @@ contract SynthetixBridgeToOptimism is Owned, MixinSystemSettings, ISynthetixBrid
 
     /* ========== VIEWS ========== */
 
-    function resolverAddressesRequired() public view returns (bytes32[] memory) {
+    function resolverAddressesRequired() public view returns (bytes32[] memory addresses) {
         bytes32[] memory existingAddresses = MixinSystemSettings.resolverAddressesRequired();
-        bytes32[] memory addresses = new bytes32[](5);
+        addresses = new bytes32[](5);
         addresses[0] = CONTRACT_EXT_MESSENGER;
         addresses[1] = CONTRACT_SYNTHETIX;
         addresses[2] = CONTRACT_ISSUER;

--- a/contracts/SynthetixBridgeToOptimism.sol
+++ b/contracts/SynthetixBridgeToOptimism.sol
@@ -82,7 +82,7 @@ contract SynthetixBridgeToOptimism is Owned, MixinSystemSettings, ISynthetixBrid
         addresses[2] = CONTRACT_ISSUER;
         addresses[3] = CONTRACT_REWARDSDISTRIBUTION;
         addresses[4] = CONTRACT_OVM_SYNTHETIXBRIDGETOBASE;
-        return combineArrays(existingAddresses, addresses);
+        addresses = combineArrays(existingAddresses, addresses);
     }
 
     // ========== MODIFIERS ============

--- a/contracts/SynthetixBridgeToOptimism.sol
+++ b/contracts/SynthetixBridgeToOptimism.sol
@@ -76,13 +76,13 @@ contract SynthetixBridgeToOptimism is Owned, MixinSystemSettings, ISynthetixBrid
 
     function resolverAddressesRequired() public view returns (bytes32[] memory addresses) {
         bytes32[] memory existingAddresses = MixinSystemSettings.resolverAddressesRequired();
-        addresses = new bytes32[](5);
-        addresses[0] = CONTRACT_EXT_MESSENGER;
-        addresses[1] = CONTRACT_SYNTHETIX;
-        addresses[2] = CONTRACT_ISSUER;
-        addresses[3] = CONTRACT_REWARDSDISTRIBUTION;
-        addresses[4] = CONTRACT_OVM_SYNTHETIXBRIDGETOBASE;
-        addresses = combineArrays(existingAddresses, addresses);
+        bytes32[] memory newAddresses = new bytes32[](5);
+        newAddresses[0] = CONTRACT_EXT_MESSENGER;
+        newAddresses[1] = CONTRACT_SYNTHETIX;
+        newAddresses[2] = CONTRACT_ISSUER;
+        newAddresses[3] = CONTRACT_REWARDSDISTRIBUTION;
+        newAddresses[4] = CONTRACT_OVM_SYNTHETIXBRIDGETOBASE;
+        addresses = combineArrays(existingAddresses, newAddresses);
     }
 
     // ========== MODIFIERS ============


### PR DESCRIPTION
As far as I know, naming a return variable and using the return statement does not have unwanted effects. I've also verified this in Remix.

However, I believe that the code is semantically incorrect like this, and deviations between what's written and what's intended should always be avoided.