### PR TITLE
change to correct block number for v2.0-19 release

### DIFF
--- a/publish/deployed/mainnet/versions.json
+++ b/publish/deployed/mainnet/versions.json
@@ -6,7 +6,7 @@
 		"network": "mainnet",
 		"date": "2019-03-11T18:17:52-04:00",
 		"commit": "eeb271f4fdd2e615f9dba90503f42b2cb9f9716e",
-		"block": 6834810,
+		"block": 5873222,
 		"contracts": {
 			"Depot": {
 				"address": "0x172E09691DfBbC035E37c73B62095caa16Ee2388",


### PR DESCRIPTION
The `synthetix-subgraphs` repo will be relying on this `versions.json` file in order to include relevant block numbers for all upgrades on all networks. on recent testing, we discovered that the `synthetix` subgraph was lacking a large number of stakers in its aggregate statistics.

after investigation, it was discovered that if we made the block number adjustment included herein, the number of stakers was corrected to the higher, expected number.

Please note that the block number will not match the displayed date. Should the date be updated to match the new block number, or somethign else?

/hours 1