### PR TITLE
fix: broken links to docs

### DIFF
--- a/contracts/AddressResolver.sol
+++ b/contracts/AddressResolver.sol
@@ -8,7 +8,7 @@ import "./interfaces/IAddressResolver.sol";
 import "./interfaces/IIssuer.sol";
 import "./MixinResolver.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/addressresolver
+// https://docs.synthetix.io/contracts/source/contracts/AddressResolver
 contract AddressResolver is Owned, IAddressResolver {
     mapping(bytes32 => address) public repository;
 

--- a/contracts/AddressSetLib.sol
+++ b/contracts/AddressSetLib.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.16;
 
-// https://docs.synthetix.io/contracts/source/libraries/addresssetlib/
+// https://docs.synthetix.io/contracts/source/libraries/AddressSetLib/
 library AddressSetLib {
     struct AddressSet {
         address[] elements;

--- a/contracts/BaseDebtCache.sol
+++ b/contracts/BaseDebtCache.sol
@@ -19,7 +19,7 @@ import "./interfaces/IEtherCollateralsUSD.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/ICollateralManager.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/debtcache
+// https://docs.synthetix.io/contracts/source/contracts/DebtCache
 contract BaseDebtCache is Owned, MixinSystemSettings, IDebtCache {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/BinaryOption.sol
+++ b/contracts/BinaryOption.sol
@@ -10,7 +10,7 @@ import "./SafeDecimalMath.sol";
 // Internal references
 import "./BinaryOptionMarket.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/binaryoption
+// https://docs.synthetix.io/contracts/source/contracts/BinaryOption
 contract BinaryOption is IERC20, IBinaryOption {
     /* ========== LIBRARIES ========== */
 

--- a/contracts/BinaryOptionMarket.sol
+++ b/contracts/BinaryOptionMarket.sol
@@ -15,7 +15,7 @@ import "./interfaces/IExchangeRates.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/IFeePool.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/binaryoptionmarket
+// https://docs.synthetix.io/contracts/source/contracts/BinaryOptionMarket
 contract BinaryOptionMarket is Owned, MixinResolver, IBinaryOptionMarket {
     /* ========== LIBRARIES ========== */
 

--- a/contracts/BinaryOptionMarketData.sol
+++ b/contracts/BinaryOptionMarketData.sol
@@ -6,7 +6,7 @@ import "./BinaryOption.sol";
 import "./BinaryOptionMarket.sol";
 import "./BinaryOptionMarketManager.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/binaryoptionmarketdata
+// https://docs.synthetix.io/contracts/source/contracts/BinaryOptionMarketData
 contract BinaryOptionMarketData {
     struct OptionValues {
         uint long;

--- a/contracts/BinaryOptionMarketFactory.sol
+++ b/contracts/BinaryOptionMarketFactory.sol
@@ -7,7 +7,7 @@ import "./MixinResolver.sol";
 // Internal references
 import "./BinaryOptionMarket.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/binaryoptionmarketfactory
+// https://docs.synthetix.io/contracts/source/contracts/BinaryOptionMarketFactory
 contract BinaryOptionMarketFactory is Owned, MixinResolver {
     /* ========== STATE VARIABLES ========== */
 

--- a/contracts/BinaryOptionMarketManager.sol
+++ b/contracts/BinaryOptionMarketManager.sol
@@ -18,7 +18,7 @@ import "./interfaces/IExchangeRates.sol";
 import "./interfaces/ISystemStatus.sol";
 import "./interfaces/IERC20.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/binaryoptionmarketmanager
+// https://docs.synthetix.io/contracts/source/contracts/BinaryOptionMarketManager
 contract BinaryOptionMarketManager is Owned, Pausable, MixinResolver, IBinaryOptionMarketManager {
     /* ========== LIBRARIES ========== */
 

--- a/contracts/Bytes32SetLib.sol
+++ b/contracts/Bytes32SetLib.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.16;
 
-// https://docs.synthetix.io/contracts/source/libraries/bytes32setlib/
+// https://docs.synthetix.io/contracts/source/libraries/Bytes32SetLib/
 library Bytes32SetLib {
     struct Bytes32Set {
         bytes32[] elements;

--- a/contracts/Collateral.sol
+++ b/contracts/Collateral.sol
@@ -21,6 +21,7 @@ import "./interfaces/IExchangeRates.sol";
 import "./interfaces/IExchanger.sol";
 import "./interfaces/IShortingRewards.sol";
 
+// https://docs.synthetix.io/contracts/source/contracts/Collateral
 contract Collateral is ICollateralLoan, Owned, MixinSystemSettings {
     /* ========== LIBRARIES ========== */
     using SafeMath for uint;

--- a/contracts/CollateralErc20.sol
+++ b/contracts/CollateralErc20.sol
@@ -11,6 +11,7 @@ import "./CollateralState.sol";
 import "./interfaces/IERC20.sol";
 
 // This contract handles the specific ERC20 implementation details of managing a loan.
+// https://docs.synthetix.io/contracts/source/contracts/CollateralErc20
 contract CollateralErc20 is ICollateralErc20, Collateral {
     // The underlying asset for this ERC20 collateral
     address public underlyingContract;

--- a/contracts/CollateralEth.sol
+++ b/contracts/CollateralEth.sol
@@ -11,6 +11,7 @@ import "./interfaces/ICollateralEth.sol";
 import "./CollateralState.sol";
 
 // This contract handles the payable aspects of eth loans.
+// https://docs.synthetix.io/contracts/source/contracts/CollateralEth
 contract CollateralEth is Collateral, ICollateralEth, ReentrancyGuard {
     mapping(address => uint) public pendingWithdrawals;
 

--- a/contracts/CollateralManager.sol
+++ b/contracts/CollateralManager.sol
@@ -18,6 +18,7 @@ import "./interfaces/IExchangeRates.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/ISynth.sol";
 
+// https://docs.synthetix.io/contracts/source/contracts/CollateralManager
 contract CollateralManager is ICollateralManager, Owned, Pausable, MixinResolver {
     /* ========== LIBRARIES ========== */
     using SafeMath for uint;

--- a/contracts/CollateralManagerState.sol
+++ b/contracts/CollateralManagerState.sol
@@ -9,6 +9,7 @@ import "./State.sol";
 // Libraries
 import "./SafeDecimalMath.sol";
 
+// https://docs.synthetix.io/contracts/source/contracts/CollateralManagerState
 contract CollateralManagerState is Owned, State {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/CollateralShort.sol
+++ b/contracts/CollateralShort.sol
@@ -8,6 +8,7 @@ import "./Collateral.sol";
 // Internal references
 import "./CollateralState.sol";
 
+// https://docs.synthetix.io/contracts/source/contracts/CollateralShort
 contract CollateralShort is Collateral {
     constructor(
         CollateralState _state,

--- a/contracts/CollateralState.sol
+++ b/contracts/CollateralState.sol
@@ -10,6 +10,7 @@ import "./interfaces/ICollateralLoan.sol";
 // Libraries
 import "./SafeDecimalMath.sol";
 
+// https://docs.synthetix.io/contracts/source/contracts/CollateralState
 contract CollateralState is Owned, State, ICollateralLoan {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/ContractStorage.sol
+++ b/contracts/ContractStorage.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.16;
 // Internal References
 import "./interfaces/IAddressResolver.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/contractstorage
+// https://docs.synthetix.io/contracts/source/contracts/ContractStorage
 contract ContractStorage {
     IAddressResolver public resolverProxy;
 

--- a/contracts/DappMaintenance.sol
+++ b/contracts/DappMaintenance.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.16;
 
 import "./Owned.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/dappmaintenance
+// https://docs.synthetix.io/contracts/source/contracts/DappMaintenance
 
 /**
  * @title DappMaintenance contract.

--- a/contracts/DebtCache.sol
+++ b/contracts/DebtCache.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.16;
 // Inheritance
 import "./BaseDebtCache.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/debtcache
+// https://docs.synthetix.io/contracts/source/contracts/DebtCache
 contract DebtCache is BaseDebtCache {
     constructor(address _owner, address _resolver) public BaseDebtCache(_owner, _resolver) {}
 

--- a/contracts/DelegateApprovals.sol
+++ b/contracts/DelegateApprovals.sol
@@ -7,7 +7,7 @@ import "./interfaces/IDelegateApprovals.sol";
 // Internal references
 import "./EternalStorage.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/delegateapprovals
+// https://docs.synthetix.io/contracts/source/contracts/DelegateApprovals
 contract DelegateApprovals is Owned, IDelegateApprovals {
     bytes32 public constant BURN_FOR_ADDRESS = "BurnForAddress";
     bytes32 public constant ISSUE_FOR_ADDRESS = "IssueForAddress";

--- a/contracts/Depot.sol
+++ b/contracts/Depot.sol
@@ -14,7 +14,7 @@ import "./SafeDecimalMath.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/IExchangeRates.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/depot
+// https://docs.synthetix.io/contracts/source/contracts/Depot
 contract Depot is Owned, Pausable, ReentrancyGuard, MixinResolver, IDepot {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/EmptyEtherCollateral.sol
+++ b/contracts/EmptyEtherCollateral.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.16;
 
 // Empty contract for ether collateral placeholder for OVM
-// https://docs.synthetix.io/contracts/source/contracts/emptyethercollateral
+// https://docs.synthetix.io/contracts/source/contracts/EmptyEtherCollateral
 contract EmptyEtherCollateral {
     function totalIssuedSynths() external pure returns (uint) {
         return 0;

--- a/contracts/EscrowChecker.sol
+++ b/contracts/EscrowChecker.sol
@@ -6,7 +6,7 @@ interface ISynthetixEscrow {
     function getVestingScheduleEntry(address account, uint index) external view returns (uint[2] memory);
 }
 
-// https://docs.synthetix.io/contracts/source/contracts/escrowchecker
+// https://docs.synthetix.io/contracts/source/contracts/EscrowChecker
 contract EscrowChecker {
     ISynthetixEscrow public synthetix_escrow;
 

--- a/contracts/EternalStorage.sol
+++ b/contracts/EternalStorage.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.5.16;
 import "./Owned.sol";
 import "./State.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/eternalstorage
+// https://docs.synthetix.io/contracts/source/contracts/EternalStorage
 /**
  * @notice  This contract is based on the code available from this blog
  * https://blog.colony.io/writing-upgradeable-contracts-in-solidity-6743f0eecc88/

--- a/contracts/EtherCollateral.sol
+++ b/contracts/EtherCollateral.sol
@@ -18,7 +18,7 @@ import "./interfaces/IERC20.sol";
 import "./interfaces/IDepot.sol";
 import "./interfaces/IExchangeRates.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/ethercollateral
+// https://docs.synthetix.io/contracts/source/contracts/EtherCollateral
 contract EtherCollateral is Owned, Pausable, ReentrancyGuard, MixinResolver, IEtherCollateral {
     using SafeMath for uint256;
     using SafeDecimalMath for uint256;

--- a/contracts/EtherCollateralsUSD.sol
+++ b/contracts/EtherCollateralsUSD.sol
@@ -18,7 +18,7 @@ import "./interfaces/IERC20.sol";
 import "./interfaces/IExchangeRates.sol";
 
 // ETH Collateral v0.3 (sUSD)
-// https://docs.synthetix.io/contracts/source/contracts/ethercollateralsusd
+// https://docs.synthetix.io/contracts/source/contracts/EtherCollateralsUSD
 contract EtherCollateralsUSD is Owned, Pausable, ReentrancyGuard, MixinResolver, IEtherCollateralsUSD {
     using SafeMath for uint256;
     using SafeDecimalMath for uint256;

--- a/contracts/ExchangeRates.sol
+++ b/contracts/ExchangeRates.sol
@@ -16,7 +16,7 @@ import "@chainlink/contracts-0.0.10/src/v0.5/interfaces/AggregatorV2V3Interface.
 import "@chainlink/contracts-0.0.10/src/v0.5/interfaces/FlagsInterface.sol";
 import "./interfaces/IExchanger.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/exchangerates
+// https://docs.synthetix.io/contracts/source/contracts/ExchangeRates
 contract ExchangeRates is Owned, MixinSystemSettings, IExchangeRates {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/ExchangeRatesWithoutInvPricing.sol
+++ b/contracts/ExchangeRatesWithoutInvPricing.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.16;
 // Internal references
 import "./ExchangeRates.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/exchangerateswithoutinvpricing
+// https://docs.synthetix.io/contracts/source/contracts/ExchangeRatesWithoutInvPricing
 contract ExchangeRatesWithoutInvPricing is ExchangeRates {
     constructor(
         address _owner,

--- a/contracts/ExchangeState.sol
+++ b/contracts/ExchangeState.sol
@@ -5,7 +5,7 @@ import "./Owned.sol";
 import "./State.sol";
 import "./interfaces/IExchangeState.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/exchangestate
+// https://docs.synthetix.io/contracts/source/contracts/ExchangeState
 contract ExchangeState is Owned, State, IExchangeState {
     mapping(address => mapping(bytes32 => IExchangeState.ExchangeEntry[])) public exchanges;
 

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -61,7 +61,7 @@ interface IExchangerInternalDebtCache {
     function updateCachedSynthDebts(bytes32[] calldata currencyKeys) external;
 }
 
-// https://docs.synthetix.io/contracts/source/contracts/exchanger
+// https://docs.synthetix.io/contracts/source/contracts/Exchanger
 contract Exchanger is Owned, MixinSystemSettings, IExchanger {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/ExchangerWithVirtualSynth.sol
+++ b/contracts/ExchangerWithVirtualSynth.sol
@@ -8,7 +8,7 @@ import "./interfaces/IVirtualSynth.sol";
 import "./MinimalProxyFactory.sol";
 import "./VirtualSynth.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/exchangerwithvirtualsynth
+// https://docs.synthetix.io/contracts/source/contracts/ExchangerWithVirtualSynth
 contract ExchangerWithVirtualSynth is MinimalProxyFactory, Exchanger {
     constructor(address _owner, address _resolver) public MinimalProxyFactory() Exchanger(_owner, _resolver) {}
 

--- a/contracts/ExternStateToken.sol
+++ b/contracts/ExternStateToken.sol
@@ -10,7 +10,7 @@ import "./SafeDecimalMath.sol";
 // Internal references
 import "./TokenState.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/externstatetoken
+// https://docs.synthetix.io/contracts/source/contracts/ExternStateToken
 contract ExternStateToken is Owned, Proxyable {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/FeePool.sol
+++ b/contracts/FeePool.sol
@@ -27,7 +27,7 @@ import "./interfaces/IRewardsDistribution.sol";
 import "./interfaces/IEtherCollateralsUSD.sol";
 import "./interfaces/ICollateralManager.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/feepool
+// https://docs.synthetix.io/contracts/source/contracts/FeePool
 contract FeePool is Owned, Proxyable, LimitedSetup, MixinSystemSettings, IFeePool {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/FeePoolEternalStorage.sol
+++ b/contracts/FeePoolEternalStorage.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.5.16;
 import "./EternalStorage.sol";
 import "./LimitedSetup.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/feepooleternalstorage
+// https://docs.synthetix.io/contracts/source/contracts/FeePoolEternalStorage
 contract FeePoolEternalStorage is EternalStorage, LimitedSetup {
     bytes32 internal constant LAST_FEE_WITHDRAWAL = "last_fee_withdrawal";
 

--- a/contracts/FeePoolState.sol
+++ b/contracts/FeePoolState.sol
@@ -10,7 +10,7 @@ import "./SafeDecimalMath.sol";
 // Internal references
 import "./interfaces/IFeePool.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/feepoolstate
+// https://docs.synthetix.io/contracts/source/contracts/FeePoolState
 contract FeePoolState is Owned, LimitedSetup {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/FlexibleStorage.sol
+++ b/contracts/FlexibleStorage.sol
@@ -7,7 +7,7 @@ import "./interfaces/IFlexibleStorage.sol";
 // Internal References
 import "./interfaces/IAddressResolver.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/flexiblestorage
+// https://docs.synthetix.io/contracts/source/contracts/FlexibleStorage
 contract FlexibleStorage is ContractStorage, IFlexibleStorage {
     mapping(bytes32 => mapping(bytes32 => uint)) internal uintStorage;
     mapping(bytes32 => mapping(bytes32 => int)) internal intStorage;

--- a/contracts/Issuer.sol
+++ b/contracts/Issuer.sol
@@ -47,7 +47,7 @@ interface IIssuerInternalDebtCache {
         );
 }
 
-// https://docs.synthetix.io/contracts/source/contracts/issuer
+// https://docs.synthetix.io/contracts/source/contracts/Issuer
 contract Issuer is Owned, MixinSystemSettings, IIssuer {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/IssuerWithoutLiquidations.sol
+++ b/contracts/IssuerWithoutLiquidations.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.16;
 // Internal references
 import "./Issuer.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/issuerwithoutliquidations
+// https://docs.synthetix.io/contracts/source/contracts/IssuerWithoutLiquidations
 contract IssuerWithoutLiquidations is Issuer {
     constructor(address _owner, address _resolver) public Issuer(_owner, _resolver) {}
 

--- a/contracts/LimitedSetup.sol
+++ b/contracts/LimitedSetup.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.16;
 
-// https://docs.synthetix.io/contracts/source/contracts/limitedsetup
+// https://docs.synthetix.io/contracts/source/contracts/LimitedSetup
 contract LimitedSetup {
     uint public setupExpiryTime;
 

--- a/contracts/Liquidations.sol
+++ b/contracts/Liquidations.sol
@@ -16,7 +16,7 @@ import "./interfaces/IExchangeRates.sol";
 import "./interfaces/IIssuer.sol";
 import "./interfaces/ISystemStatus.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/liquidations
+// https://docs.synthetix.io/contracts/source/contracts/Liquidations
 contract Liquidations is Owned, MixinSystemSettings, ILiquidations {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/Math.sol
+++ b/contracts/Math.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.16;
 // Libraries
 import "./SafeDecimalMath.sol";
 
-// https://docs.synthetix.io/contracts/source/libraries/math
+// https://docs.synthetix.io/contracts/source/libraries/Math
 library Math {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/MinimalProxyFactory.sol
+++ b/contracts/MinimalProxyFactory.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.16;
 
-// https://docs.synthetix.io/contracts/source/contracts/minimalproxyfactory
+// https://docs.synthetix.io/contracts/source/contracts/MinimalProxyFactory
 contract MinimalProxyFactory {
     function _cloneAsMinimalProxy(address _base, string memory _revertMsg) internal returns (address clone) {
         bytes memory createData = _generateMinimalProxyCreateData(_base);

--- a/contracts/MintableSynthetix.sol
+++ b/contracts/MintableSynthetix.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.16;
 // Inheritance
 import "./BaseSynthetix.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/mintablesynthetix
+// https://docs.synthetix.io/contracts/source/contracts/MintableSynthetix
 contract MintableSynthetix is BaseSynthetix {
     bytes32 private constant CONTRACT_SYNTHETIX_BRIDGE = "SynthetixBridgeToBase";
 

--- a/contracts/MixinResolver.sol
+++ b/contracts/MixinResolver.sol
@@ -7,7 +7,7 @@ import "./Owned.sol";
 import "./AddressResolver.sol";
 import "./ReadProxy.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/mixinresolver
+// https://docs.synthetix.io/contracts/source/contracts/MixinResolver
 contract MixinResolver {
     AddressResolver public resolver;
 

--- a/contracts/MixinSystemSettings.sol
+++ b/contracts/MixinSystemSettings.sol
@@ -5,7 +5,7 @@ import "./MixinResolver.sol";
 // Internal references
 import "./interfaces/IFlexibleStorage.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/mixinsystemsettings
+// https://docs.synthetix.io/contracts/source/contracts/MixinSystemSettings
 contract MixinSystemSettings is MixinResolver {
     bytes32 internal constant SETTING_CONTRACT_NAME = "SystemSettings";
 

--- a/contracts/MultiCollateralSynth.sol
+++ b/contracts/MultiCollateralSynth.sol
@@ -8,7 +8,7 @@ import "./interfaces/ICollateralManager.sol";
 import "./interfaces/IEtherCollateralsUSD.sol";
 import "./interfaces/IEtherCollateral.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/multicollateralsynth
+// https://docs.synthetix.io/contracts/source/contracts/MultiCollateralSynth
 contract MultiCollateralSynth is Synth {
     /* ========== ADDRESS RESOLVER CONFIGURATION ========== */
 

--- a/contracts/Owned.sol
+++ b/contracts/Owned.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.16;
 
-// https://docs.synthetix.io/contracts/source/contracts/owned
+// https://docs.synthetix.io/contracts/source/contracts/Owned
 contract Owned {
     address public owner;
     address public nominatedOwner;

--- a/contracts/Proxy.sol
+++ b/contracts/Proxy.sol
@@ -6,7 +6,7 @@ import "./Owned.sol";
 // Internal references
 import "./Proxyable.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/proxy
+// https://docs.synthetix.io/contracts/source/contracts/Proxy
 contract Proxy is Owned {
     Proxyable public target;
 

--- a/contracts/ProxyERC20.sol
+++ b/contracts/ProxyERC20.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.5.16;
 import "./Proxy.sol";
 import "./interfaces/IERC20.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/proxyerc20
+// https://docs.synthetix.io/contracts/source/contracts/ProxyERC20
 contract ProxyERC20 is Proxy, IERC20 {
     constructor(address _owner) public Proxy(_owner) {}
 

--- a/contracts/Proxyable.sol
+++ b/contracts/Proxyable.sol
@@ -6,7 +6,7 @@ import "./Owned.sol";
 // Internal references
 import "./Proxy.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/proxyable
+// https://docs.synthetix.io/contracts/source/contracts/Proxyable
 contract Proxyable is Owned {
     // This contract should be treated like an abstract contract
 

--- a/contracts/PurgeableSynth.sol
+++ b/contracts/PurgeableSynth.sol
@@ -9,7 +9,7 @@ import "./SafeDecimalMath.sol";
 // Internal References
 import "./interfaces/IExchangeRates.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/purgeablesynth
+// https://docs.synthetix.io/contracts/source/contracts/PurgeableSynth
 contract PurgeableSynth is Synth {
     using SafeDecimalMath for uint;
 

--- a/contracts/ReadProxy.sol
+++ b/contracts/ReadProxy.sol
@@ -4,7 +4,7 @@ import "./Owned.sol";
 
 // solhint-disable payable-fallback
 
-// https://docs.synthetix.io/contracts/source/contracts/readproxy
+// https://docs.synthetix.io/contracts/source/contracts/ReadProxy
 contract ReadProxy is Owned {
     address public target;
 

--- a/contracts/RealtimeDebtCache.sol
+++ b/contracts/RealtimeDebtCache.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.16;
 // Inheritance
 import "./BaseDebtCache.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/realtimedebtcache
+// https://docs.synthetix.io/contracts/source/contracts/RealtimeDebtCache
 contract RealtimeDebtCache is BaseDebtCache {
     constructor(address _owner, address _resolver) public BaseDebtCache(_owner, _resolver) {}
 

--- a/contracts/RewardEscrow.sol
+++ b/contracts/RewardEscrow.sol
@@ -12,7 +12,7 @@ import "./interfaces/IERC20.sol";
 import "./interfaces/IFeePool.sol";
 import "./interfaces/ISynthetix.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/rewardescrow
+// https://docs.synthetix.io/contracts/source/contracts/RewardEscrow
 contract RewardEscrow is Owned, IRewardEscrow {
     using SafeMath for uint;
 

--- a/contracts/RewardsDistribution.sol
+++ b/contracts/RewardsDistribution.sol
@@ -12,7 +12,7 @@ import "./interfaces/IERC20.sol";
 import "./interfaces/IFeePool.sol";
 import "./interfaces/IRewardsDistribution.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/rewardsdistribution
+// https://docs.synthetix.io/contracts/source/contracts/RewardsDistribution
 contract RewardsDistribution is Owned, IRewardsDistribution {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/RewardsDistributionRecipient.sol
+++ b/contracts/RewardsDistributionRecipient.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.16;
 // Inheritance
 import "./Owned.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/rewardsdistributionrecipient
+// https://docs.synthetix.io/contracts/source/contracts/RewardsDistributionRecipient
 contract RewardsDistributionRecipient is Owned {
     address public rewardsDistribution;
 

--- a/contracts/ShortingRewards.sol
+++ b/contracts/ShortingRewards.sol
@@ -16,7 +16,7 @@ import "./MixinResolver.sol";
 
 import "./interfaces/ICollateralErc20.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/stakingrewards
+// https://docs.synthetix.io/contracts/source/contracts/ShortingRewards
 contract ShortingRewards is IShortingRewards, RewardsDistributionRecipient, ReentrancyGuard, Pausable, MixinResolver {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;

--- a/contracts/StakingRewards.sol
+++ b/contracts/StakingRewards.sol
@@ -11,7 +11,7 @@ import "./interfaces/IStakingRewards.sol";
 import "./RewardsDistributionRecipient.sol";
 import "./Pausable.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/stakingrewards
+// https://docs.synthetix.io/contracts/source/contracts/StakingRewards
 contract StakingRewards is IStakingRewards, RewardsDistributionRecipient, ReentrancyGuard, Pausable {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;

--- a/contracts/State.sol
+++ b/contracts/State.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.5.16;
 // Inheritance
 import "./Owned.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/state
+// https://docs.synthetix.io/contracts/source/contracts/State
 contract State is Owned {
     // the address of the contract that can modify variables
     // this can only be changed by the owner of this contract

--- a/contracts/SupplySchedule.sol
+++ b/contracts/SupplySchedule.sol
@@ -13,7 +13,7 @@ import "./Proxy.sol";
 import "./interfaces/ISynthetix.sol";
 import "./interfaces/IERC20.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/supplyschedule
+// https://docs.synthetix.io/contracts/source/contracts/SupplySchedule
 contract SupplySchedule is Owned, ISupplySchedule {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/Synth.sol
+++ b/contracts/Synth.sol
@@ -13,7 +13,7 @@ import "./interfaces/IFeePool.sol";
 import "./interfaces/IExchanger.sol";
 import "./interfaces/IIssuer.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/synth
+// https://docs.synthetix.io/contracts/source/contracts/Synth
 contract Synth is Owned, IERC20, ExternStateToken, MixinResolver, ISynth {
     /* ========== STATE VARIABLES ========== */
 

--- a/contracts/SynthUtil.sol
+++ b/contracts/SynthUtil.sol
@@ -7,7 +7,7 @@ import "./interfaces/IExchangeRates.sol";
 import "./interfaces/IAddressResolver.sol";
 import "./interfaces/IERC20.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/synthutil
+// https://docs.synthetix.io/contracts/source/contracts/SynthUtil
 contract SynthUtil {
     IAddressResolver public addressResolverProxy;
 

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -8,7 +8,7 @@ import "./interfaces/IRewardEscrow.sol";
 import "./interfaces/IRewardEscrowV2.sol";
 import "./interfaces/ISupplySchedule.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/synthetix
+// https://docs.synthetix.io/contracts/source/contracts/Synthetix
 contract Synthetix is BaseSynthetix {
     // ========== ADDRESS RESOLVER CONFIGURATION ==========
     bytes32 private constant CONTRACT_REWARD_ESCROW = "RewardEscrow";

--- a/contracts/SynthetixBridgeToOptimism.sol
+++ b/contracts/SynthetixBridgeToOptimism.sol
@@ -17,6 +17,7 @@ import "./interfaces/ISynthetixBridgeToBase.sol";
 // solhint-disable indent
 import "@eth-optimism/contracts/build/contracts/iOVM/bridge/iOVM_BaseCrossDomainMessenger.sol";
 
+// https://docs.synthetix.io/contracts/source/contracts/SynthetixBridgeToOptimism
 contract SynthetixBridgeToOptimism is Owned, MixinSystemSettings, ISynthetixBridgeToOptimism {
     /* ========== ADDRESS RESOLVER CONFIGURATION ========== */
     bytes32 private constant CONTRACT_EXT_MESSENGER = "ext:Messenger";

--- a/contracts/SynthetixEscrow.sol
+++ b/contracts/SynthetixEscrow.sol
@@ -12,7 +12,7 @@ import "./SafeDecimalMath.sol";
 import "./interfaces/IERC20.sol";
 import "./interfaces/ISynthetix.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/synthetixescrow
+// https://docs.synthetix.io/contracts/source/contracts/SynthetixEscrow
 contract SynthetixEscrow is Owned, LimitedSetup(8 weeks), IHasBalance {
     using SafeMath for uint;
 

--- a/contracts/SynthetixState.sol
+++ b/contracts/SynthetixState.sol
@@ -8,7 +8,7 @@ import "./interfaces/ISynthetixState.sol";
 // Libraries
 import "./SafeDecimalMath.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/synthetixstate
+// https://docs.synthetix.io/contracts/source/contracts/SynthetixState
 contract SynthetixState is Owned, State, ISynthetixState {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/SynthetixStateWithLimitedSetup.sol
+++ b/contracts/SynthetixStateWithLimitedSetup.sol
@@ -7,7 +7,7 @@ import "./SynthetixState.sol";
 // Internal References
 import "./interfaces/IFeePool.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/synthetixstate
+// https://docs.synthetix.io/contracts/source/contracts/SynthetixState
 contract SynthetixStateWithLimitedSetup is SynthetixState, LimitedSetup {
     IFeePool public feePool;
 

--- a/contracts/SystemSettings.sol
+++ b/contracts/SystemSettings.sol
@@ -9,7 +9,7 @@ import "./interfaces/ISystemSettings.sol";
 // Libraries
 import "./SafeDecimalMath.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/systemsettings
+// https://docs.synthetix.io/contracts/source/contracts/SystemSettings
 contract SystemSettings is Owned, MixinSystemSettings, ISystemSettings {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/SystemStatus.sol
+++ b/contracts/SystemStatus.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.5.16;
 import "./Owned.sol";
 import "./interfaces/ISystemStatus.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/systemstatus
+// https://docs.synthetix.io/contracts/source/contracts/SystemStatus
 contract SystemStatus is Owned, ISystemStatus {
     mapping(bytes32 => mapping(address => Status)) public accessControl;
 

--- a/contracts/TokenState.sol
+++ b/contracts/TokenState.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.5.16;
 import "./Owned.sol";
 import "./State.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/tokenstate
+// https://docs.synthetix.io/contracts/source/contracts/TokenState
 contract TokenState is Owned, State {
     /* ERC20 fields. */
     mapping(address => uint) public balanceOf;

--- a/contracts/TradingRewards.sol
+++ b/contracts/TradingRewards.sol
@@ -17,7 +17,7 @@ import "./SafeDecimalMath.sol";
 import "./interfaces/ITradingRewards.sol";
 import "./interfaces/IExchanger.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/tradingrewards
+// https://docs.synthetix.io/contracts/source/contracts/TradingRewards
 contract TradingRewards is ITradingRewards, ReentrancyGuard, Owned, Pausable, MixinResolver {
     using SafeMath for uint;
     using SafeDecimalMath for uint;

--- a/contracts/VirtualSynth.sol
+++ b/contracts/VirtualSynth.sol
@@ -15,7 +15,7 @@ import "./interfaces/IExchanger.sol";
 // during the build
 import "openzeppelin-solidity-2.3.0/contracts/token/ERC20/IERC20.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/virtualsynth
+// https://docs.synthetix.io/contracts/source/contracts/VirtualSynth
 // Note: this contract should be treated as an abstract contract and should not be directly deployed.
 //       On higher versions of solidity, it would be marked with the `abstract` keyword.
 //       This contracts implements logic that is only intended to be accessed behind a proxy.

--- a/contracts/VirtualSynthMastercopy.sol
+++ b/contracts/VirtualSynthMastercopy.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.5.16;
 
 import "./VirtualSynth.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/virtualsynthmastercopy
+// https://docs.synthetix.io/contracts/source/contracts/VirtualSynthMastercopy
 // Note: this is the "frozen" mastercopy of the VirtualSynth contract that should be linked to from
 //       proxies.
 contract VirtualSynthMastercopy is VirtualSynth {

--- a/contracts/interfaces/IAddressResolver.sol
+++ b/contracts/interfaces/IAddressResolver.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/iaddressresolver
+// https://docs.synthetix.io/contracts/source/interfaces/IAddressResolver
 interface IAddressResolver {
     function getAddress(bytes32 name) external view returns (address);
 

--- a/contracts/interfaces/IBinaryOption.sol
+++ b/contracts/interfaces/IBinaryOption.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.4.24;
 import "../interfaces/IBinaryOptionMarket.sol";
 import "../interfaces/IERC20.sol";
 
-// https://docs.synthetix.io/contracts/source/interfaces/ibinaryoption
+// https://docs.synthetix.io/contracts/source/interfaces/IBinaryOption
 interface IBinaryOption {
     /* ========== VIEWS / VARIABLES ========== */
 

--- a/contracts/interfaces/IBinaryOptionMarket.sol
+++ b/contracts/interfaces/IBinaryOptionMarket.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.4.24;
 import "../interfaces/IBinaryOptionMarketManager.sol";
 import "../interfaces/IBinaryOption.sol";
 
-// https://docs.synthetix.io/contracts/source/interfaces/ibinaryoptionmarket
+// https://docs.synthetix.io/contracts/source/interfaces/IBinaryOptionMarket
 interface IBinaryOptionMarket {
     /* ========== TYPES ========== */
 

--- a/contracts/interfaces/IBinaryOptionMarketManager.sol
+++ b/contracts/interfaces/IBinaryOptionMarketManager.sol
@@ -2,7 +2,7 @@ pragma solidity >=0.4.24;
 
 import "../interfaces/IBinaryOptionMarket.sol";
 
-// https://docs.synthetix.io/contracts/source/interfaces/ibinaryoptionmarketmanager
+// https://docs.synthetix.io/contracts/source/interfaces/IBinaryOptionMarketManager
 interface IBinaryOptionMarketManager {
     /* ========== VIEWS / VARIABLES ========== */
 

--- a/contracts/interfaces/IDelegateApprovals.sol
+++ b/contracts/interfaces/IDelegateApprovals.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/idelegateapprovals
+// https://docs.synthetix.io/contracts/source/interfaces/IDelegateApprovals
 interface IDelegateApprovals {
     // Views
     function canBurnFor(address authoriser, address delegate) external view returns (bool);

--- a/contracts/interfaces/IDepot.sol
+++ b/contracts/interfaces/IDepot.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/idepot
+// https://docs.synthetix.io/contracts/source/interfaces/IDepot
 interface IDepot {
     // Views
     function fundsWallet() external view returns (address payable);

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/ierc20
+// https://docs.synthetix.io/contracts/source/interfaces/IERC20
 interface IERC20 {
     // ERC20 Optional Views
     function name() external view returns (string memory);

--- a/contracts/interfaces/IEtherCollateral.sol
+++ b/contracts/interfaces/IEtherCollateral.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/iethercollateral
+// https://docs.synthetix.io/contracts/source/interfaces/IEtherCollateral
 interface IEtherCollateral {
     // Views
     function totalIssuedSynths() external view returns (uint256);

--- a/contracts/interfaces/IEtherCollateralsUSD.sol
+++ b/contracts/interfaces/IEtherCollateralsUSD.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/iethercollateralsusd
+// https://docs.synthetix.io/contracts/source/interfaces/IEtherCollateralsUSD
 interface IEtherCollateralsUSD {
     // Views
     function totalIssuedSynths() external view returns (uint256);

--- a/contracts/interfaces/IExchangeRates.sol
+++ b/contracts/interfaces/IExchangeRates.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/iexchangerates
+// https://docs.synthetix.io/contracts/source/interfaces/IExchangeRates
 interface IExchangeRates {
     // Structs
     struct RateAndUpdatedTime {

--- a/contracts/interfaces/IExchangeState.sol
+++ b/contracts/interfaces/IExchangeState.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/iexchangestate
+// https://docs.synthetix.io/contracts/source/interfaces/IExchangeState
 interface IExchangeState {
     // Views
     struct ExchangeEntry {

--- a/contracts/interfaces/IExchanger.sol
+++ b/contracts/interfaces/IExchanger.sol
@@ -2,7 +2,7 @@ pragma solidity >=0.4.24;
 
 import "./IVirtualSynth.sol";
 
-// https://docs.synthetix.io/contracts/source/interfaces/iexchanger
+// https://docs.synthetix.io/contracts/source/interfaces/IExchanger
 interface IExchanger {
     // Views
     function calculateAmountAfterSettlement(

--- a/contracts/interfaces/IFeePool.sol
+++ b/contracts/interfaces/IFeePool.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/ifeepool
+// https://docs.synthetix.io/contracts/source/interfaces/IFeePool
 interface IFeePool {
     // Views
 

--- a/contracts/interfaces/IFlexibleStorage.sol
+++ b/contracts/interfaces/IFlexibleStorage.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/iflexiblestorage
+// https://docs.synthetix.io/contracts/source/interfaces/IFlexibleStorage
 interface IFlexibleStorage {
     // Views
     function getUIntValue(bytes32 contractName, bytes32 record) external view returns (uint);

--- a/contracts/interfaces/IHasBalance.sol
+++ b/contracts/interfaces/IHasBalance.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/ihasbalance
+// https://docs.synthetix.io/contracts/source/interfaces/IHasBalance
 interface IHasBalance {
     // Views
     function balanceOf(address account) external view returns (uint);

--- a/contracts/interfaces/IIssuer.sol
+++ b/contracts/interfaces/IIssuer.sol
@@ -2,7 +2,7 @@ pragma solidity >=0.4.24;
 
 import "../interfaces/ISynth.sol";
 
-// https://docs.synthetix.io/contracts/source/interfaces/iissuer
+// https://docs.synthetix.io/contracts/source/interfaces/IIssuer
 interface IIssuer {
     // Views
     function anySynthOrSNXRateIsInvalid() external view returns (bool anyRateInvalid);

--- a/contracts/interfaces/ILiquidations.sol
+++ b/contracts/interfaces/ILiquidations.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/iliquidations
+// https://docs.synthetix.io/contracts/source/interfaces/ILiquidations
 interface ILiquidations {
     // Views
     function isOpenForLiquidation(address account) external view returns (bool);

--- a/contracts/interfaces/IRewardEscrow.sol
+++ b/contracts/interfaces/IRewardEscrow.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/irewardescrow
+// https://docs.synthetix.io/contracts/source/interfaces/IRewardEscrow
 interface IRewardEscrow {
     // Views
     function balanceOf(address account) external view returns (uint);

--- a/contracts/interfaces/IRewardsDistribution.sol
+++ b/contracts/interfaces/IRewardsDistribution.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/irewardsdistribution
+// https://docs.synthetix.io/contracts/source/interfaces/IRewardsDistribution
 interface IRewardsDistribution {
     // Structs
     struct DistributionData {

--- a/contracts/interfaces/IShortingRewards.sol
+++ b/contracts/interfaces/IShortingRewards.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/istakingrewards
+// https://docs.synthetix.io/contracts/source/interfaces/IStakingRewards
 interface IShortingRewards {
     // Views
     function lastTimeRewardApplicable() external view returns (uint256);

--- a/contracts/interfaces/IStakingRewards.sol
+++ b/contracts/interfaces/IStakingRewards.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/istakingrewards
+// https://docs.synthetix.io/contracts/source/interfaces/IStakingRewards
 interface IStakingRewards {
     // Views
     function lastTimeRewardApplicable() external view returns (uint256);

--- a/contracts/interfaces/ISupplySchedule.sol
+++ b/contracts/interfaces/ISupplySchedule.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/isupplyschedule
+// https://docs.synthetix.io/contracts/source/interfaces/ISupplySchedule
 interface ISupplySchedule {
     // Views
     function mintableSupply() external view returns (uint);

--- a/contracts/interfaces/ISynth.sol
+++ b/contracts/interfaces/ISynth.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/isynth
+// https://docs.synthetix.io/contracts/source/interfaces/ISynth
 interface ISynth {
     // Views
     function currencyKey() external view returns (bytes32);

--- a/contracts/interfaces/ISynthetix.sol
+++ b/contracts/interfaces/ISynthetix.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.4.24;
 import "./ISynth.sol";
 import "./IVirtualSynth.sol";
 
-// https://docs.synthetix.io/contracts/source/interfaces/isynthetix
+// https://docs.synthetix.io/contracts/source/interfaces/ISynthetix
 interface ISynthetix {
     // Views
     function anySynthOrSNXRateIsInvalid() external view returns (bool anyRateInvalid);

--- a/contracts/interfaces/ISynthetixState.sol
+++ b/contracts/interfaces/ISynthetixState.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/isynthetixstate
+// https://docs.synthetix.io/contracts/source/interfaces/ISynthetixState
 interface ISynthetixState {
     // Views
     function debtLedger(uint index) external view returns (uint);

--- a/contracts/interfaces/ISystemSettings.sol
+++ b/contracts/interfaces/ISystemSettings.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/isystemsettings
+// https://docs.synthetix.io/contracts/source/interfaces/ISystemSettings
 interface ISystemSettings {
     // Views
     function priceDeviationThresholdFactor() external view returns (uint);

--- a/contracts/interfaces/ISystemStatus.sol
+++ b/contracts/interfaces/ISystemStatus.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/isystemstatus
+// https://docs.synthetix.io/contracts/source/interfaces/ISystemStatus
 interface ISystemStatus {
     struct Status {
         bool canSuspend;

--- a/contracts/interfaces/ITradingRewards.sol
+++ b/contracts/interfaces/ITradingRewards.sol
@@ -1,6 +1,6 @@
 pragma solidity >=0.4.24;
 
-// https://docs.synthetix.io/contracts/source/interfaces/itradingrewards
+// https://docs.synthetix.io/contracts/source/interfaces/ITradingRewards
 interface ITradingRewards {
     /* ========== VIEWS ========== */
 


### PR DESCRIPTION
The links all used lowercase naming, when our docs site uses CamelCase. This addresses that.

The alternative was duplicating data in the docs generator, as it is a static site, we can't dynamically redirect lowercase -> CamelCase for example.