### PR TITLE
Add coverage parallelization

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,13 +222,10 @@ jobs:
       - attach_workspace:
           at: /tmp/coverage
       - run:
-          name: Combine coverage reports
+          name: Upload coverage
           command: |
             cp -R /tmp/coverage/coverage-*.json .
-            npx istanbul-combine-updated coverage-*.json
-      - run:
-          name: Upload coverage
-          command: bash <(curl -s https://codecov.io/bash)
+            bash <(curl -s https://codecov.io/bash)
   job-unit-tests-coverage:
     working_directory: ~/repo
     docker:
@@ -255,7 +252,6 @@ jobs:
           name: Save coverage
           command: |
             cp coverage.json /tmp/coverage/coverage-$CIRCLE_NODE_INDEX.json
-            chmod -R 777 /tmp/coverage/coverage-$CIRCLE_NODE_INDEX.json
       - persist_to_workspace:
           root: /tmp/coverage
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -210,6 +210,25 @@ jobs:
       - store_artifacts:
           path: test/publish/test-log.html
           destination: test-log.html
+  job-unit-tests-coverage-report:
+    working_directory: ~/repo
+    docker:
+      - image: synthetixio/docker-node:14.16-focal
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
+    steps:
+      - checkout
+      - attach_workspace:
+          at: /tmp/coverage
+      - run:
+          name: Combine coverage reports
+          command: |
+            cp -R /tmp/coverage/coverage-*.json .
+            npx istanbul-combine-updated coverage-*.json
+      - run:
+          name: Upload coverage
+          command: bash <(curl -s https://codecov.io/bash)
   job-unit-tests-coverage:
     working_directory: ~/repo
     docker:
@@ -218,12 +237,29 @@ jobs:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
     resource_class: large
+    parallelism: 8
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - run: npm run coverage
-      - run: bash <(curl -s https://codecov.io/bash)
+      - run:
+          name: Create shared coverage outputs folder
+          command: mkdir -p /tmp/coverage
+      - run:
+          name: Coverage
+          command: |
+            TEST_FILES="{$(circleci tests glob "test/contracts/*.js" | \
+              circleci tests split --split-by=timings | xargs | sed -e 's/ /,/g')}"
+            npm run coverage -- --testfiles "$TEST_FILES"
+      - run:
+          name: Save coverage
+          command: |
+            cp coverage.json /tmp/coverage/coverage-$CIRCLE_NODE_INDEX.json
+            chmod -R 777 /tmp/coverage/coverage-$CIRCLE_NODE_INDEX.json
+      - persist_to_workspace:
+          root: /tmp/coverage
+          paths:
+            - coverage-*.json
   job-unit-tests-gas-report:
     working_directory: ~/repo
     docker:
@@ -311,6 +347,10 @@ workflows:
       - job-unit-tests-coverage:
           requires:
             - job-prepare
+      - job-unit-tests-coverage-report:
+          requires:
+            - job-prepare
+            - job-unit-tests-coverage
       - job-unit-tests-gas-report:
           requires:
             - job-prepare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,7 +222,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - run: NODE_OPTIONS=--max_old_space_size=4096 npm run coverage
+      - run: npm run coverage
       - run: bash <(curl -s https://codecov.io/bash)
   job-unit-tests-gas-report:
     working_directory: ~/repo

--- a/.circleci/src/jobs/job-unit-tests-coverage-report.yml
+++ b/.circleci/src/jobs/job-unit-tests-coverage-report.yml
@@ -5,10 +5,7 @@ steps:
   - attach_workspace:
       at: /tmp/coverage
   - run:
-      name: Combine coverage reports
+      name: Upload coverage
       command: |
         cp -R /tmp/coverage/coverage-*.json .
-        npx istanbul-combine-updated coverage-*.json
-  - run:
-      name: Upload coverage
-      command: bash <(curl -s https://codecov.io/bash)
+        bash <(curl -s https://codecov.io/bash)

--- a/.circleci/src/jobs/job-unit-tests-coverage-report.yml
+++ b/.circleci/src/jobs/job-unit-tests-coverage-report.yml
@@ -1,0 +1,14 @@
+# Measures unit and spec test coverage
+{{> job-header.yml}}
+steps:
+  - checkout
+  - attach_workspace:
+      at: /tmp/coverage
+  - run:
+      name: Combine coverage reports
+      command: |
+        cp -R /tmp/coverage/coverage-*.json .
+        npx istanbul-combine-updated coverage-*.json
+  - run:
+      name: Upload coverage
+      command: bash <(curl -s https://codecov.io/bash)

--- a/.circleci/src/jobs/job-unit-tests-coverage.yml
+++ b/.circleci/src/jobs/job-unit-tests-coverage.yml
@@ -19,7 +19,6 @@ steps:
       name: Save coverage
       command: |
         cp coverage.json /tmp/coverage/coverage-$CIRCLE_NODE_INDEX.json
-        chmod -R 777 /tmp/coverage/coverage-$CIRCLE_NODE_INDEX.json
   - persist_to_workspace:
       root: /tmp/coverage
       paths:

--- a/.circleci/src/jobs/job-unit-tests-coverage.yml
+++ b/.circleci/src/jobs/job-unit-tests-coverage.yml
@@ -5,5 +5,5 @@ steps:
   - checkout
   - attach_workspace:
       at: .
-  - run: NODE_OPTIONS=--max_old_space_size=4096 npm run coverage
+  - run: npm run coverage
   - run: bash <(curl -s https://codecov.io/bash)

--- a/.circleci/src/jobs/job-unit-tests-coverage.yml
+++ b/.circleci/src/jobs/job-unit-tests-coverage.yml
@@ -1,9 +1,26 @@
 # Measures unit and spec test coverage
 {{> job-header.yml}}
 resource_class: large
+parallelism: 8
 steps:
   - checkout
   - attach_workspace:
       at: .
-  - run: npm run coverage
-  - run: bash <(curl -s https://codecov.io/bash)
+  - run:
+      name: Create shared coverage outputs folder
+      command: mkdir -p /tmp/coverage
+  - run:
+      name: Coverage
+      command: |
+        TEST_FILES="{$(circleci tests glob "test/contracts/*.js" | \
+          circleci tests split --split-by=timings | xargs | sed -e 's/ /,/g')}"
+        npm run coverage -- --testfiles "$TEST_FILES"
+  - run:
+      name: Save coverage
+      command: |
+        cp coverage.json /tmp/coverage/coverage-$CIRCLE_NODE_INDEX.json
+        chmod -R 777 /tmp/coverage/coverage-$CIRCLE_NODE_INDEX.json
+  - persist_to_workspace:
+      root: /tmp/coverage
+      paths:
+        - coverage-*.json

--- a/.circleci/src/snippets/require-unit-tests-coverage.yml
+++ b/.circleci/src/snippets/require-unit-tests-coverage.yml
@@ -1,0 +1,3 @@
+requires:
+  - job-prepare
+  - job-unit-tests-coverage

--- a/.circleci/src/workflows/workflow-all.yml
+++ b/.circleci/src/workflows/workflow-all.yml
@@ -17,6 +17,8 @@ jobs:
       {{> require-prepare.yml}}
   - job-unit-tests-coverage:
       {{> require-prepare.yml}}
+  - job-unit-tests-coverage-report:
+      {{> require-unit-tests-coverage.yml}}
   - job-unit-tests-gas-report:
       {{> require-prepare.yml}}
   - job-test-deploy-script:


### PR DESCRIPTION
This is a follow up on [unit tests parallelization PR](https://github.com/Synthetixio/synthetix/pull/1272), implementing the same strategy for CI, but including coverage reports.

## Performance 
After implementing parallelization the job improved run time from [`33m`](https://app.circleci.com/pipelines/github/Synthetixio/synthetix/7125/workflows/f239da92-a9d6-4bd7-9c5b-afd59c487b6f/jobs/65393) to [`10m`](https://app.circleci.com/pipelines/github/Synthetixio/synthetix/7129/workflows/0ab7ca13-3675-4680-b7af-1c4725380923/jobs/65456)