### PR TITLE
add importIssuerData to SynthetixState for L2 import debt amounts

### DIFF
--- a/contracts/SynthetixState.sol
+++ b/contracts/SynthetixState.sol
@@ -35,8 +35,6 @@ contract SynthetixState is Owned, State, LimitedSetup, ISynthetixState {
     // The total count of people that have outstanding issued synths in any flavour
     uint public totalIssuerCount;
 
-    uint public importedDebtAmount;
-
     // Global debt pool tracking
     uint[] public debtLedger;
 
@@ -92,61 +90,6 @@ contract SynthetixState is Owned, State, LimitedSetup, ISynthetixState {
      */
     function appendDebtLedgerValue(uint value) external onlyAssociatedContract {
         debtLedger.push(value);
-    }
-
-    // /**
-    //  * @notice Import issuer data from the old Synthetix contract before multicurrency
-    //  * @dev Only callable by the contract owner, and only for 1 week after deployment.
-    //  */
-    function importIssuerData(address[] calldata accounts, uint[] calldata sUSDAmounts) external onlyOwner onlyDuringSetup {
-        require(accounts.length == sUSDAmounts.length, "Length mismatch");
-
-        for (uint8 i = 0; i < accounts.length; i++) {
-            _addToDebtRegister(accounts[i], sUSDAmounts[i]);
-        }
-    }
-
-    // /**
-    //  * @notice Import issuer data from the old Synthetix contract before multicurrency
-    //  * @dev Only used from importIssuerData above, meant to be disposable
-    //  */
-    function _addToDebtRegister(address account, uint amount) internal {
-        // What is the value that we've previously imported?
-        uint totalDebtIssued = importedDebtAmount;
-
-        // What will the new total be including the new value?
-        uint newTotalDebtIssued = amount.add(totalDebtIssued);
-
-        // Save that for the next import.
-        importedDebtAmount = newTotalDebtIssued;
-
-        // What is their percentage (as a high precision int) of the total debt?
-        uint debtPercentage = amount.divideDecimalRoundPrecise(newTotalDebtIssued);
-
-        // And what effect does this percentage change have on the global debt holding of other issuers?
-        // The delta specifically needs to not take into account any existing debt as it's already
-        // accounted for in the delta from when they issued previously.
-        // The delta is a high precision integer.
-        uint delta = SafeDecimalMath.preciseUnit().sub(debtPercentage);
-
-        // We ignore any existingDebt as this is being imported in as amount
-
-        // Are they a new issuer? If so, record them. (same as incrementTotalIssuerCount)
-        if (issuanceData[account].initialDebtOwnership == 0) {
-            totalIssuerCount = totalIssuerCount.add(1);
-        }
-
-        // Save the debt entry parameters (same as setCurrentIssuanceData)
-        issuanceData[account].initialDebtOwnership = debtPercentage;
-        issuanceData[account].debtEntryIndex = debtLedger.length;
-
-        // And if we're the first, push 1 as there was no effect to any other holders, otherwise push
-        // the change for the rest of the debt holders. The debt ledger holds high precision integers.
-        if (debtLedger.length > 0) {
-            debtLedger.push(debtLedger[debtLedger.length - 1].multiplyDecimalRoundPrecise(delta));
-        } else {
-            debtLedger.push(SafeDecimalMath.preciseUnit());
-        }
     }
 
     /* ========== VIEWS ========== */

--- a/contracts/SynthetixState.sol
+++ b/contracts/SynthetixState.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.5.16;
 // Inheritance
 import "./Owned.sol";
 import "./State.sol";
-import "./LimitedSetup.sol";
 import "./interfaces/ISynthetixState.sol";
 
 // Libraries
@@ -11,7 +10,7 @@ import "./SafeDecimalMath.sol";
 
 
 // https://docs.synthetix.io/contracts/source/contracts/synthetixstate
-contract SynthetixState is Owned, State, LimitedSetup, ISynthetixState {
+contract SynthetixState is Owned, State, ISynthetixState {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
 
@@ -38,12 +37,7 @@ contract SynthetixState is Owned, State, LimitedSetup, ISynthetixState {
     // Global debt pool tracking
     uint[] public debtLedger;
 
-    constructor(address _owner, address _associatedContract)
-        public
-        Owned(_owner)
-        State(_associatedContract)
-        LimitedSetup(1 weeks)
-    {}
+    constructor(address _owner, address _associatedContract) public Owned(_owner) State(_associatedContract) {}
 
     /* ========== SETTERS ========== */
 

--- a/contracts/SynthetixStateWithLimitedSetup.sol
+++ b/contracts/SynthetixStateWithLimitedSetup.sol
@@ -11,13 +11,17 @@ import "./SafeDecimalMath.sol";
 
 
 // https://docs.synthetix.io/contracts/source/contracts/synthetixstate
-contract SynthetixStateWithLimitedSetup is SynthetixState {
+contract SynthetixStateWithLimitedSetup is SynthetixState, LimitedSetup {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
 
     uint public importedDebtAmount;
 
-    constructor(address _owner, address _associatedContract) public SynthetixState(_owner, _associatedContract) {}
+    constructor(address _owner, address _associatedContract)
+        public
+        SynthetixState(_owner, _associatedContract)
+        LimitedSetup(1 weeks)
+    {}
 
     /* ========== SETTERS ========== */
 

--- a/contracts/SynthetixStateWithLimitedSetup.sol
+++ b/contracts/SynthetixStateWithLimitedSetup.sol
@@ -1,0 +1,78 @@
+pragma solidity ^0.5.16;
+
+// Inheritance
+import "./Owned.sol";
+import "./State.sol";
+import "./LimitedSetup.sol";
+import "./SynthetixState.sol";
+
+// Libraries
+import "./SafeDecimalMath.sol";
+
+
+// https://docs.synthetix.io/contracts/source/contracts/synthetixstate
+contract SynthetixStateWithLimitedSetup is SynthetixState {
+    using SafeMath for uint;
+    using SafeDecimalMath for uint;
+
+    uint public importedDebtAmount;
+
+    constructor(address _owner, address _associatedContract) public SynthetixState(_owner, _associatedContract) {}
+
+    /* ========== SETTERS ========== */
+
+    // /**
+    //  * @notice Import issuer data
+    //  * @dev Only callable by the contract owner, and only for 1 week after deployment.
+    //  */
+    function importIssuerData(address[] calldata accounts, uint[] calldata sUSDAmounts) external onlyOwner onlyDuringSetup {
+        require(accounts.length == sUSDAmounts.length, "Length mismatch");
+
+        for (uint8 i = 0; i < accounts.length; i++) {
+            _addToDebtRegister(accounts[i], sUSDAmounts[i]);
+        }
+    }
+
+    // /**
+    //  * @notice Import issuer debt data
+    //  * @dev Only used from importIssuerData above, meant to be disposable
+    //  */
+    function _addToDebtRegister(address account, uint amount) internal {
+        // What is the value that we've previously imported?
+        uint totalDebtIssued = importedDebtAmount;
+
+        // What will the new total be including the new value?
+        uint newTotalDebtIssued = amount.add(totalDebtIssued);
+
+        // Save that for the next import.
+        importedDebtAmount = newTotalDebtIssued;
+
+        // What is their percentage (as a high precision int) of the total debt?
+        uint debtPercentage = amount.divideDecimalRoundPrecise(newTotalDebtIssued);
+
+        // And what effect does this percentage change have on the global debt holding of other issuers?
+        // The delta specifically needs to not take into account any existing debt as it's already
+        // accounted for in the delta from when they issued previously.
+        // The delta is a high precision integer.
+        uint delta = SafeDecimalMath.preciseUnit().sub(debtPercentage);
+
+        // We ignore any existingDebt as this is being imported in as amount
+
+        // Are they a new issuer? If so, record them. (same as incrementTotalIssuerCount)
+        if (issuanceData[account].initialDebtOwnership == 0) {
+            totalIssuerCount = totalIssuerCount.add(1);
+        }
+
+        // Save the debt entry parameters (same as setCurrentIssuanceData)
+        issuanceData[account].initialDebtOwnership = debtPercentage;
+        issuanceData[account].debtEntryIndex = debtLedger.length;
+
+        // And if we're the first, push 1 as there was no effect to any other holders, otherwise push
+        // the change for the rest of the debt holders. The debt ledger holds high precision integers.
+        if (debtLedger.length > 0) {
+            debtLedger.push(debtLedger[debtLedger.length - 1].multiplyDecimalRoundPrecise(delta));
+        } else {
+            debtLedger.push(SafeDecimalMath.preciseUnit());
+        }
+    }
+}

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -547,6 +547,7 @@ const deploy = async ({
 
 	const synthetixState = await deployer.deployContract({
 		name: 'SynthetixState',
+		source: useOvm ? 'SynthetixStateWithLimitedSetup' : 'SynthetixState',
 		args: [account, account],
 	});
 


### PR DESCRIPTION
- based off synthetixState at https://etherscan.io/address/0x4b9Ca5607f1fF8019c1C6A3c2f0CC8de622D5B82#code


```
/**
     * @notice Import issuer data from the old Synthetix contract before multicurrency
     * @dev Only callable by the contract owner, and only for 1 week after deployment.
     */
    function importIssuerData(address[] accounts, uint[] sUSDAmounts)
        external
        onlyOwner
        onlyDuringSetup
    {
        require(accounts.length == sUSDAmounts.length, "Length mismatch");

        for (uint8 i = 0; i < accounts.length; i++) {
            _addToDebtRegister(accounts[i], sUSDAmounts[i]);
        }
    }

    /**
     * @notice Import issuer data from the old Synthetix contract before multicurrency
     * @dev Only used from importIssuerData above, meant to be disposable
     */
    function _addToDebtRegister(address account, uint amount)
        internal
    {
        // This code is duplicated from Synthetix so that we can call it directly here
        // during setup only.
        Synthetix synthetix = Synthetix(associatedContract);

        // What is the value of the requested debt in XDRs?
        uint xdrValue = synthetix.effectiveValue("sUSD", amount, "XDR");

        // What is the value that we've previously imported?
        uint totalDebtIssued = importedXDRAmount;

        // What will the new total be including the new value?
        uint newTotalDebtIssued = xdrValue.add(totalDebtIssued);

        // Save that for the next import.
        importedXDRAmount = newTotalDebtIssued;

        // What is their percentage (as a high precision int) of the total debt?
        uint debtPercentage = xdrValue.divideDecimalRoundPrecise(newTotalDebtIssued);

        // And what effect does this percentage have on the global debt holding of other issuers?
        // The delta specifically needs to not take into account any existing debt as it's already
        // accounted for in the delta from when they issued previously.
        // The delta is a high precision integer.
        uint delta = SafeDecimalMath.preciseUnit().sub(debtPercentage);

        uint existingDebt = synthetix.debtBalanceOf(account, "XDR");

        // And what does their debt ownership look like including this previous stake?
        if (existingDebt > 0) {
            debtPercentage = xdrValue.add(existingDebt).divideDecimalRoundPrecise(newTotalDebtIssued);
        }

        // Are they a new issuer? If so, record them.
        if (issuanceData[account].initialDebtOwnership == 0) {
            totalIssuerCount = totalIssuerCount.add(1);
        }

        // Save the debt entry parameters
        issuanceData[account].initialDebtOwnership = debtPercentage;
        issuanceData[account].debtEntryIndex = debtLedger.length;

        // And if we're the first, push 1 as there was no effect to any other holders, otherwise push
        // the change for the rest of the debt holders. The debt ledger holds high precision integers.
        if (debtLedger.length > 0) {
            debtLedger.push(
                debtLedger[debtLedger.length - 1].multiplyDecimalRoundPrecise(delta)
            );
        } else {
            debtLedger.push(SafeDecimalMath.preciseUnit());
        }
    }
```