### PR TITLE
Fix deploy script overriding waitingPeriodSecs from zero

### DIFF
--- a/publish/deployed/kovan-ovm/params.json
+++ b/publish/deployed/kovan-ovm/params.json
@@ -2,5 +2,9 @@
 	{
 		"name": "INITIAL_ISSUANCE",
 		"value": "0"
+	},
+	{
+		"name": "WAITING_PERIOD_SECS",
+		"value": "0"
 	}
 ]

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -1985,7 +1985,7 @@ const deploy = async ({
 			contract: 'SystemSettings',
 			target: systemSettings,
 			read: 'waitingPeriodSecs',
-			expected: input => input !== waitingPeriodSecs,
+			expected: input => (waitingPeriodSecs === '0' ? true : input !== '0'),
 			write: 'setWaitingPeriodSecs',
 			writeArg: waitingPeriodSecs,
 		});

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -1979,13 +1979,15 @@ const deploy = async ({
 		}
 
 		// setup initial values if they are unset
+
+		const waitingPeriodSecs = await getDeployParameter('WAITING_PERIOD_SECS');
 		await runStep({
 			contract: 'SystemSettings',
 			target: systemSettings,
 			read: 'waitingPeriodSecs',
-			expected: input => input !== '0',
+			expected: input => input !== waitingPeriodSecs,
 			write: 'setWaitingPeriodSecs',
-			writeArg: await getDeployParameter('WAITING_PERIOD_SECS'),
+			writeArg: waitingPeriodSecs,
 		});
 
 		await runStep({

--- a/test/publish/index.js
+++ b/test/publish/index.js
@@ -247,6 +247,7 @@ describe('publish scripts', () => {
 					freshDeploy: true,
 					yes: true,
 					privateKey: accounts.deployer.private,
+					ignoreCustomParameters: true,
 				});
 
 				sources = getSource();


### PR DESCRIPTION
Although we recently addressed the setting in of `waitingPeriodSecs` in the deploy script, it still not behaving as expected. Them problem is that, in Optimism configurations, we actually want the value to be zero. The deploy script considers something "unset" when it is zero. Thus, if it finds `waitingPeriodSecs` to be zero, it will set it back to 300s when redeploying to an ovm network, effectively turning fee reclamation back on!

Since the deploy script would require a complete redesign regarding setting parameters to fix this, the modification proposed here merely always considers whatever is set to be valid when the value specified in params.json is zero, and maintains the old behavior otherwise.