### PR TITLE
deploy: ovm-pair cli options

### DIFF
--- a/publish/src/commands/deploy-ovm-pair.js
+++ b/publish/src/commands/deploy-ovm-pair.js
@@ -86,6 +86,7 @@ module.exports = {
 			)
 			.option('--l1-provider-url <value>', 'The L1 provider to use', L1_PROVIDER_URL)
 			.option('--l2-provider-url <value>', 'The L2 provider to use', L2_PROVIDER_URL)
+			.option('--data-provider-url <value>', 'The data provider to use', DATA_PROVIDER_URL)
 			.action(async (...args) => {
 				try {
 					await deployOvmPair(...args);

--- a/publish/src/commands/deploy-ovm-pair.js
+++ b/publish/src/commands/deploy-ovm-pair.js
@@ -10,6 +10,7 @@ const {
 	constants: { OVM_MAX_GAS_LIMIT },
 } = require('../../../.');
 
+// Default values for CLI flags
 const L1_PROVIDER_URL = 'http://localhost:9545';
 const L2_PROVIDER_URL = 'http://localhost:8545';
 const DATA_PROVIDER_URL = 'http://localhost:8080';
@@ -29,8 +30,8 @@ const deployOvmPair = async ({ l1ProviderUrl, l2ProviderUrl }) => {
 	// Private Key: 0xea8b000efb33c49d819e8d6452f681eed55cdf7de47d655887fc0e318906f2e7
 	const privateKey = '0xea8b000efb33c49d819e8d6452f681eed55cdf7de47d655887fc0e318906f2e7';
 
-	await deployInstance({ useOvm: false, privateKey });
-	await deployInstance({ useOvm: true, privateKey });
+	await deployInstance({ useOvm: false, privateKey, l1ProviderUrl, l2ProviderUrl });
+	await deployInstance({ useOvm: true, privateKey, l1ProviderUrl, l2ProviderUrl });
 
 	const { l1Messenger, l2Messenger } = await getMessengers();
 
@@ -49,14 +50,14 @@ const deployOvmPair = async ({ l1ProviderUrl, l2ProviderUrl }) => {
 	});
 };
 
-const deployInstance = async ({ useOvm, privateKey }) => {
+const deployInstance = async ({ useOvm, privateKey, l1ProviderUrl, l2ProviderUrl }) => {
 	await commands.build({ useOvm, optimizerRuns: useOvm ? 1 : 200, testHelpers: true });
 
 	await commands.deploy({
 		network: 'local',
 		freshDeploy: true,
 		yes: true,
-		providerUrl: useOvm ? L2_PROVIDER_URL : L1_PROVIDER_URL,
+		providerUrl: useOvm ? l2ProviderUrl : l1ProviderUrl,
 		gasPrice: '0',
 		useOvm,
 		methodCallGasLimit: '3500000',

--- a/publish/src/commands/deploy-ovm-pair.js
+++ b/publish/src/commands/deploy-ovm-pair.js
@@ -15,7 +15,7 @@ const L1_PROVIDER_URL = 'http://localhost:9545';
 const L2_PROVIDER_URL = 'http://localhost:8545';
 const DATA_PROVIDER_URL = 'http://localhost:8080';
 
-const deployOvmPair = async ({ l1ProviderUrl, l2ProviderUrl }) => {
+const deployOvmPair = async ({ l1ProviderUrl, l2ProviderUrl, dataProviderUrl }) => {
 	// This private key is #4 displayed when starting optimism-integration.
 	// When used on a fresh L2 chain, it passes all safety checks.
 	// Account #0: 0x023ffdc1530468eb8c8eebc3e38380b5bc19cc5d (10000 ETH)
@@ -33,7 +33,7 @@ const deployOvmPair = async ({ l1ProviderUrl, l2ProviderUrl }) => {
 	await deployInstance({ useOvm: false, privateKey, l1ProviderUrl, l2ProviderUrl });
 	await deployInstance({ useOvm: true, privateKey, l1ProviderUrl, l2ProviderUrl });
 
-	const { l1Messenger, l2Messenger } = await getMessengers();
+	const { l1Messenger, l2Messenger } = await getMessengers({ dataProviderUrl });
 
 	await commands.connectBridge({
 		l1Network: 'local',
@@ -67,8 +67,8 @@ const deployInstance = async ({ useOvm, privateKey, l1ProviderUrl, l2ProviderUrl
 	});
 };
 
-const getMessengers = async () => {
-	const response = await axios.get(`${DATA_PROVIDER_URL}/addresses.json`);
+const getMessengers = async ({ dataProviderUrl }) => {
+	const response = await axios.get(`${dataProviderUrl}/addresses.json`);
 	const addresses = response.data;
 
 	return {

--- a/publish/src/commands/deploy-ovm-pair.js
+++ b/publish/src/commands/deploy-ovm-pair.js
@@ -14,7 +14,7 @@ const L1_PROVIDER_URL = 'http://localhost:9545';
 const L2_PROVIDER_URL = 'http://localhost:8545';
 const DATA_PROVIDER_URL = 'http://localhost:8080';
 
-const deployOvmPair = async () => {
+const deployOvmPair = async ({ l1ProviderUrl, l2ProviderUrl }) => {
 	// This private key is #4 displayed when starting optimism-integration.
 	// When used on a fresh L2 chain, it passes all safety checks.
 	// Account #0: 0x023ffdc1530468eb8c8eebc3e38380b5bc19cc5d (10000 ETH)
@@ -37,8 +37,8 @@ const deployOvmPair = async () => {
 	await commands.connectBridge({
 		l1Network: 'local',
 		l2Network: 'local',
-		l1ProviderUrl: L1_PROVIDER_URL,
-		l2ProviderUrl: L2_PROVIDER_URL,
+		l1ProviderUrl: l1ProviderUrl,
+		l2ProviderUrl: l2ProviderUrl,
 		l1Messenger,
 		l2Messenger,
 		l1PrivateKey: privateKey,
@@ -84,6 +84,8 @@ module.exports = {
 			.description(
 				'Deploys a pair of L1 and L2 instances on local running chains started with `optimism-integration`, and connects them together. To be used exclusively for local testing.'
 			)
+			.option('--l1-provider-url <value>', 'The L1 provider to use', L1_PROVIDER_URL)
+			.option('--l2-provider-url <value>', 'The L2 provider to use', L2_PROVIDER_URL)
 			.action(async (...args) => {
 				try {
 					await deployOvmPair(...args);

--- a/publish/src/commands/deploy-ovm-pair.js
+++ b/publish/src/commands/deploy-ovm-pair.js
@@ -10,11 +10,6 @@ const {
 	constants: { OVM_MAX_GAS_LIMIT },
 } = require('../../../.');
 
-// Default values for CLI flags
-const L1_PROVIDER_URL = 'http://localhost:9545';
-const L2_PROVIDER_URL = 'http://localhost:8545';
-const DATA_PROVIDER_URL = 'http://localhost:8080';
-
 const deployOvmPair = async ({ l1ProviderUrl, l2ProviderUrl, dataProviderUrl }) => {
 	// This private key is #4 displayed when starting optimism-integration.
 	// When used on a fresh L2 chain, it passes all safety checks.
@@ -85,9 +80,9 @@ module.exports = {
 			.description(
 				'Deploys a pair of L1 and L2 instances on local running chains started with `optimism-integration`, and connects them together. To be used exclusively for local testing.'
 			)
-			.option('--l1-provider-url <value>', 'The L1 provider to use', L1_PROVIDER_URL)
-			.option('--l2-provider-url <value>', 'The L2 provider to use', L2_PROVIDER_URL)
-			.option('--data-provider-url <value>', 'The data provider to use', DATA_PROVIDER_URL)
+			.option('--l1-provider-url <value>', 'The L1 provider to use', 'http://localhost:9545')
+			.option('--l2-provider-url <value>', 'The L2 provider to use', 'http://localhost:8545')
+			.option('--data-provider-url <value>', 'The data provider to use', 'http://localhost:8080')
 			.action(async (...args) => {
 				try {
 					await deployOvmPair(...args);


### PR DESCRIPTION
Adds CLI options for specifying the L1 and L2 providers