### PR TITLE
Add unit tests parallelization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -248,6 +248,7 @@ jobs:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
     resource_class: large
+    parallelism: 8
     steps:
       - checkout
       - attach_workspace:
@@ -257,7 +258,9 @@ jobs:
           name: Test and output gas used
           command: |
             set +e
-            npm test
+            circleci tests glob 'test/contracts/*.js' |
+            circleci tests split |
+            xargs npm test
             EXIT_CODE=$?
             cat test-gas-used.log
             printf "\\n"

--- a/.circleci/src/jobs/job-unit-tests.yml
+++ b/.circleci/src/jobs/job-unit-tests.yml
@@ -1,6 +1,7 @@
 # Runs all unit and spec tests
 {{> job-header.yml}}
 resource_class: large
+parallelism: 8
 steps:
   - checkout
   - attach_workspace:
@@ -10,7 +11,9 @@ steps:
       name: Test and output gas used
       command: |
         set +e
-        npm test
+        circleci tests glob 'test/contracts/*.js' |
+        circleci tests split |
+        xargs npm test
         EXIT_CODE=$?
         cat test-gas-used.log
         printf "\\n"

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -65,6 +65,6 @@ module.exports = {
 		outputFile: 'test-gas-used.log',
 	},
 	mocha: {
-		timeout: 30e3, // 30s
+		timeout: 60e3, // 60s
 	},
 };

--- a/hardhat/tasks/task-test.js
+++ b/hardhat/tasks/task-test.js
@@ -1,5 +1,5 @@
 const Mocha = require('mocha');
-const { task, subtask } = require('hardhat/config');
+const { types, task, subtask } = require('hardhat/config');
 const { TASK_TEST_RUN_MOCHA_TESTS } = require('hardhat/builtin-tasks/task-names');
 const { gray, yellow } = require('chalk');
 const optimizeIfRequired = require('../util/optimizeIfRequired');
@@ -22,10 +22,11 @@ task('test')
 	.addFlag('gas', 'Compile gas usage')
 	.addFlag('native', 'Compile with the native solc compiler')
 	.addFlag('parallel', 'Run tests in parallel')
+	.addOptionalParam('jobs', 'Max number of worker processes for parallel runs', 4, types.int)
 	.addOptionalParam('gasOutputFile', 'Gas reporter output file')
 	.addOptionalParam('grep', 'Filter tests to only those with given logic')
 	.setAction(async (taskArguments, hre, runSuper) => {
-		const { gas, grep, native, gasOutputFile, parallel } = taskArguments;
+		const { gas, grep, native, gasOutputFile, parallel, jobs } = taskArguments;
 
 		if (native) {
 			hre.config.solc.native = true;
@@ -34,8 +35,9 @@ task('test')
 		optimizeIfRequired({ hre, taskArguments });
 
 		if (parallel) {
-			console.log(gray('Running tests in parallel'));
+			console.log(gray(`Running tests in parallel. Jobs count: ${jobs}`));
 			hre.config.mocha.parallel = true;
+			hre.config.mocha.jobs = jobs;
 		}
 
 		if (grep) {

--- a/hardhat/tasks/task-test.js
+++ b/hardhat/tasks/task-test.js
@@ -6,16 +6,22 @@ task('test')
 	.addFlag('optimizer', 'Compile with the optimizer')
 	.addFlag('gas', 'Compile gas usage')
 	.addFlag('native', 'Compile with the native solc compiler')
+	.addFlag('parallel', 'Run tests in parallel')
 	.addOptionalParam('gasOutputFile', 'Gas reporter output file')
 	.addOptionalParam('grep', 'Filter tests to only those with given logic')
 	.setAction(async (taskArguments, hre, runSuper) => {
-		const { gas, grep, native, gasOutputFile } = taskArguments;
+		const { gas, grep, native, gasOutputFile, parallel } = taskArguments;
 
 		if (native) {
 			hre.config.solc.native = true;
 		}
 
 		optimizeIfRequired({ hre, taskArguments });
+
+		if (parallel) {
+			console.log(gray('Running tests in parallel'));
+			hre.config.mocha.parallel = true;
+		}
 
 		if (grep) {
 			console.log(gray('Filtering tests to those containing'), yellow(grep));

--- a/hardhat/tasks/task-test.js
+++ b/hardhat/tasks/task-test.js
@@ -1,6 +1,21 @@
-const { task } = require('hardhat/config');
+const Mocha = require('mocha');
+const { task, subtask } = require('hardhat/config');
+const { TASK_TEST_RUN_MOCHA_TESTS } = require('hardhat/builtin-tasks/task-names');
 const { gray, yellow } = require('chalk');
 const optimizeIfRequired = require('../util/optimizeIfRequired');
+
+// Override builtin "test:run-mocha-tests" subtask so we can use the local mocha
+// installation, which is up to date and allows us to run parallel tests.
+subtask(TASK_TEST_RUN_MOCHA_TESTS).setAction(async ({ testFiles }, { config }) => {
+	const mocha = new Mocha(config.mocha);
+	testFiles.forEach(file => mocha.addFile(file));
+
+	const testFailures = await new Promise(resolve => {
+		mocha.run(resolve);
+	});
+
+	return testFailures;
+});
 
 task('test')
 	.addFlag('optimizer', 'Compile with the optimizer')


### PR DESCRIPTION
The objective of this PR is to improve the performance of running the unit tests both locally and on the CI.

### Mocha 8.x parallelization

Mocha versions starting from [`8.0.0`](https://github.com/mochajs/mocha/releases/tag/v8.0.0) adds a native parallelization feature using workers. This is implemented [here](https://github.com/Synthetixio/synthetix/pull/1233/commits/aab9cd6ac6eb990403e36307c1f2f06a8562bce5) making hardhat to use the locally installed version of mocha which is newer and has the feature. 

It can be used with:
```bash
npm run test -- --parallel
```

**_For the future_**, when Mocha gets updated on hardhat (https://github.com/nomiclabs/hardhat/pull/1429) we should be able to just delete the subtask override.

**_Register mocha plugin:_** In this case, instead of using the mocha register plugin as exemplified [here](https://github.com/fvictorio/hardhat-examples/blob/master/parallel-tests/package.json#L8) I opted for overriding the `subtask` so we can more transparently share the tasks configuration flags defined at `hardhat/tasks/task-test` using the same script.

**_Jobs Flag:_** This PR also adds the `--jobs` flag that allows you to define the amount of jobs you want to run in parallel, defaulted to `4`. e.g.: `npm run test -- --parallel --jobs 8`

**_Timeout update:_** I had to update the global tests timeout from 30 secs to 60 secs because when running them in parallel sometimes it could take a little more.

### Circle CI parallelization

The above flag is not recommended to be used on Circle CI because it consumes all the CPUs and gets killed during the tests, that's why it is implemented using [CircleCI's job parallelization](https://circleci.com/docs/2.0/parallelism-faster-jobs/) feature.

### Performance
* **My Computer:** Initial tests ran on my computer (i5 quad core) improved tests execution time from 26m to 9m.
* **CI:** Improved from [`31m`](https://app.circleci.com/pipelines/github/Synthetixio/synthetix/7077/workflows/b782dbc5-6e6e-42fd-9e52-5e3931376834/jobs/64659) to [`8m~`](https://app.circleci.com/pipelines/github/Synthetixio/synthetix/7078/workflows/a2c3c269-049b-461e-aaab-ad48950e5355/jobs/64671)
