### PR TITLE
Refactoring of Exchanger.sol to reduce size on OVM

### DIFF
--- a/contracts/BaseSynthetix.sol
+++ b/contracts/BaseSynthetix.sol
@@ -167,7 +167,17 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         uint sourceAmount,
         bytes32 destinationCurrencyKey
     ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {
-        return exchanger().exchange(messageSender, sourceCurrencyKey, sourceAmount, destinationCurrencyKey, messageSender);
+        (amountReceived, ) = exchanger().exchange(
+            messageSender,
+            messageSender,
+            sourceCurrencyKey,
+            sourceAmount,
+            destinationCurrencyKey,
+            messageSender,
+            false,
+            messageSender,
+            bytes32(0)
+        );
     }
 
     function exchangeOnBehalf(
@@ -176,14 +186,17 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         uint sourceAmount,
         bytes32 destinationCurrencyKey
     ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {
-        return
-            exchanger().exchangeOnBehalf(
-                exchangeForAddress,
-                messageSender,
-                sourceCurrencyKey,
-                sourceAmount,
-                destinationCurrencyKey
-            );
+        (amountReceived, ) = exchanger().exchange(
+            exchangeForAddress,
+            messageSender,
+            sourceCurrencyKey,
+            sourceAmount,
+            destinationCurrencyKey,
+            exchangeForAddress,
+            false,
+            exchangeForAddress,
+            bytes32(0)
+        );
     }
 
     function settle(bytes32 currencyKey)
@@ -205,16 +218,17 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         address originator,
         bytes32 trackingCode
     ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {
-        return
-            exchanger().exchangeWithTracking(
-                messageSender,
-                sourceCurrencyKey,
-                sourceAmount,
-                destinationCurrencyKey,
-                messageSender,
-                originator,
-                trackingCode
-            );
+        (amountReceived, ) = exchanger().exchange(
+            messageSender,
+            messageSender,
+            sourceCurrencyKey,
+            sourceAmount,
+            destinationCurrencyKey,
+            messageSender,
+            false,
+            originator,
+            trackingCode
+        );
     }
 
     function exchangeOnBehalfWithTracking(
@@ -225,16 +239,17 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         address originator,
         bytes32 trackingCode
     ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {
-        return
-            exchanger().exchangeOnBehalfWithTracking(
-                exchangeForAddress,
-                messageSender,
-                sourceCurrencyKey,
-                sourceAmount,
-                destinationCurrencyKey,
-                originator,
-                trackingCode
-            );
+        (amountReceived, ) = exchanger().exchange(
+            exchangeForAddress,
+            messageSender,
+            sourceCurrencyKey,
+            sourceAmount,
+            destinationCurrencyKey,
+            exchangeForAddress,
+            false,
+            originator,
+            trackingCode
+        );
     }
 
     function transfer(address to, uint value) external optionalProxy systemActive returns (bool) {

--- a/contracts/BaseSynthetix.sol
+++ b/contracts/BaseSynthetix.sol
@@ -215,7 +215,7 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         bytes32 sourceCurrencyKey,
         uint sourceAmount,
         bytes32 destinationCurrencyKey,
-        address originator,
+        address rewardAddress,
         bytes32 trackingCode
     ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {
         (amountReceived, ) = exchanger().exchange(
@@ -226,7 +226,7 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
             destinationCurrencyKey,
             messageSender,
             false,
-            originator,
+            rewardAddress,
             trackingCode
         );
     }
@@ -236,7 +236,7 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         bytes32 sourceCurrencyKey,
         uint sourceAmount,
         bytes32 destinationCurrencyKey,
-        address originator,
+        address rewardAddress,
         bytes32 trackingCode
     ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {
         (amountReceived, ) = exchanger().exchange(
@@ -247,7 +247,7 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
             destinationCurrencyKey,
             exchangeForAddress,
             false,
-            originator,
+            rewardAddress,
             trackingCode
         );
     }

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -661,12 +661,11 @@ contract Exchanger is Owned, MixinSystemSettings, IExchanger {
 
     // SIP-139
     function resetLastExchangeRate(bytes32[] calldata currencyKeys) external onlyOwner {
-        IExchangeRates exRates = exchangeRates();
-        require(!exRates.anyRateIsInvalid(currencyKeys), "Rates for given synths not valid");
+        require(!exchangeRates().anyRateIsInvalid(currencyKeys), "Rates for given synths not valid");
 
         for (uint i = 0; i < currencyKeys.length; i++) {
             bytes32 currencyKey = currencyKeys[i];
-            lastExchangeRate[currencyKey] = exRates.rateForCurrency((currencyKey));
+            lastExchangeRate[currencyKey] = exchangeRates().rateForCurrency((currencyKey));
         }
     }
 

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -661,11 +661,12 @@ contract Exchanger is Owned, MixinSystemSettings, IExchanger {
 
     // SIP-139
     function resetLastExchangeRate(bytes32[] calldata currencyKeys) external onlyOwner {
-        require(!exchangeRates().anyRateIsInvalid(currencyKeys), "Rates for given synths not valid");
+        (uint[] memory rates, bool anyRateInvalid) = exchangeRates().ratesAndInvalidForCurrencies(currencyKeys);
+
+        require(!anyRateInvalid, "Rates for given synths not valid");
 
         for (uint i = 0; i < currencyKeys.length; i++) {
-            bytes32 currencyKey = currencyKeys[i];
-            lastExchangeRate[currencyKey] = exchangeRates().rateForCurrency((currencyKey));
+            lastExchangeRate[currencyKeys[i]] = rates[i];
         }
     }
 

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -323,7 +323,7 @@ contract Exchanger is Owned, MixinSystemSettings, IExchanger {
         bytes32 destinationCurrencyKey,
         address destinationAddress,
         bool virtualSynth,
-        address originator,
+        address rewardAddress,
         bytes32 trackingCode
     ) external onlySynthetixorSynth returns (uint amountReceived, IVirtualSynth vSynth) {
         uint fee;
@@ -340,8 +340,8 @@ contract Exchanger is Owned, MixinSystemSettings, IExchanger {
             virtualSynth
         );
 
-        if (originator != address(0)) {
-            _processTradingRewards(fee, originator);
+        if (rewardAddress != address(0)) {
+            _processTradingRewards(fee, rewardAddress);
         }
 
         if (trackingCode != bytes32(0)) {
@@ -358,9 +358,9 @@ contract Exchanger is Owned, MixinSystemSettings, IExchanger {
         ISynthetixInternal(address(synthetix())).emitExchangeTracking(trackingCode, toCurrencyKey, toAmount, fee);
     }
 
-    function _processTradingRewards(uint fee, address originator) internal {
-        if (fee > 0 && originator != address(0) && getTradingRewardsEnabled()) {
-            tradingRewards().recordExchangeFeeForAccount(fee, originator);
+    function _processTradingRewards(uint fee, address rewardAddress) internal {
+        if (fee > 0 && rewardAddress != address(0) && getTradingRewardsEnabled()) {
+            tradingRewards().recordExchangeFeeForAccount(fee, rewardAddress);
         }
     }
 

--- a/contracts/PurgeableSynth.sol
+++ b/contracts/PurgeableSynth.sol
@@ -62,7 +62,7 @@ contract PurgeableSynth is Synth {
             uint amountHeld = tokenState.balanceOf(holder);
 
             if (amountHeld > 0) {
-                exchanger().exchange(holder, currencyKey, amountHeld, "sUSD", holder);
+                exchanger().exchange(holder, holder, currencyKey, amountHeld, "sUSD", holder, false, address(0), bytes32(0));
                 emitPurged(holder, amountHeld);
             }
         }

--- a/contracts/Synth.sol
+++ b/contracts/Synth.sol
@@ -133,7 +133,17 @@ contract Synth is Owned, IERC20, ExternStateToken, MixinResolver, ISynth {
             super._internalTransfer(messageSender, to, value);
         } else {
             // else exchange synth into sUSD and send to FEE_ADDRESS
-            amountInUSD = exchanger().exchange(messageSender, currencyKey, value, "sUSD", FEE_ADDRESS);
+            (amountInUSD, ) = exchanger().exchange(
+                messageSender,
+                messageSender,
+                currencyKey,
+                value,
+                "sUSD",
+                FEE_ADDRESS,
+                false,
+                address(0),
+                bytes32(0)
+            );
         }
 
         // Notify feePool to record sUSD to distribute as fees

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -82,7 +82,7 @@ contract Synthetix is BaseSynthetix {
         bytes32 sourceCurrencyKey,
         uint sourceAmount,
         bytes32 destinationCurrencyKey,
-        address originator,
+        address rewardAddress,
         bytes32 trackingCode
     ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {
         (amountReceived, ) = exchanger().exchange(
@@ -94,7 +94,7 @@ contract Synthetix is BaseSynthetix {
             // solhint-disable avoid-tx-origin
             tx.origin,
             false,
-            originator,
+            rewardAddress,
             trackingCode
         );
     }

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -62,11 +62,14 @@ contract Synthetix is BaseSynthetix {
         returns (uint amountReceived, IVirtualSynth vSynth)
     {
         return
-            exchanger().exchangeWithVirtual(
+            exchanger().exchange(
+                messageSender,
                 messageSender,
                 sourceCurrencyKey,
                 sourceAmount,
                 destinationCurrencyKey,
+                messageSender,
+                true,
                 messageSender,
                 trackingCode
             );
@@ -82,17 +85,18 @@ contract Synthetix is BaseSynthetix {
         address originator,
         bytes32 trackingCode
     ) external exchangeActive(sourceCurrencyKey, destinationCurrencyKey) optionalProxy returns (uint amountReceived) {
-        return
-            exchanger().exchangeWithTracking(
-                messageSender,
-                sourceCurrencyKey,
-                sourceAmount,
-                destinationCurrencyKey,
-                // solhint-disable avoid-tx-origin
-                tx.origin,
-                originator,
-                trackingCode
-            );
+        (amountReceived, ) = exchanger().exchange(
+            messageSender,
+            messageSender,
+            sourceCurrencyKey,
+            sourceAmount,
+            destinationCurrencyKey,
+            // solhint-disable avoid-tx-origin
+            tx.origin,
+            false,
+            originator,
+            trackingCode
+        );
     }
 
     function settle(bytes32 currencyKey)

--- a/contracts/interfaces/IExchanger.sol
+++ b/contracts/interfaces/IExchanger.sol
@@ -58,7 +58,7 @@ interface IExchanger {
         bytes32 destinationCurrencyKey,
         address destinationAddress,
         bool virtualSynth,
-        address originator,
+        address rewardAddress,
         bytes32 trackingCode
     ) external returns (uint amountReceived, IVirtualSynth vSynth);
 

--- a/contracts/interfaces/IExchanger.sol
+++ b/contracts/interfaces/IExchanger.sol
@@ -51,47 +51,14 @@ interface IExchanger {
 
     // Mutative functions
     function exchange(
-        address from,
-        bytes32 sourceCurrencyKey,
-        uint sourceAmount,
-        bytes32 destinationCurrencyKey,
-        address destinationAddress
-    ) external returns (uint amountReceived);
-
-    function exchangeOnBehalf(
-        address exchangeForAddress,
-        address from,
-        bytes32 sourceCurrencyKey,
-        uint sourceAmount,
-        bytes32 destinationCurrencyKey
-    ) external returns (uint amountReceived);
-
-    function exchangeWithTracking(
-        address from,
-        bytes32 sourceCurrencyKey,
-        uint sourceAmount,
-        bytes32 destinationCurrencyKey,
-        address destinationAddress,
-        address originator,
-        bytes32 trackingCode
-    ) external returns (uint amountReceived);
-
-    function exchangeOnBehalfWithTracking(
         address exchangeForAddress,
         address from,
         bytes32 sourceCurrencyKey,
         uint sourceAmount,
         bytes32 destinationCurrencyKey,
-        address originator,
-        bytes32 trackingCode
-    ) external returns (uint amountReceived);
-
-    function exchangeWithVirtual(
-        address from,
-        bytes32 sourceCurrencyKey,
-        uint sourceAmount,
-        bytes32 destinationCurrencyKey,
         address destinationAddress,
+        bool virtualSynth,
+        address originator,
         bytes32 trackingCode
     ) external returns (uint amountReceived, IVirtualSynth vSynth);
 

--- a/contracts/interfaces/ISynthetix.sol
+++ b/contracts/interfaces/ISynthetix.sol
@@ -69,7 +69,7 @@ interface ISynthetix {
         bytes32 sourceCurrencyKey,
         uint sourceAmount,
         bytes32 destinationCurrencyKey,
-        address originator,
+        address rewardAddress,
         bytes32 trackingCode
     ) external returns (uint amountReceived);
 
@@ -77,7 +77,7 @@ interface ISynthetix {
         bytes32 sourceCurrencyKey,
         uint sourceAmount,
         bytes32 destinationCurrencyKey,
-        address originator,
+        address rewardAddress,
         bytes32 trackingCode
     ) external returns (uint amountReceived);
 
@@ -86,7 +86,7 @@ interface ISynthetix {
         bytes32 sourceCurrencyKey,
         uint sourceAmount,
         bytes32 destinationCurrencyKey,
-        address originator,
+        address rewardAddress,
         bytes32 trackingCode
     ) external returns (uint amountReceived);
 

--- a/test/contracts/BaseSynthetix.js
+++ b/test/contracts/BaseSynthetix.js
@@ -19,7 +19,10 @@ const {
 	setStatus,
 } = require('./helpers');
 
-const { toBytes32 } = require('../..');
+const {
+	toBytes32,
+	constants: { ZERO_ADDRESS },
+} = require('../..');
 
 contract('BaseSynthetix', async accounts => {
 	const [sUSD, sAUD, sEUR, SNX, sETH] = ['sUSD', 'sAUD', 'sEUR', 'SNX', 'sETH'].map(toBytes32);
@@ -313,9 +316,7 @@ contract('BaseSynthetix', async accounts => {
 		let smockExchanger;
 		beforeEach(async () => {
 			smockExchanger = await smockit(artifacts.require('Exchanger').abi);
-			smockExchanger.smocked.exchangeOnBehalf.will.return.with(() => '1');
-			smockExchanger.smocked.exchangeWithTracking.will.return.with(() => '1');
-			smockExchanger.smocked.exchangeOnBehalfWithTracking.will.return.with(() => '1');
+			smockExchanger.smocked.exchange.will.return.with(() => ['1', ZERO_ADDRESS]);
 			smockExchanger.smocked.settle.will.return.with(() => ['1', '2', '3']);
 			await addressResolver.importAddresses(
 				['Exchanger'].map(toBytes32),
@@ -335,11 +336,15 @@ contract('BaseSynthetix', async accounts => {
 			await baseSynthetix.exchangeOnBehalf(account1, currencyKey1, amount1, currencyKey2, {
 				from: msgSender,
 			});
-			assert.equal(smockExchanger.smocked.exchangeOnBehalf.calls[0][0], account1);
-			assert.equal(smockExchanger.smocked.exchangeOnBehalf.calls[0][1], msgSender);
-			assert.equal(smockExchanger.smocked.exchangeOnBehalf.calls[0][2], currencyKey1);
-			assert.equal(smockExchanger.smocked.exchangeOnBehalf.calls[0][3].toString(), amount1);
-			assert.equal(smockExchanger.smocked.exchangeOnBehalf.calls[0][4], currencyKey2);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][0], account1);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][1], msgSender);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][2], currencyKey1);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][3].toString(), amount1);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][4], currencyKey2);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][5], account1);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][6], false);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][7], account1);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][8], toBytes32(''));
 		});
 
 		it('exchangeWithTracking is called with the right arguments ', async () => {
@@ -351,13 +356,15 @@ contract('BaseSynthetix', async accounts => {
 				trackingCode,
 				{ from: msgSender }
 			);
-			assert.equal(smockExchanger.smocked.exchangeWithTracking.calls[0][0], msgSender);
-			assert.equal(smockExchanger.smocked.exchangeWithTracking.calls[0][1], currencyKey1);
-			assert.equal(smockExchanger.smocked.exchangeWithTracking.calls[0][2].toString(), amount1);
-			assert.equal(smockExchanger.smocked.exchangeWithTracking.calls[0][3], currencyKey2);
-			assert.equal(smockExchanger.smocked.exchangeWithTracking.calls[0][4], msgSender);
-			assert.equal(smockExchanger.smocked.exchangeWithTracking.calls[0][5], account2);
-			assert.equal(smockExchanger.smocked.exchangeWithTracking.calls[0][6], trackingCode);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][0], msgSender);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][1], msgSender);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][2], currencyKey1);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][3].toString(), amount1);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][4], currencyKey2);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][5], msgSender);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][6], false);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][7], account2);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][8], trackingCode);
 		});
 
 		it('exchangeOnBehalfWithTracking is called with the right arguments ', async () => {
@@ -370,16 +377,16 @@ contract('BaseSynthetix', async accounts => {
 				trackingCode,
 				{ from: owner }
 			);
-			assert.equal(smockExchanger.smocked.exchangeOnBehalfWithTracking.calls[0][0], account1);
-			assert.equal(smockExchanger.smocked.exchangeOnBehalfWithTracking.calls[0][1], msgSender);
-			assert.equal(smockExchanger.smocked.exchangeOnBehalfWithTracking.calls[0][2], currencyKey1);
-			assert.equal(
-				smockExchanger.smocked.exchangeOnBehalfWithTracking.calls[0][3].toString(),
-				amount1
-			);
-			assert.equal(smockExchanger.smocked.exchangeOnBehalfWithTracking.calls[0][4], currencyKey2);
-			assert.equal(smockExchanger.smocked.exchangeOnBehalfWithTracking.calls[0][5], account2);
-			assert.equal(smockExchanger.smocked.exchangeOnBehalfWithTracking.calls[0][6], trackingCode);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][0], account1);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][1], msgSender);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][2], currencyKey1);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][3].toString(), amount1);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][4], currencyKey2);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][5], account1);
+
+			assert.equal(smockExchanger.smocked.exchange.calls[0][6], false);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][7], account2);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][8], trackingCode);
 		});
 
 		it('settle is called with the right arguments ', async () => {

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -1755,15 +1755,6 @@ contract('Exchanger (spec tests)', async accounts => {
 				});
 			});
 
-			it('exchangeWithTracking() cannot be invoked directly by any account via Exchanger', async () => {
-				await onlyGivenAddressCanInvoke({
-					fnc: exchanger.exchangeWithTracking,
-					accounts,
-					args: [account1, sUSD, toUnit('100'), sAUD, account2, account3, trackingCode],
-					reason: 'Only synthetix or a synth contract can perform this action',
-				});
-			});
-
 			describe('various exchange scenarios', () => {
 				describe('when a user has 1000 sUSD', () => {
 					// already issued in the top-level beforeEach
@@ -2009,7 +2000,9 @@ contract('Exchanger (spec tests)', async accounts => {
 								await onlyGivenAddressCanInvoke({
 									fnc: synthetix.exchangeOnBehalf,
 									args: [authoriser, sUSD, amountIssued, sAUD],
-									accounts,
+									// We cannot test the revert condition with the authoriser as the recipient
+									// because this will lead to a regular exchange, not one on behalf
+									accounts: accounts.filter(a => a !== authoriser),
 									address: delegate,
 									reason: 'Not approved to act on behalf',
 								});
@@ -2136,7 +2129,9 @@ contract('Exchanger (spec tests)', async accounts => {
 								await onlyGivenAddressCanInvoke({
 									fnc: synthetix.exchangeOnBehalfWithTracking,
 									args: [authoriser, sUSD, amountIssued, sAUD, authoriser, trackingCode],
-									accounts,
+									// We cannot test the revert condition with the authoriser as the recipient
+									// because this will lead to a regular exchange, not one on behalf
+									accounts: accounts.filter(a => a !== authoriser),
 									address: delegate,
 									reason: 'Not approved to act on behalf',
 								});

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -1703,7 +1703,17 @@ contract('Exchanger (spec tests)', async accounts => {
 				await onlyGivenAddressCanInvoke({
 					fnc: exchanger.exchange,
 					accounts,
-					args: [account1, sUSD, toUnit('100'), sAUD, account1],
+					args: [
+						account1,
+						account1,
+						sUSD,
+						toUnit('100'),
+						sAUD,
+						account1,
+						false,
+						account1,
+						toBytes32(''),
+					],
 					reason: 'Only synthetix or a synth contract can perform this action',
 				});
 			});
@@ -1935,16 +1945,6 @@ contract('Exchanger (spec tests)', async accounts => {
 					describe('exchanging on behalf', async () => {
 						const authoriser = account1;
 						const delegate = account2;
-
-						it('exchangeOnBehalf() cannot be invoked directly by any account via Exchanger', async () => {
-							await onlyGivenAddressCanInvoke({
-								fnc: exchanger.exchangeOnBehalf,
-								accounts,
-								args: [authoriser, delegate, sUSD, toUnit('100'), sAUD],
-								reason: 'Only synthetix or a synth contract can perform this action',
-							});
-						});
-
 						describe('when not approved it should revert on', async () => {
 							it('exchangeOnBehalf', async () => {
 								await assert.revert(
@@ -2041,15 +2041,6 @@ contract('Exchanger (spec tests)', async accounts => {
 					describe('exchanging on behalf with tracking', async () => {
 						const authoriser = account1;
 						const delegate = account2;
-
-						it('exchangeOnBehalfWithTracking() cannot be invoked directly by any account via Exchanger', async () => {
-							await onlyGivenAddressCanInvoke({
-								fnc: exchanger.exchangeOnBehalfWithTracking,
-								accounts,
-								args: [authoriser, delegate, sUSD, toUnit('100'), sAUD, authoriser, trackingCode],
-								reason: 'Only synthetix or a synth contract can perform this action',
-							});
-						});
 
 						describe('when not approved it should revert on', async () => {
 							it('exchangeOnBehalfWithTracking', async () => {

--- a/test/contracts/Synthetix.js
+++ b/test/contracts/Synthetix.js
@@ -108,8 +108,7 @@ contract('Synthetix', async accounts => {
 		let smockExchanger;
 		beforeEach(async () => {
 			smockExchanger = await smockit(artifacts.require('Exchanger').abi);
-			smockExchanger.smocked.exchangeWithVirtual.will.return.with(() => ['1', account1]);
-			smockExchanger.smocked.exchangeWithTracking.will.return.with(() => ['1']);
+			smockExchanger.smocked.exchange.will.return.with(() => ['1', account1]);
 			await addressResolver.importAddresses(
 				['Exchanger'].map(toBytes32),
 				[smockExchanger.address],
@@ -126,14 +125,17 @@ contract('Synthetix', async accounts => {
 
 		it('exchangeWithVirtual is called with the right arguments ', async () => {
 			await synthetix.exchangeWithVirtual(currencyKey1, amount1, currencyKey2, trackingCode, {
-				from: owner,
+				from: msgSender,
 			});
-			assert.equal(smockExchanger.smocked.exchangeWithVirtual.calls[0][0], msgSender);
-			assert.equal(smockExchanger.smocked.exchangeWithVirtual.calls[0][1], currencyKey1);
-			assert.equal(smockExchanger.smocked.exchangeWithVirtual.calls[0][2].toString(), amount1);
-			assert.equal(smockExchanger.smocked.exchangeWithVirtual.calls[0][3], currencyKey2);
-			assert.equal(smockExchanger.smocked.exchangeWithVirtual.calls[0][4], msgSender);
-			assert.equal(smockExchanger.smocked.exchangeWithVirtual.calls[0][5], trackingCode);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][0], msgSender);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][1], msgSender);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][2], currencyKey1);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][3].toString(), amount1);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][4], currencyKey2);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][5], msgSender);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][6], true);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][7], msgSender);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][8], trackingCode);
 		});
 
 		it('exchangeWithTrackingForInitiator is called with the right arguments ', async () => {
@@ -145,13 +147,15 @@ contract('Synthetix', async accounts => {
 				trackingCode,
 				{ from: account3 }
 			);
-			assert.equal(smockExchanger.smocked.exchangeWithTracking.calls[0][0], account3);
-			assert.equal(smockExchanger.smocked.exchangeWithTracking.calls[0][1], currencyKey1);
-			assert.equal(smockExchanger.smocked.exchangeWithTracking.calls[0][2].toString(), amount1);
-			assert.equal(smockExchanger.smocked.exchangeWithTracking.calls[0][3], currencyKey2);
-			assert.equal(smockExchanger.smocked.exchangeWithTracking.calls[0][4], account3); // destination address (tx.origin)
-			assert.equal(smockExchanger.smocked.exchangeWithTracking.calls[0][5], account2);
-			assert.equal(smockExchanger.smocked.exchangeWithTracking.calls[0][6], trackingCode);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][0], account3);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][1], account3);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][2], currencyKey1);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][3].toString(), amount1);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][4], currencyKey2);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][5], account3); // destination address (tx.origin)
+			assert.equal(smockExchanger.smocked.exchange.calls[0][6], false);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][7], account2);
+			assert.equal(smockExchanger.smocked.exchange.calls[0][8], trackingCode);
 		});
 	});
 

--- a/test/contracts/TradingRewards.spec.js
+++ b/test/contracts/TradingRewards.spec.js
@@ -278,7 +278,7 @@ contract('TradingRewards', accounts => {
 			describe('when executing an exchange with tracking', () => {
 				addSnapshotBeforeRestoreAfter();
 
-				describe('when a valid originator address is passed', () => {
+				describe('when a valid reward address is passed', () => {
 					before('execute exchange with tracking', async () => {
 						const exchangeTx = await synthetix.exchangeWithTracking(
 							sUSD,
@@ -303,13 +303,13 @@ contract('TradingRewards', accounts => {
 					});
 				});
 
-				describe('when no valid originator address is passed', () => {
+				describe('when no valid reward address is passed', () => {
 					before('execute exchange with tracking', async () => {
 						const exchangeTx = await synthetix.exchangeWithTracking(
 							sUSD,
 							toUnit('100'),
 							sETH,
-							zeroAddress, // No originator = 0x0
+							zeroAddress, // No reward address = 0x0
 							toBytes32('1INCH'),
 							{
 								from: account1,


### PR DESCRIPTION
#1285 caused `Exchanger.sol` to be oversize on OVM during deployment. 

This PR overhauls `Exchanger.sol` by deduping the restricted `exchange*()` functions into one mighty handler 💪🏼 . 