### PR TITLE
Ensuring collateral defaults change only when non-zero

### DIFF
--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -2241,7 +2241,7 @@ const deploy = async ({
 			contract: 'CollateralManager',
 			target: collateralManager,
 			read: 'maxDebt',
-			expected: input => input === collateralManagerDefaults['MAX_DEBT'],
+			expected: input => input !== '0', // only change if zero
 			write: 'setMaxDebt',
 			writeArg: [collateralManagerDefaults['MAX_DEBT']],
 		});
@@ -2250,7 +2250,7 @@ const deploy = async ({
 			contract: 'CollateralManager',
 			target: collateralManager,
 			read: 'baseBorrowRate',
-			expected: input => input === collateralManagerDefaults['BASE_BORROW_RATE'],
+			expected: input => input !== '0', // only change if zero
 			write: 'setBaseBorrowRate',
 			writeArg: [collateralManagerDefaults['BASE_BORROW_RATE']],
 		});
@@ -2259,7 +2259,7 @@ const deploy = async ({
 			contract: 'CollateralManager',
 			target: collateralManager,
 			read: 'baseShortRate',
-			expected: input => input === collateralManagerDefaults['BASE_SHORT_RATE'],
+			expected: input => input !== '0', // only change if zero
 			write: 'setBaseShortRate',
 			writeArg: [collateralManagerDefaults['BASE_SHORT_RATE']],
 		});
@@ -2311,7 +2311,7 @@ const deploy = async ({
 			contract: 'CollateralShort',
 			target: collateralShort,
 			read: 'interactionDelay',
-			expected: input => input === collateralShortInteractionDelay,
+			expected: input => input !== '0', // only change if zero
 			write: 'setInteractionDelay',
 			writeArg: collateralShortInteractionDelay,
 		});


### PR DESCRIPTION
This was causing prod tests to fail as MAX_DEBT was still set to 50m in `index.js` and prod tests were reverting the fork values to `50m` from `65m`.