### PR TITLE
ci: fix failing codechecks on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,7 @@ jobs:
       - run: node publish prepare-deploy --network mainnet
       - run: node publish deploy --ignore-safety-checks --add-new-synths --use-fork --yes --network mainnet
       - run: npm run test:prod:gas -- --target-network mainnet --patch-fresh-deployment
-      - run: npm run codechecks codechecks.prod.yml
+      - run: npm run ci:codechecks codechecks.prod.yml
       - store_artifacts:
           path: test-gas-used-prod.log
   job-prod-tests:
@@ -146,7 +146,7 @@ jobs:
           background: true
       - cmd-wait-for-rpc
       - run: npm run test:prod:gas -- --target-network mainnet
-      - run: npm run codechecks codechecks.prod.yml
+      - run: npm run ci:codechecks codechecks.prod.yml
       - store_artifacts:
           path: test-gas-used-prod.log
   job-static-analysis:
@@ -219,7 +219,7 @@ jobs:
       - attach_workspace:
           at: .
       - run: npm run test:gas
-      - run: npm run codechecks codechecks.unit.yml
+      - run: npm run ci:codechecks codechecks.unit.yml
       - store_artifacts:
           path: test-gas-used.log
   job-unit-tests-ovm:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,8 @@ jobs:
       - cmd-wait-for-rpc
       - run: node publish prepare-deploy --network mainnet
       - run: node publish deploy --ignore-safety-checks --add-new-synths --use-fork --yes --network mainnet
-      - run: npm run test:prod:gas -- --target-network mainnet --patch-fresh-deployment && npx codechecks codechecks.prod.yml
+      - run: npm run test:prod:gas -- --target-network mainnet --patch-fresh-deployment
+      - run: npm run codechecks codechecks.prod.yml
       - store_artifacts:
           path: test-gas-used-prod.log
   job-prod-tests:
@@ -144,7 +145,8 @@ jobs:
           command: npx hardhat node --target-network mainnet
           background: true
       - cmd-wait-for-rpc
-      - run: npm run test:prod:gas -- --target-network mainnet && npx codechecks codechecks.prod.yml
+      - run: npm run test:prod:gas -- --target-network mainnet
+      - run: npm run codechecks codechecks.prod.yml
       - store_artifacts:
           path: test-gas-used-prod.log
   job-static-analysis:
@@ -216,7 +218,8 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: npm run test:gas && npx codechecks codechecks.unit.yml
+      - run: npm run test:gas
+      - run: npm run codechecks codechecks.unit.yml
       - store_artifacts:
           path: test-gas-used.log
   job-unit-tests-ovm:

--- a/.circleci/src/jobs/job-prod-diff-tests.yml
+++ b/.circleci/src/jobs/job-prod-diff-tests.yml
@@ -18,6 +18,6 @@ steps:
   - run: node publish deploy --ignore-safety-checks --add-new-synths --use-fork --yes --network mainnet
   # Run production tests
   - run: npm run test:prod:gas -- --target-network mainnet --patch-fresh-deployment
-  - run: npm run codechecks codechecks.prod.yml
+  - run: npm run ci:codechecks codechecks.prod.yml
   - store_artifacts:
       path: test-gas-used-prod.log

--- a/.circleci/src/jobs/job-prod-diff-tests.yml
+++ b/.circleci/src/jobs/job-prod-diff-tests.yml
@@ -17,6 +17,7 @@ steps:
   # Deploy
   - run: node publish deploy --ignore-safety-checks --add-new-synths --use-fork --yes --network mainnet
   # Run production tests
-  - run: npm run test:prod:gas -- --target-network mainnet --patch-fresh-deployment && npx codechecks codechecks.prod.yml
+  - run: npm run test:prod:gas -- --target-network mainnet --patch-fresh-deployment
+  - run: npm run codechecks codechecks.prod.yml
   - store_artifacts:
       path: test-gas-used-prod.log

--- a/.circleci/src/jobs/job-prod-tests.yml
+++ b/.circleci/src/jobs/job-prod-tests.yml
@@ -9,6 +9,6 @@ steps:
       background: true
   - cmd-wait-for-rpc
   - run: npm run test:prod:gas -- --target-network mainnet
-  - run: npm run codechecks codechecks.prod.yml
+  - run: npm run ci:codechecks codechecks.prod.yml
   - store_artifacts:
       path: test-gas-used-prod.log

--- a/.circleci/src/jobs/job-prod-tests.yml
+++ b/.circleci/src/jobs/job-prod-tests.yml
@@ -8,6 +8,7 @@ steps:
       command: npx hardhat node --target-network mainnet
       background: true
   - cmd-wait-for-rpc
-  - run: npm run test:prod:gas -- --target-network mainnet && npx codechecks codechecks.prod.yml
+  - run: npm run test:prod:gas -- --target-network mainnet
+  - run: npm run codechecks codechecks.prod.yml
   - store_artifacts:
       path: test-gas-used-prod.log

--- a/.circleci/src/jobs/job-unit-tests-gas-report.yml
+++ b/.circleci/src/jobs/job-unit-tests-gas-report.yml
@@ -6,6 +6,6 @@ steps:
   - attach_workspace:
       at: .
   - run: npm run test:gas
-  - run: npm run codechecks codechecks.unit.yml
+  - run: npm run ci:codechecks codechecks.unit.yml
   - store_artifacts:
       path: test-gas-used.log

--- a/.circleci/src/jobs/job-unit-tests-gas-report.yml
+++ b/.circleci/src/jobs/job-unit-tests-gas-report.yml
@@ -5,6 +5,7 @@ steps:
   - checkout
   - attach_workspace:
       at: .
-  - run: npm run test:gas && npx codechecks codechecks.unit.yml
+  - run: npm run test:gas
+  - run: npm run codechecks codechecks.unit.yml
   - store_artifacts:
       path: test-gas-used.log

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
 		"test:prod:ovm": "concurrently --kill-others --success first \"wait-port 8545 && wait-port 9545 && mocha test/optimism --timeout 900000\"",
 		"test:deployments": "mocha test/deployments -- --timeout 15000",
 		"test:etherscan": "node test/etherscan",
-		"test:publish": "concurrently --kill-others --success first \"npx hardhat node > /dev/null\" \"wait-port 8545 && mocha test/publish --timeout 240000\""
+		"test:publish": "concurrently --kill-others --success first \"npx hardhat node > /dev/null\" \"wait-port 8545 && mocha test/publish --timeout 240000\"",
+		"ci:codechecks": "codechecks"
 	},
 	"husky": {
 		"hooks": {


### PR DESCRIPTION
Codechecks SSH issue seems to be related to `npx`. Switching to `npm run` should fix this issue and make failing pipelines on `develop` green. In the meantime I'm continuing to debug the issue with CircleCI support team in #1125.