### PR TITLE
BO minimal proxies pattern

### DIFF
--- a/contracts/BinaryOptionMarket.sol
+++ b/contracts/BinaryOptionMarket.sol
@@ -14,7 +14,7 @@ import "./BinaryOption.sol";
 import "./interfaces/IExchangeRates.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/IFeePool.sol";
-
+import "./interfaces/IAddressResolver.sol";
 
 // https://docs.synthetix.io/contracts/source/contracts/binaryoptionmarket
 contract BinaryOptionMarket is Owned, MixinResolver, IBinaryOptionMarket {
@@ -74,10 +74,10 @@ contract BinaryOptionMarket is Owned, MixinResolver, IBinaryOptionMarket {
 
     /* ========== CONSTRUCTOR ========== */
 
-    constructor(
-        address _owner,
+    bool public initialized = false;
+
+    function initialize(
         address _creator,
-        address _resolver,
         uint[2] memory _creatorLimits, // [capitalRequirement, skewLimit]
         bytes32 _oracleKey,
         uint _strikePrice,
@@ -85,7 +85,9 @@ contract BinaryOptionMarket is Owned, MixinResolver, IBinaryOptionMarket {
         uint[3] memory _times, // [biddingEnd, maturity, expiry]
         uint[2] memory _bids, // [longBid, shortBid]
         uint[3] memory _fees // [poolFee, creatorFee, refundFee]
-    ) public Owned(_owner) MixinResolver(_resolver) {
+    ) public {
+        require(!initialized, "vSynth already initialized");
+        initialized = true;
         creator = _creator;
         creatorLimits = BinaryOptionMarketManager.CreatorLimits(_creatorLimits[0], _creatorLimits[1]);
 
@@ -115,6 +117,9 @@ contract BinaryOptionMarket is Owned, MixinResolver, IBinaryOptionMarket {
         // Instantiate the options themselves
         options.long = new BinaryOption(_creator, longBid);
         options.short = new BinaryOption(_creator, shortBid);
+
+        // Note: the ERC20 base contract does not have a constructor, so we do not have to worry
+        // about initializing its state separately
     }
 
     /* ========== VIEWS ========== */

--- a/contracts/BinaryOptionMarketFactory.sol
+++ b/contracts/BinaryOptionMarketFactory.sol
@@ -6,31 +6,39 @@ import "./MixinResolver.sol";
 
 // Internal references
 import "./BinaryOptionMarket.sol";
-
+import "./MinimalProxyFactory.sol";
 
 // https://docs.synthetix.io/contracts/source/contracts/binaryoptionmarketfactory
-contract BinaryOptionMarketFactory is Owned, MixinResolver {
+contract BinaryOptionMarketFactory is MinimalProxyFactory, Owned, MixinResolver {
     /* ========== STATE VARIABLES ========== */
 
     /* ---------- Address Resolver Configuration ---------- */
 
     bytes32 internal constant CONTRACT_BINARYOPTIONMARKETMANAGER = "BinaryOptionMarketManager";
+    bytes32 internal constant CONTRACT_BINARYOPTION_MASTERCOPY = "BinaryOptionMarketMastercopy";
 
     /* ========== CONSTRUCTOR ========== */
 
-    constructor(address _owner, address _resolver) public Owned(_owner) MixinResolver(_resolver) {}
+    constructor(address _owner, address _resolver) public MinimalProxyFactory() Owned(_owner) MixinResolver(_resolver) {}
 
     /* ========== VIEWS ========== */
 
     function resolverAddressesRequired() public view returns (bytes32[] memory addresses) {
-        addresses = new bytes32[](1);
+        addresses = new bytes32[](2);
         addresses[0] = CONTRACT_BINARYOPTIONMARKETMANAGER;
+        addresses[1] = CONTRACT_BINARYOPTION_MASTERCOPY;
     }
 
     /* ---------- Related Contracts ---------- */
 
     function _manager() internal view returns (address) {
         return requireAndGetAddress(CONTRACT_BINARYOPTIONMARKETMANAGER);
+    }
+
+    /* ========== INTERNAL FUNCTIONS ========== */
+
+    function _binaryOptionMastercopy() internal view returns (address) {
+        return requireAndGetAddress(CONTRACT_BINARYOPTION_MASTERCOPY);
     }
 
     /* ========== MUTATIVE FUNCTIONS ========== */
@@ -48,18 +56,11 @@ contract BinaryOptionMarketFactory is Owned, MixinResolver {
         address manager = _manager();
         require(address(manager) == msg.sender, "Only permitted by the manager.");
 
-        return
-            new BinaryOptionMarket(
-                manager,
-                creator,
-                address(resolver),
-                creatorLimits,
-                oracleKey,
-                strikePrice,
-                refundsEnabled,
-                times,
-                bids,
-                fees
-            );
+        BinaryOptionMarket bom =
+            BinaryOptionMarket(_cloneAsMinimalProxy(_binaryOptionMastercopy(), "Could not create a Binary Option Market"));
+        bom.initOwner(manager);
+        bom.initResolver(address(resolver));
+        bom.initialize(creator, creatorLimits, oracleKey, strikePrice, refundsEnabled, times, bids, fees);
+        return bom;
     }
 }

--- a/contracts/BinaryOptionMarketManager.sol
+++ b/contracts/BinaryOptionMarketManager.sol
@@ -18,7 +18,6 @@ import "./interfaces/IExchangeRates.sol";
 import "./interfaces/ISystemStatus.sol";
 import "./interfaces/IERC20.sol";
 
-
 // https://docs.synthetix.io/contracts/source/contracts/binaryoptionmarketmanager
 contract BinaryOptionMarketManager is Owned, Pausable, MixinResolver, IBinaryOptionMarketManager {
     /* ========== LIBRARIES ========== */
@@ -262,16 +261,17 @@ contract BinaryOptionMarketManager is Owned, Pausable, MixinResolver, IBinaryOpt
         // Fees being in range are checked in the setters.
         // The market itself validates the capital and skew requirements.
 
-        BinaryOptionMarket market = _factory().createMarket(
-            msg.sender,
-            [creatorLimits.capitalRequirement, creatorLimits.skewLimit],
-            oracleKey,
-            strikePrice,
-            refundsEnabled,
-            [biddingEnd, maturity, expiry],
-            bids,
-            [fees.poolFee, fees.creatorFee, fees.refundFee]
-        );
+        BinaryOptionMarket market =
+            _factory().createMarket(
+                msg.sender,
+                [creatorLimits.capitalRequirement, creatorLimits.skewLimit],
+                oracleKey,
+                strikePrice,
+                refundsEnabled,
+                [biddingEnd, maturity, expiry],
+                bids,
+                [fees.poolFee, fees.creatorFee, fees.refundFee]
+            );
         market.rebuildCache();
         _activeMarkets.add(address(market));
 
@@ -325,10 +325,8 @@ contract BinaryOptionMarketManager is Owned, Pausable, MixinResolver, IBinaryOpt
 
             if (!success) {
                 // handle legacy markets that used an old cache rebuilding logic
-                bytes memory payloadForLegacyCache = abi.encodeWithSignature(
-                    "setResolverAndSyncCache(address)",
-                    address(resolver)
-                );
+                bytes memory payloadForLegacyCache =
+                    abi.encodeWithSignature("setResolverAndSyncCache(address)", address(resolver));
 
                 // solhint-disable avoid-low-level-calls
                 (bool legacySuccess, ) = market.call(payloadForLegacyCache);

--- a/contracts/BinaryOptionMarketMastercopy.sol
+++ b/contracts/BinaryOptionMarketMastercopy.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.5.16;
+
+// Inheritance
+import "./Owned.sol";
+import "./MixinResolver.sol";
+
+// Internal references
+import "./BinaryOptionMarket.sol";
+
+// https://docs.synthetix.io/contracts/source/contracts/binaryoptionmarket
+contract BinaryOptionMarketMastercopy is BinaryOptionMarket {
+    constructor(address _owner, address _resolver) public Owned(_owner) MixinResolver(_resolver) {}
+}

--- a/contracts/MixinResolver.sol
+++ b/contracts/MixinResolver.sol
@@ -7,7 +7,6 @@ import "./Owned.sol";
 import "./AddressResolver.sol";
 import "./ReadProxy.sol";
 
-
 // https://docs.synthetix.io/contracts/source/contracts/mixinresolver
 contract MixinResolver {
     AddressResolver public resolver;
@@ -15,6 +14,15 @@ contract MixinResolver {
     mapping(bytes32 => address) private addressCache;
 
     constructor(address _resolver) internal {
+        resolver = AddressResolver(_resolver);
+        initialized = true;
+    }
+
+    bool public initialized = false;
+
+    function initResolver(address _resolver) public {
+        //MinimalProxyFactory resets all state, thus an explicit init is needed
+        require(!initialized, "Can only be called if not initialized already");
         resolver = AddressResolver(_resolver);
     }
 
@@ -47,10 +55,8 @@ contract MixinResolver {
         for (uint i = 0; i < requiredAddresses.length; i++) {
             bytes32 name = requiredAddresses[i];
             // Note: can only be invoked once the resolver has all the targets needed added
-            address destination = resolver.requireAndGetAddress(
-                name,
-                string(abi.encodePacked("Resolver missing target: ", name))
-            );
+            address destination =
+                resolver.requireAndGetAddress(name, string(abi.encodePacked("Resolver missing target: ", name)));
             addressCache[name] = destination;
             emit CacheUpdated(name, destination);
         }

--- a/contracts/Owned.sol
+++ b/contracts/Owned.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.16;
 
+import "./MinimalProxyFactory.sol";
 
 // https://docs.synthetix.io/contracts/source/contracts/owned
 contract Owned {
@@ -9,12 +10,21 @@ contract Owned {
     constructor(address _owner) public {
         require(_owner != address(0), "Owner address cannot be 0");
         owner = _owner;
+        initialized = true;
         emit OwnerChanged(address(0), _owner);
     }
+
+    bool public initialized = false;
 
     function nominateNewOwner(address _owner) external onlyOwner {
         nominatedOwner = _owner;
         emit OwnerNominated(_owner);
+    }
+
+    function initOwner(address _owner) public {
+        //MinimalProxyFactory resets all state, thus an explicit init is needed
+        require(!initialized, "Can only be called if not initialized already");
+        owner = _owner;
     }
 
     function acceptOwnership() external {

--- a/contracts/test-helpers/MockBinaryOptionMarketManager.sol
+++ b/contracts/test-helpers/MockBinaryOptionMarketManager.sol
@@ -1,8 +1,8 @@
 pragma solidity ^0.5.16;
 
 import "../BinaryOptionMarket.sol";
+import "../BinaryOptionMarketMastercopy.sol";
 import "../AddressResolver.sol";
-
 
 contract MockBinaryOptionMarketManager {
     BinaryOptionMarket public market;
@@ -19,18 +19,8 @@ contract MockBinaryOptionMarketManager {
         uint[2] calldata bids, // [longBid, shortBid]
         uint[3] calldata fees // [poolFee, creatorFee, refundFee]
     ) external {
-        market = new BinaryOptionMarket(
-            address(this),
-            creator,
-            address(resolver),
-            creatorLimits,
-            oracleKey,
-            strikePrice,
-            refundsEnabled,
-            times,
-            bids,
-            fees
-        );
+        market = new BinaryOptionMarketMastercopy(address(this), address(resolver));
+        market.initialize(creator, creatorLimits, oracleKey, strikePrice, refundsEnabled, times, bids, fees);
         market.rebuildCache();
     }
 

--- a/contracts/test-helpers/TestableBinaryOptionMarket.sol
+++ b/contracts/test-helpers/TestableBinaryOptionMarket.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.5.16;
 
 import "../BinaryOptionMarket.sol";
+import "../BinaryOptionMarketMastercopy.sol";
 
-
-contract TestableBinaryOptionMarket is BinaryOptionMarket {
+contract TestableBinaryOptionMarket is BinaryOptionMarketMastercopy {
     constructor(
         address _owner,
         address _creator,
@@ -15,21 +15,9 @@ contract TestableBinaryOptionMarket is BinaryOptionMarket {
         uint[3] memory _times,
         uint[2] memory _bids,
         uint[3] memory _fees
-    )
-        public
-        BinaryOptionMarket(
-            _owner,
-            _creator,
-            _resolver,
-            _creatorLimits,
-            _oracleKey,
-            _strikePrice,
-            _refundsEnabled,
-            _times,
-            _bids,
-            _fees
-        )
-    {}
+    ) public BinaryOptionMarketMastercopy(_owner, _resolver) {
+        initialize(_creator, _creatorLimits, _oracleKey, _strikePrice, _refundsEnabled, _times, _bids, _fees);
+    }
 
     function updatePrices(
         uint256 longBids,

--- a/publish/deployed/local/config.json
+++ b/publish/deployed/local/config.json
@@ -20,6 +20,9 @@
 	"BinaryOptionMarketData": {
 		"deploy": true
 	},
+	"BinaryOptionMarketMastercopy": {
+		"deploy": true
+	},
 	"CollateralManager": {
 		"deploy": true
 	},

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -1251,6 +1251,8 @@ const deploy = async ({
 
 	await deployer.deployContract({
 		name: 'BinaryOptionsMarketMastercopy',
+		args: [account, addressOf(readProxyForResolver)],
+		deps: ['AddressResolver'],
 	});
 
 	console.log(gray(`\n------ DEPLOY DAPP UTILITIES ------\n`));

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -1249,6 +1249,10 @@ const deploy = async ({
 		deps: ['AddressResolver'],
 	});
 
+	await deployer.deployContract({
+		name: 'BinaryOptionsMarketMastercopy',
+	});
+
 	console.log(gray(`\n------ DEPLOY DAPP UTILITIES ------\n`));
 
 	await deployer.deployContract({

--- a/test/contracts/BinaryOptionMarket.js
+++ b/test/contracts/BinaryOptionMarket.js
@@ -134,6 +134,7 @@ contract('BinaryOptionMarket @gas-skip', accounts => {
 			synths: ['sUSD'],
 			contracts: [
 				'BinaryOptionMarketManager',
+				'BinaryOptionMarketMastercopy',
 				'AddressResolver',
 				'ExchangeRates',
 				'FeePool',
@@ -384,6 +385,7 @@ contract('BinaryOptionMarket @gas-skip', accounts => {
 					'exerciseOptions',
 					'expire',
 					'cancel',
+					'initialize',
 				],
 			});
 		});

--- a/test/contracts/BinaryOptionMarketData.js
+++ b/test/contracts/BinaryOptionMarketData.js
@@ -15,6 +15,7 @@ contract('BinaryOptionMarketData @gas-skip', accounts => {
 			synths: ['sUSD'],
 			contracts: [
 				'BinaryOptionMarketManager',
+				'BinaryOptionMarketMastercopy',
 				'AddressResolver',
 				'ExchangeRates',
 				'FeePool',

--- a/test/contracts/BinaryOptionMarketManager.js
+++ b/test/contracts/BinaryOptionMarketManager.js
@@ -30,7 +30,7 @@ const computePrices = (longs, shorts, debt, fee) => {
 	};
 };
 
-contract('BinaryOptionMarketManager @gas-skip', accounts => {
+contract('BinaryOptionMarketManager', accounts => {
 	const [initialCreator, managerOwner, bidder, dummy] = accounts;
 
 	const sUSDQty = toUnit(10000);
@@ -88,6 +88,7 @@ contract('BinaryOptionMarketManager @gas-skip', accounts => {
 			contracts: [
 				'SystemStatus',
 				'BinaryOptionMarketManager',
+				'BinaryOptionMarketMastercopy',
 				'AddressResolver',
 				'ExchangeRates',
 				'FeePool',
@@ -392,9 +393,6 @@ contract('BinaryOptionMarketManager @gas-skip', accounts => {
 				{ from: initialCreator }
 			);
 
-			assert.eventEqual(getEventByName({ tx: result, name: 'OwnerChanged' }), 'OwnerChanged', {
-				newOwner: manager.address,
-			});
 			assert.eventEqual(getEventByName({ tx: result, name: 'MarketCreated' }), 'MarketCreated', {
 				creator: initialCreator,
 				oracleKey: sAUDKey,
@@ -405,12 +403,12 @@ contract('BinaryOptionMarketManager @gas-skip', accounts => {
 			});
 
 			const decodedLogs = BinaryOptionMarket.decodeLogs(result.receipt.rawLogs);
-			assert.eventEqual(decodedLogs[1], 'Bid', {
+			assert.eventEqual(decodedLogs[0], 'Bid', {
 				side: Side.Long,
 				account: initialCreator,
 				value: toUnit(2),
 			});
-			assert.eventEqual(decodedLogs[2], 'Bid', {
+			assert.eventEqual(decodedLogs[1], 'Bid', {
 				side: Side.Short,
 				account: initialCreator,
 				value: toUnit(3),
@@ -422,7 +420,7 @@ contract('BinaryOptionMarketManager @gas-skip', accounts => {
 				toUnit(5),
 				initialPoolFee.add(initialCreatorFee)
 			);
-			assert.eventEqual(decodedLogs[3], 'PricesUpdated', {
+			assert.eventEqual(decodedLogs[2], 'PricesUpdated', {
 				longPrice: prices.long,
 				shortPrice: prices.short,
 			});

--- a/test/contracts/MixinResolver.js
+++ b/test/contracts/MixinResolver.js
@@ -26,7 +26,7 @@ contract('MixinResolver', async accounts => {
 		ensureOnlyExpectedMutativeFunctions({
 			abi: MixinResolver.abi,
 			ignoreParents: ['Owned'],
-			expected: ['rebuildCache'],
+			expected: ['rebuildCache', 'initResolver'],
 		});
 	});
 

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -230,6 +230,10 @@ const setupContract = async ({
 			toWei('0.02'), // refund fee
 		],
 		BinaryOptionMarketData: [],
+		BinaryOptionMarketMastercopy: [
+			tryGetAddressOf('BinaryOptionMarketManager'),
+			tryGetAddressOf('AddressResolver'),
+		],
 		CollateralManager: [
 			tryGetAddressOf('CollateralManagerState'),
 			owner,
@@ -774,6 +778,10 @@ const setupAllContracts = async ({
 				'Synthetix',
 				'BinaryOptionMarketFactory',
 			],
+		},
+		{
+			contract: 'BinaryOptionMarketMastercopy',
+			deps: ['BinaryOptionMarketManager'],
 		},
 		{
 			contract: 'BinaryOptionMarketData',

--- a/test/publish/index.js
+++ b/test/publish/index.js
@@ -1586,6 +1586,7 @@ describe('publish scripts', () => {
 									.filter(([contract]) => !/^SynthetixBridge/.test(contract))
 									// Note: the VirtualSynth mastercopy is null-initialized and shouldn't be checkd
 									.filter(([contract]) => !/^VirtualSynthMastercopy/.test(contract))
+									.filter(([contract]) => !/^BinaryOptionMarketMastercopy/.test(contract))
 									.filter(([, { source }]) =>
 										sources[source].abi.find(({ name }) => name === 'resolver')
 									)


### PR DESCRIPTION
Following Brett's approach to implementing minimal proxies for BOs.
Tests show a reduction of gas to create markets of 50%.
Differences to Brett's implemention:
 - Mastercopy for BinaryOptionsMarket inherits Owned and MixinResolver so those two now have the init methods to be called from the BinaryOptionsMarketFactory. The init method will only work when a contract has been copied through the MinimalProxyFactory and thus had its state reset (Brett advised this approach)
 - Used a different approach for initializing BinaryOptionsMarketMastercopy so that if adheres to the pattern established in setup.js