### PR TITLE
fix: circleci github auth issue (repository.url)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
 	},
 	"repository": {
 		"type": "git",
-		"url": "git+https://github.com/Synthetixio/synthetix.git"
+		"url": "https://github.com/Synthetixio/synthetix.git"
 	},
 	"keywords": [
 		"Synthetix",


### PR DESCRIPTION
Should fix `the authenticity of host 'github.com' can't be established` error on CircleCI.

npm docs also suggest to use url without `git+` prefix:
https://docs.npmjs.com/cli/v7/configuring-npm/package-json#repository

Signed-off-by: Jakub Mucha <jakub.mucha@icloud.com>