### PR TITLE
Fixing EthWrapper tests by restoring default rates in test setup

### DIFF
--- a/test/contracts/EtherWrapper.js
+++ b/test/contracts/EtherWrapper.js
@@ -88,6 +88,10 @@ contract('EtherWrapper', async accounts => {
 			],
 		}));
 
+		// set defaults for test - 50bps mint and burn fees
+		await systemSettings.setEtherWrapperMintFeeRate(toUnit('0.005'), { from: owner });
+		await systemSettings.setEtherWrapperBurnFeeRate(toUnit('0.005'), { from: owner });
+
 		FEE_ADDRESS = await feePool.FEE_ADDRESS();
 		timestamp = await currentTime();
 


### PR DESCRIPTION
Fixes tests broken by this change: https://github.com/Synthetixio/synthetix/commit/8bd0057830284a6c4f3b855b7e8a0360c9e36e38