### PR TITLE
Accurate gas reports for Futures on Optimism

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -56,6 +56,11 @@ module.exports = {
 			blockGasLimit: 12e6,
 			url: 'http://localhost:8545',
 		},
+		localhostOVM: {
+			gas: 0,
+			blockGasLimit: 9e6,
+			url: 'http://localhost:8545',
+		},
 	},
 	gasReporter: {
 		enabled: false,

--- a/publish/deployed/local-ovm/config.json
+++ b/publish/deployed/local-ovm/config.json
@@ -139,8 +139,5 @@
 	},
 	"EtherWrapper": {
 		"deploy": true
-	},
-	"NativeEtherWrapper": {
-		"deploy": true
 	}
 }

--- a/publish/src/commands/deploy.js
+++ b/publish/src/commands/deploy.js
@@ -269,8 +269,17 @@ const deploy = async ({
 	}
 
 	// if not specified, or in a local network, override the private key passed as a CLI option, with the one specified in .env
-	if (network !== 'local' && !privateKey) {
+	if (network === 'local' && !privateKey) {
 		privateKey = envPrivateKey;
+	}
+
+	// The OVM geth node requires that transactions are sent using eth_sendSignedTransaction.
+	// For web3.js to do this, it needs a private key.
+	//
+	// If OVM geth receives eth_sendTransaction, it will fail with error "OVM: Unsupported RPC Method".
+	// OVM has disabled this RPC method, as the local rollup node has no notion of unlocked accounts.
+	if (network === 'local' && useOvm && !privateKey) {
+		throw new Error('No private key specified while trying to deploy to OVM Geth.');
 	}
 
 	const nonceManager = new NonceManager({});

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -108,6 +108,8 @@ const setupContract = async ({
 	properties = {},
 }) => {
 	const [deployerAccount, owner, oracle, fundsWallet] = accounts;
+	// TODO: temporary to share notes.
+	console.log(accounts); // currently [ '0x1B16A796a68a9d5C8A49D2607551f6c7F65709fa' ] on OVM Geth
 
 	const artifact = artifacts.require(source || contract);
 


### PR DESCRIPTION
## Background
We (Anton and I) are currently working on the futures implementation, which will exist natively on L2. Currently, our methods of observing the gas costs of our L2 contracts are manual (deploying contracts, running tx's etc.), which will cost significant time as we move forward with building on Optimism. 

To recap, Optimism OVM has a different model to gas costs we find on L1. Due to the extra overhead of proving L2 fraud on L1 (transferring proofs of L2 storage leaves to L1), transactions in the OVM include an additional cost known as "nuisance gas". Interestingly, nuisance gas isn't a simple "multiplier" on existing gas - for example, the [first time an account is loaded on L2](https://github.com/ethereum-optimism/contracts/blob/f6069a881fbf6c35687a1676a73c67596b3ef4f9/contracts/optimistic-ethereum/OVM/execution/OVM_ExecutionManager.sol#L1182-L1187), it incurs a charge for nuisance gas. For this reason, it's important then that an accurate gas report is generated based on running tx's on the canonical OVM Geth implementation.

Problem: how might we get the L2 gas cost of the futures contracts?

## Approach.
1. run optimism geth
2. deploy to l2
3. run test suite and log gas output

todo:

 - [ ] fix accounts issue below
 - [ ] generate gas reports in CI

problems:

 - [ ] tests won't run, as the `accounts` during tests is populated by `web3.eth.getAccounts`, and the OVM geth node has no notion of local accounts. Current idea - adding private keys for all the same accounts as L1.
 - [ ] we can't run a hardhat fork for tests, as this would use the EVM. Potential solution is snapshotting before and after the test suite for the local geth node, although this is potentially unsupported due to ovm's one-tx-per-block?
 - [ ] tests written with smockit will not report gas using the OVM.

## Getting setup.
Note that this is WIP.

```sh
# Run Optimism geth
git clone https://github.com/ethereum-optimism/optimism.git -b master
cd optimism/ 
yarn
cd ops/
docker-compose build
docker-compose up -d

# Now compile our code.
node publish build --test-helpers --use-ovm

# Deploy to OVM
node publish deploy --network local --use-ovm --method-call-gas-limit 8999999 --provider-url http://localhost:8545 --fresh-deploy --yes --private-key 0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80

# Connect up L1 and L2.
node publish deploy-ovm-pair
# Rebuild with OVM bytecode (temp fix).
node publish build --test-helpers -k --use-ovm

# Generate a gas report through testing.
# Get an understanding of gas costs during tests for different contracts.
# 1. Specify "--no-compile" to avoid recompiling OVM code into EVM code.
# 2. Specify "--network localhostOVM" as the default behaviour of running the tests against a forked hardhat
#    will run the code in EVM, rather than OVM.
npx hardhat test --gas --optimizer --no-compile --network localhostOVM test/contracts/EtherWrapper.js
```