### PR TITLE
Rename bridge emitted to be consistent to Optimism's interfaces

### DIFF
--- a/contracts/SynthetixBridgeToBase.sol
+++ b/contracts/SynthetixBridgeToBase.sol
@@ -99,11 +99,11 @@ contract SynthetixBridgeToBase is BaseSynthetixBridge, ISynthetixBridgeToBase, i
     }
 
     // invoked by Messenger on L2
-    function finalizeRewardDeposit(uint256 amount) external onlyOptimismBridge {
+    function finalizeRewardDeposit(address from, uint256 amount) external onlyOptimismBridge {
         // now tell Synthetix to mint these tokens, deposited in L1, into reward escrow on L2
         synthetix().mintSecondaryRewards(amount);
 
-        emit MintedSecondaryRewards(amount);
+        emit RewardDepositFinalized(from, amount);
     }
 
     // ========== EVENTS ==========
@@ -113,5 +113,5 @@ contract SynthetixBridgeToBase is BaseSynthetixBridge, ISynthetixBridgeToBase, i
         VestingEntries.VestingEntry[] vestingEntries
     );
 
-    event MintedSecondaryRewards(uint256 amount);
+    event RewardDepositFinalized(address from, uint256 amount);
 }

--- a/contracts/interfaces/ISynthetixBridgeToBase.sol
+++ b/contracts/interfaces/ISynthetixBridgeToBase.sol
@@ -12,5 +12,5 @@ interface ISynthetixBridgeToBase {
     ) external;
 
     // invoked by the xDomain messenger on L2
-    function finalizeRewardDeposit(uint amount) external;
+    function finalizeRewardDeposit(address from, uint amount) external;
 }

--- a/test/contracts/SynthetixBridgeToBase.unit.js
+++ b/test/contracts/SynthetixBridgeToBase.unit.js
@@ -295,7 +295,7 @@ contract('SynthetixBridgeToBase (unit tests)', accounts => {
 					it('should only allow the relayer (aka messenger) to call finalizeRewardDeposit()', async () => {
 						await onlyGivenAddressCanInvoke({
 							fnc: instance.finalizeRewardDeposit,
-							args: [100],
+							args: [user1, 100],
 							accounts,
 							address: smockedMessenger,
 							reason: 'Only the relayer can call this',
@@ -306,7 +306,7 @@ contract('SynthetixBridgeToBase (unit tests)', accounts => {
 						// 'smock' the messenger to return a random msg sender
 						messenger.smocked.xDomainMessageSender.will.return.with(() => randomAddress);
 						await assert.revert(
-							instance.finalizeRewardDeposit(100, {
+							instance.finalizeRewardDeposit(user1, 100, {
 								from: smockedMessenger,
 							}),
 							'Only the L1 bridge can invoke'
@@ -319,6 +319,7 @@ contract('SynthetixBridgeToBase (unit tests)', accounts => {
 					const finalizeRewardDepositAmount = 100;
 					beforeEach('finalizeRewardDeposit is called', async () => {
 						finalizeRewardDepositTx = await instance.finalizeRewardDeposit(
+							user1,
 							finalizeRewardDepositAmount,
 							{
 								from: smockedMessenger,
@@ -326,8 +327,8 @@ contract('SynthetixBridgeToBase (unit tests)', accounts => {
 						);
 					});
 
-					it('should emit a MintedSecondaryRewards event', async () => {
-						assert.eventEqual(finalizeRewardDepositTx, 'MintedSecondaryRewards', {
+					it('should emit a RewardDepositFinalized event', async () => {
+						assert.eventEqual(finalizeRewardDepositTx, 'RewardDepositFinalized', {
 							amount: finalizeRewardDepositAmount,
 						});
 					});

--- a/test/contracts/SynthetixBridgeToOptimism.unit.js
+++ b/test/contracts/SynthetixBridgeToOptimism.unit.js
@@ -431,14 +431,14 @@ contract('SynthetixBridgeToOptimism (unit tests)', accounts => {
 						const expectedData = getDataOfEncodedFncCall({
 							contract: 'SynthetixBridgeToBase',
 							fnc: 'finalizeRewardDeposit',
-							args: [amount],
+							args: [user1, amount],
 						});
 						assert.equal(messenger.smocked.sendMessage.calls[0][1], expectedData);
 						assert.equal(messenger.smocked.sendMessage.calls[0][2], (3e6).toString());
 					});
 
-					it('and a RewardDeposit event is emitted', async () => {
-						assert.eventEqual(txn, 'RewardDeposit', [user1, amount]);
+					it('and a RewardDepositInitiated event is emitted', async () => {
+						assert.eventEqual(txn, 'RewardDepositInitiated', [user1, amount]);
 					});
 				});
 			});
@@ -476,7 +476,7 @@ contract('SynthetixBridgeToOptimism (unit tests)', accounts => {
 						const expectedData = getDataOfEncodedFncCall({
 							contract: 'SynthetixBridgeToBase',
 							fnc: 'finalizeRewardDeposit',
-							args: [amount],
+							args: [rewardsDistribution, amount],
 						});
 
 						assert.equal(messenger.smocked.sendMessage.calls[0][1], expectedData);
@@ -488,8 +488,8 @@ contract('SynthetixBridgeToOptimism (unit tests)', accounts => {
 						assert.equal(synthetix.smocked.transfer.calls[0][1].toString(), amount);
 					});
 
-					it('and a RewardDeposit event is emitted', async () => {
-						assert.eventEqual(txn, 'RewardDeposit', [rewardsDistribution, amount]);
+					it('and a RewardDepositInitiated event is emitted', async () => {
+						assert.eventEqual(txn, 'RewardDepositInitiated', [rewardsDistribution, amount]);
 					});
 				});
 			});

--- a/test/optimism/depositAndMigrateEscrow.test.js
+++ b/test/optimism/depositAndMigrateEscrow.test.js
@@ -184,7 +184,7 @@ const itCanPerformDepositAndEscrowMigration = ({ ctx }) => {
 									const depositFinalizedEvents = [];
 									const importedVestingEntriesEvents = [];
 
-									const mintedSecondaryEventListener = (account, amount, event) => {
+									const depositFinalizedEventListener = (account, amount, event) => {
 										if (event && event.event === 'DepositFinalized') {
 											depositFinalizedEvents.push(event);
 										}
@@ -201,7 +201,7 @@ const itCanPerformDepositAndEscrowMigration = ({ ctx }) => {
 											'ImportedVestingEntries',
 											importedVestingEntriesEventListener
 										);
-										SynthetixBridgeToBaseL2.on('DepositFinalized', mintedSecondaryEventListener);
+										SynthetixBridgeToBaseL2.on('DepositFinalized', depositFinalizedEventListener);
 									});
 
 									before('depositAndMigrateEscrow', async () => {
@@ -269,7 +269,10 @@ const itCanPerformDepositAndEscrowMigration = ({ ctx }) => {
 												'ImportedVestingEntries',
 												importedVestingEntriesEventListener
 											);
-											SynthetixBridgeToBaseL2.off('DepositFinalized', mintedSecondaryEventListener);
+											SynthetixBridgeToBaseL2.off(
+												'DepositFinalized',
+												depositFinalizedEventListener
+											);
 										});
 
 										it('emitted two ImportedVestingEntries events', async () => {

--- a/test/optimism/index.js
+++ b/test/optimism/index.js
@@ -69,10 +69,10 @@ describe('Layer 2 production tests', () => {
 		});
 	});
 
-	// after('exit', async () => {
-	// 	// TODO: Optimism watchers leave the process open, so we explicitely kill it
-	// 	process.exit(0);
-	// });
+	after('exit', async () => {
+		// TODO: Optimism watchers leave the process open, so we explicitely kill it
+		process.exit(0);
+	});
 
 	describe('when instances have been deployed in local L1 and L2 chains', () => {
 		before('connect to contracts', async () => {


### PR DESCRIPTION
- `MintedSecondaryRewards` => `RewardDepositInitiated` and emits the msg sender.
- `RewardDepositInitiated` now emits also the msg sender.
- `finalizeRewardDeposit()` uses an extra argument (from denoting the msg sender on L1)