### PR TITLE
Better way to get SNX in integration tests

### DIFF
--- a/contracts/MintableSynthetix.sol
+++ b/contracts/MintableSynthetix.sol
@@ -16,7 +16,6 @@ contract MintableSynthetix is BaseSynthetix {
     ) public BaseSynthetix(_proxy, _tokenState, _owner, _totalSupply, _resolver) {}
 
     /* ========== INTERNALS =================== */
-
     function _mintSecondary(address account, uint amount) internal {
         tokenState.setBalanceOf(account, tokenState.balanceOf(account).add(amount));
         emitTransfer(address(this), account, amount);

--- a/hardhat/tasks/task-test-integration-l2.js
+++ b/hardhat/tasks/task-test-integration-l2.js
@@ -29,7 +29,6 @@ task('test:integration:l2', 'run isolated layer 2 production tests')
 		if (taskArguments.deploy) {
 			await deployInstance({
 				useOvm: true,
-				ignoreCustomParameters: true,
 				providerUrl,
 				providerPort,
 			});

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,6 +186,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
 			"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
 			"dev": true,
 			"optional": true
 		},
@@ -2380,9 +2381,9 @@
 			}
 		},
 		"node_modules/@ledgerhq/hw-transport-node-hid-noevents/node_modules/node-addon-api": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.0.tgz",
-			"integrity": "sha512-kcwSAWhPi4+QzAtsL2+2s/awvDo2GKLsvMCwNRxb5BUshteXU8U97NCyvQDsGKs/m0He9WcG4YWew/BnuLx++w==",
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+			"integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
 			"dev": true,
 			"optional": true
 		},
@@ -2780,6 +2781,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
 			"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
 			"dev": true
 		},
 		"node_modules/@openzeppelin/contracts": {
@@ -3083,9 +3085,9 @@
 			}
 		},
 		"node_modules/@sinonjs/fake-timers": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.1.tgz",
-			"integrity": "sha512-am34LJf0N2nON/PT9G7pauA+xjcwX9P6x31m4hBgfUeSXYRZBRv/R6EcdWs8iV4XJjPO++NTsrj7ua/cN2s6ZA==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+			"integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
 			"dev": true,
 			"dependencies": {
 				"@sinonjs/commons": "^1.7.0"
@@ -3432,6 +3434,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
 			"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
 			"dev": true,
 			"optional": true
 		},
@@ -3611,6 +3614,7 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
 			"dev": true,
 			"optional": true,
 			"bin": {
@@ -3941,6 +3945,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
 			"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
 			"dev": true
 		},
 		"node_modules/@truffle/interface-adapter/node_modules/web3": {
@@ -4100,6 +4105,7 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
 			"dev": true,
 			"bin": {
 				"uuid": "bin/uuid"
@@ -4327,6 +4333,7 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
 			"dev": true,
 			"bin": {
 				"uuid": "bin/uuid"
@@ -7259,9 +7266,9 @@
 			}
 		},
 		"node_modules/css-what": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
-			"integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+			"integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
 			"dev": true,
 			"engines": {
 				"node": ">= 6"
@@ -7299,9 +7306,9 @@
 			}
 		},
 		"node_modules/date-fns": {
-			"version": "2.21.3",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
-			"integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw==",
+			"version": "2.22.1",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.22.1.tgz",
+			"integrity": "sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.11"
@@ -9134,6 +9141,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
 			"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
 			"dev": true
 		},
 		"node_modules/eth-gas-reporter/node_modules/which": {
@@ -22338,6 +22346,7 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
 			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
 			"dev": true,
 			"bin": {
 				"uuid": "bin/uuid"
@@ -27926,6 +27935,7 @@
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
 			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
 			"dev": true,
 			"bin": {
 				"uuid": "bin/uuid"
@@ -31233,9 +31243,9 @@
 			"integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
 		},
 		"node_modules/util": {
-			"version": "0.12.3",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
-			"integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+			"version": "0.12.4",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+			"integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
 			"dev": true,
 			"dependencies": {
 				"inherits": "^2.0.3",
@@ -32334,6 +32344,7 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
 			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
 			"dev": true,
 			"bin": {
 				"uuid": "bin/uuid"
@@ -39366,9 +39377,9 @@
 					"optional": true
 				},
 				"node-addon-api": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.0.tgz",
-					"integrity": "sha512-kcwSAWhPi4+QzAtsL2+2s/awvDo2GKLsvMCwNRxb5BUshteXU8U97NCyvQDsGKs/m0He9WcG4YWew/BnuLx++w==",
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
+					"integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
 					"dev": true,
 					"optional": true
 				},
@@ -40018,9 +40029,9 @@
 			}
 		},
 		"@sinonjs/fake-timers": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.1.tgz",
-			"integrity": "sha512-am34LJf0N2nON/PT9G7pauA+xjcwX9P6x31m4hBgfUeSXYRZBRv/R6EcdWs8iV4XJjPO++NTsrj7ua/cN2s6ZA==",
+			"version": "7.1.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-7.1.2.tgz",
+			"integrity": "sha512-iQADsW4LBMISqZ6Ci1dupJL9pprqwcVFTcOsEmQOEhW+KLCVn/Y4Jrvg2k19fIHCp+iFprriYPTdRcQR8NbUPg==",
 			"dev": true,
 			"requires": {
 				"@sinonjs/commons": "^1.7.0"
@@ -43664,9 +43675,9 @@
 			}
 		},
 		"css-what": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.0.tgz",
-			"integrity": "sha512-qxyKHQvgKwzwDWC/rGbT821eJalfupxYW2qbSJSAtdSTimsr/MlaGONoNLllaUPZWf8QnbcKM/kPVYUQuEKAFA==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/css-what/-/css-what-5.0.1.tgz",
+			"integrity": "sha512-FYDTSHb/7KXsWICVsxdmiExPjCfRC4qRFBdVwv7Ax9hMnvMmEjP9RfxTEZ3qPZGmADDn2vAKSo9UcN1jKVYscg==",
 			"dev": true
 		},
 		"cyclist": {
@@ -43695,9 +43706,9 @@
 			}
 		},
 		"date-fns": {
-			"version": "2.21.3",
-			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.21.3.tgz",
-			"integrity": "sha512-HeYdzCaFflc1i4tGbj7JKMjM4cKGYoyxwcIIkHzNgCkX8xXDNJDZXgDDVchIWpN4eQc3lH37WarduXFZJOtxfw==",
+			"version": "2.22.1",
+			"resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.22.1.tgz",
+			"integrity": "sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==",
 			"dev": true
 		},
 		"death": {
@@ -62560,9 +62571,9 @@
 			"integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
 		},
 		"util": {
-			"version": "0.12.3",
-			"resolved": "https://registry.npmjs.org/util/-/util-0.12.3.tgz",
-			"integrity": "sha512-I8XkoQwE+fPQEhy9v012V+TSdH2kp9ts29i20TaaDUXsg7x/onePbhFJUExBfv/2ay1ZOp/Vsm3nDlmnFGSAog==",
+			"version": "0.12.4",
+			"resolved": "https://registry.npmjs.org/util/-/util-0.12.4.tgz",
+			"integrity": "sha512-bxZ9qtSlGUWSOy9Qa9Xgk11kSslpuZwaxCg4sNIDj6FLucDab2JxnHwyNTCpHMtK1MjoQiWQ6DiUMZYbSrO+Sw==",
 			"dev": true,
 			"requires": {
 				"inherits": "^2.0.3",

--- a/test/integration/behaviors/erc20.behavior.js
+++ b/test/integration/behaviors/erc20.behavior.js
@@ -3,14 +3,17 @@ const { assert } = require('../../contracts/common');
 
 function itBehavesLikeAnERC20({ ctx }) {
 	describe('erc20 functionality', () => {
-		let user;
+		let owner, user;
 		let Synthetix;
 
 		let userBalance;
 
+		const amountToTransfer = ethers.utils.parseEther('1');
+
 		before('target contracts and users', () => {
 			({ Synthetix } = ctx.contracts);
 
+			owner = ctx.users.owner;
 			user = ctx.users.someUser;
 		});
 
@@ -19,10 +22,8 @@ function itBehavesLikeAnERC20({ ctx }) {
 		});
 
 		describe('when the owner transfers SNX to the user', () => {
-			const amountToTransfer = ethers.utils.parseEther('1');
-
 			before('transfer', async () => {
-				Synthetix = Synthetix.connect(ctx.users.owner);
+				Synthetix = Synthetix.connect(owner);
 
 				const tx = await Synthetix.transfer(user.address, amountToTransfer);
 				await tx.wait();

--- a/test/integration/dual/withdraw.integration.js
+++ b/test/integration/dual/withdraw.integration.js
@@ -1,7 +1,6 @@
 const ethers = require('ethers');
 const { assert } = require('../../contracts/common');
 const { bootstrapDual } = require('../utils/bootstrap');
-const { ensureBalance } = require('../utils/balances');
 const { finalizationOnL1 } = require('../utils/watchers');
 
 describe('withdraw() integration tests (L1, L2)', () => {
@@ -22,10 +21,6 @@ describe('withdraw() integration tests (L1, L2)', () => {
 			({ Synthetix, SynthetixBridgeToBase } = ctx.l2.contracts);
 
 			owner = ctx.l2.users.owner;
-		});
-
-		before('ensure the owner has SNX on L2', async () => {
-			await ensureBalance({ ctx: ctx.l2, symbol: 'SNX', user: owner, balance: amountToWithdraw });
 		});
 
 		before('record balances', async () => {

--- a/test/integration/dual/withdrawTo.integration.js
+++ b/test/integration/dual/withdrawTo.integration.js
@@ -1,7 +1,6 @@
 const ethers = require('ethers');
 const { assert } = require('../../contracts/common');
 const { bootstrapDual } = require('../utils/bootstrap');
-const { ensureBalance } = require('../utils/balances');
 const { finalizationOnL1 } = require('../utils/watchers');
 
 describe('withdrawTo() integration tests (L1, L2)', () => {
@@ -23,10 +22,6 @@ describe('withdrawTo() integration tests (L1, L2)', () => {
 
 			owner = ctx.l2.users.owner;
 			user = ctx.l2.users.someUser;
-		});
-
-		before('ensure the owner has SNX on L2', async () => {
-			await ensureBalance({ ctx: ctx.l2, symbol: 'SNX', user: owner, balance: amountToWithdraw });
 		});
 
 		before('record balances', async () => {

--- a/test/integration/utils/balances.js
+++ b/test/integration/utils/balances.js
@@ -1,3 +1,7 @@
+const ethers = require('ethers');
+const { deposit } = require('./bridge');
+const { toBytes32 } = require('../../..');
+
 async function ensureBalance({ ctx, symbol, user, balance }) {
 	const token = _getTokenFromSymbol({ ctx, symbol });
 	const currentBalance = await token.balanceOf(user.address);
@@ -20,9 +24,57 @@ async function _getTokens({ ctx, symbol, user, amount }) {
 }
 
 async function _getSNX({ ctx, user, amount }) {
-	const Synthetix = ctx.contracts.Synthetix.connect(ctx.users.owner);
+	let { Synthetix } = ctx.contracts;
 
+	const ownerTransferable = await Synthetix.transferableSynthetix(ctx.users.owner.address);
+	if (ownerTransferable.lt(amount)) {
+		await _getSNXForOwner({ ctx, amount: amount.sub(ownerTransferable) });
+	}
+
+	Synthetix = Synthetix.connect(ctx.users.owner);
 	const tx = await Synthetix.transfer(user.address, amount);
+	await tx.wait();
+}
+
+async function _getSNXForOwner({ ctx, amount }) {
+	if (!ctx.useOvm) {
+		throw new Error('There is no more SNX!');
+	} else {
+		if (ctx.l1) {
+			await _getSNXForOwnerOnL2ByDepositing({ ctx: ctx.l1, amount });
+		} else {
+			await _getSNXForOwnerOnL2ByHackMinting({ ctx, amount });
+		}
+	}
+}
+
+async function _getSNXForOwnerOnL2ByDepositing({ ctx, amount }) {
+	await deposit({ ctx, from: ctx.users.owner, to: ctx.users.owner, amount });
+}
+
+async function _getSNXForOwnerOnL2ByHackMinting({ ctx, amount }) {
+	const owner = ctx.users.owner;
+
+	let { Synthetix, AddressResolver } = ctx.contracts;
+
+	const bridgeName = toBytes32('SynthetixBridgeToBase');
+	const bridgeAddress = await AddressResolver.getAddress(bridgeName);
+
+	let tx;
+
+	AddressResolver = AddressResolver.connect(owner);
+	tx = await AddressResolver.importAddresses([bridgeName], [owner.address]);
+	await tx.wait();
+	tx = await AddressResolver.rebuildCaches([Synthetix.address]);
+	await tx.wait();
+
+	Synthetix = Synthetix.connect(owner);
+	tx = await Synthetix.mintSecondary(owner.address, amount);
+	await tx.wait();
+
+	tx = await AddressResolver.importAddresses([bridgeName], [bridgeAddress]);
+	await tx.wait();
+	tx = await AddressResolver.rebuildCaches([Synthetix.address]);
 	await tx.wait();
 }
 
@@ -31,11 +83,21 @@ async function _getsUSD({ ctx, user, amount }) {
 
 	let tx;
 
+	const requiredSNX = await _getSNXAmountRequiredForsUSDAmount({ ctx, amount });
+	await ensureBalance({ ctx, symbol: 'SNX', user, balance: requiredSNX });
+
 	tx = await Synthetix.issueSynths(amount);
 	await tx.wait();
 
 	tx = await Synthetix.transfer(user.address, amount);
 	await tx.wait();
+}
+
+async function _getSNXAmountRequiredForsUSDAmount({ ctx, amount }) {
+	// TODO: Do not assume that the c-ratio is 600%
+	// TODO: Do not assume that 1 SNX = 1 sUSD
+
+	return amount.mul(ethers.BigNumber.from('6'));
 }
 
 function _getTokenFromSymbol({ ctx, symbol }) {

--- a/test/integration/utils/bridge.js
+++ b/test/integration/utils/bridge.js
@@ -1,7 +1,7 @@
 const { finalizationOnL2 } = require('./watchers');
 
 async function deposit({ ctx, from, to, amount }) {
-	let { Synthetix, SynthetixBridgeToOptimism } = ctx.l1.contracts;
+	let { Synthetix, SynthetixBridgeToOptimism } = ctx.contracts;
 	Synthetix = Synthetix.connect(from);
 	SynthetixBridgeToOptimism = SynthetixBridgeToOptimism.connect(from);
 

--- a/test/integration/utils/rates.js
+++ b/test/integration/utils/rates.js
@@ -39,13 +39,13 @@ async function _updateCache({ ctx }) {
 	await tx.wait();
 }
 
-async function getExchangeRate({ ctx, symbol }) {
-	const { ExchangeRates } = ctx.contracts.ExchangeRates;
+async function getRate({ ctx, symbol }) {
+	const { ExchangeRates } = ctx.contracts;
 
 	return ExchangeRates.rateForCurrency(toBytes32(symbol));
 }
 
 module.exports = {
 	updateExchangeRatesIfNeeded,
-	getExchangeRate,
+	getRate,
 };

--- a/test/integration/utils/rates.js
+++ b/test/integration/utils/rates.js
@@ -24,7 +24,13 @@ async function _simulateExchangeRates({ ctx }) {
 		.concat(['SNX', 'ETH'].map(toBytes32));
 
 	const { timestamp } = await ctx.provider.getBlock();
-	const rates = currencyKeys.map(() => ethers.utils.parseEther('1'));
+	const rates = currencyKeys.map(key => {
+		if (key === toBytes32('SNX')) {
+			return ethers.utils.parseEther('2192');
+		} else {
+			return ethers.utils.parseEther('1');
+		}
+	});
 
 	const tx = await ExchangeRates.updateRates(currencyKeys, rates, timestamp);
 	await tx.wait();


### PR DESCRIPTION
Previously, to ensure that the owner has SNX in a standalone L2 instance (remember there is no initial supply in L2), the deploy was forced to ignore deployment parameters, which is where 0 issuance was set.

This PR removes that, because we actually need deployment parameters for other things, not just issuance. Instead, it tries different methods to get SNX for the owner in tests. In the particular standalone L2 case, it "hacks" the minting process and prints SNX for the user in `balances.js::_getSNXForOwnerOnL2ByHackMinting()`
https://github.com/Synthetixio/synthetix/pull/1303/files#diff-f4eeff274fd8a21e1f7fae9052616e130c9c52e7642d45ac742ba310881ad1caR55