### PR TITLE
Introduces forking via integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,7 +42,7 @@ jobs:
           background: true
       - cmd-wait-for-port:
           port: 8545
-      - run: npx hardhat test:integration:l1 --fork
+      - run: npx hardhat test:integration:l1 --compile --deploy --fork
   job-integration-tests:
     working_directory: ~/repo
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -195,8 +195,8 @@ jobs:
             git clone git@github.com:ethereum-optimism/optimism.git
             cd optimism
             git fetch
-            git checkout develop
-            git pull origin develop
+            git checkout master
+            git pull origin master
             yarn
             yarn build
             cd ops

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,23 @@ jobs:
       - run: npx hardhat compile --optimizer --fail-oversize
       - run: rm -rf build # force a clean build
       - run: npx hardhat compile --use-ovm --optimizer --fail-oversize
+  job-fork-tests:
+    working_directory: ~/repo
+    docker:
+      - image: synthetixio/docker-node:14.16-focal
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_TOKEN
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - run:
+          command: npm run fork
+          background: true
+      - cmd-wait-for-port:
+          port: 8545
+      - run: npx hardhat test:integration:l1 --fork
   job-integration-tests:
     working_directory: ~/repo
     machine:
@@ -63,7 +80,7 @@ jobs:
       - run:
           name: Run isolated layer 1 integration tests
           command: |
-            npx hardhat test:integration:l1 --compile --deploy
+            npx hardhat test:integration:l1 --compile --deploy --provider-port 9545
       - run:
           name: Run isolated layer 2 integration tests
           command: |
@@ -408,6 +425,9 @@ workflows:
           requires:
             - job-prepare
       - job-test-deploy-script:
+          requires:
+            - job-prepare
+      - job-fork-tests:
           requires:
             - job-prepare
       - job-integration-tests:

--- a/.circleci/src/jobs/job-fork-tests.yml
+++ b/.circleci/src/jobs/job-fork-tests.yml
@@ -1,0 +1,12 @@
+# Starts a fork of mainnet, deploys the latest release, and runs L1 integration tests
+{{> job-header.yml}}
+steps:
+  - checkout
+  - attach_workspace:
+      at: .
+  - run:
+      command: npm run fork
+      background: true
+  - cmd-wait-for-port:
+        port: 8545
+  - run: npx hardhat test:integration:l1 --fork

--- a/.circleci/src/jobs/job-fork-tests.yml
+++ b/.circleci/src/jobs/job-fork-tests.yml
@@ -9,4 +9,4 @@ steps:
       background: true
   - cmd-wait-for-port:
         port: 8545
-  - run: npx hardhat test:integration:l1 --fork
+  - run: npx hardhat test:integration:l1 --compile --deploy --fork

--- a/.circleci/src/jobs/job-integration-tests.yml
+++ b/.circleci/src/jobs/job-integration-tests.yml
@@ -32,7 +32,7 @@ steps:
   - run:
       name: Run isolated layer 1 integration tests
       command: |
-        npx hardhat test:integration:l1 --compile --deploy
+        npx hardhat test:integration:l1 --compile --deploy --provider-port 9545
   - run:
       name: Run isolated layer 2 integration tests
       command: |

--- a/.circleci/src/jobs/job-prod-tests-ovm.yml
+++ b/.circleci/src/jobs/job-prod-tests-ovm.yml
@@ -11,8 +11,8 @@ steps:
         git clone git@github.com:ethereum-optimism/optimism.git
         cd optimism
         git fetch
-        git checkout develop
-        git pull origin develop
+        git checkout master
+        git pull origin master
         yarn
         yarn build
         cd ops

--- a/.circleci/src/workflows/workflow-all.yml
+++ b/.circleci/src/workflows/workflow-all.yml
@@ -25,6 +25,12 @@ jobs:
       {{> require-prepare.yml}}
 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  # Fork tests
+  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  - job-fork-tests:
+      {{> require-prepare.yml}}
+
+  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Integration tests
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   - job-integration-tests:

--- a/package-lock.json
+++ b/package-lock.json
@@ -3186,17 +3186,17 @@
 			}
 		},
 		"node_modules/@truffle/contract": {
-			"version": "4.3.17",
-			"resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.3.17.tgz",
-			"integrity": "sha512-O/an0UdKgHfsPK9sdCEsbOAPE7Wke9s4pjh9ceXKaqMFyTYIhpnb41dXduyCgepfabZfUEZiwsOa18xy/YCdTg==",
+			"version": "4.3.18",
+			"resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.3.18.tgz",
+			"integrity": "sha512-CvP6iTC/sz3rAfy3awFdDsvE6Q8xfjfW/7oM3OMD49nZnBNHKGQUG5CVKeAa180IVxbA8MGFr3KDCPtN2p0zMw==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"@truffle/blockchain-utils": "^0.0.30",
 				"@truffle/contract-schema": "^3.4.1",
-				"@truffle/debug-utils": "^5.0.17",
+				"@truffle/debug-utils": "^5.0.18",
 				"@truffle/error": "^0.0.14",
-				"@truffle/interface-adapter": "^0.4.24",
+				"@truffle/interface-adapter": "^0.5.0",
 				"bignumber.js": "^7.2.1",
 				"ethereum-ens": "^0.8.0",
 				"ethers": "^4.0.32",
@@ -3226,9 +3226,9 @@
 			"optional": true
 		},
 		"node_modules/@truffle/contract/node_modules/@truffle/codec": {
-			"version": "0.10.7",
-			"resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.10.7.tgz",
-			"integrity": "sha512-mKoAzv2VOjIlRc8VD6rQBVj75cqUUVs8O4LzHNw6lnXHIas7NgBYsCixPGoanuVQ6HEu3NzRWfXDtJPHBUZJcg==",
+			"version": "0.10.8",
+			"resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.10.8.tgz",
+			"integrity": "sha512-S4fxInoPH+gTF5zTawiqgFqU2tOIfob2dk0Zc/wqATH8hf1AmRjoYSL6hazk9mdynvmsvNM/QjO6XKCMX3pYYw==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
@@ -3253,13 +3253,13 @@
 			"optional": true
 		},
 		"node_modules/@truffle/contract/node_modules/@truffle/debug-utils": {
-			"version": "5.0.17",
-			"resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-5.0.17.tgz",
-			"integrity": "sha512-0d6rc20id3UN/rH8VU1MckDhmiUX4iZZvH4Z1SqG4h/c22WqpiNmRRJBPetA2dDo2IhPMRa7/4W0/fVKD/v20A==",
+			"version": "5.0.18",
+			"resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-5.0.18.tgz",
+			"integrity": "sha512-uBPjp6w3LQK8bfSKU1vw1JjNeDn/DX2SnDH0bLNMZg224bhdcDOBhKQBPx3PhrYS01Yhktfu5kDhxgeGQzQfWg==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
-				"@truffle/codec": "^0.10.7",
+				"@truffle/codec": "^0.10.8",
 				"@trufflesuite/chromafi": "^2.2.2",
 				"bn.js": "^5.1.3",
 				"chalk": "^2.4.2",
@@ -3279,6 +3279,25 @@
 			"version": "0.0.14",
 			"resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.14.tgz",
 			"integrity": "sha512-utJx+SZYoMqk8wldQG4gCVKhV8GwMJbWY7sLXFT/D8wWZTnE2peX7URFJh/cxkjTRCO328z1s2qewkhyVsu2HA==",
+			"dev": true,
+			"optional": true
+		},
+		"node_modules/@truffle/contract/node_modules/@truffle/interface-adapter": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.5.0.tgz",
+			"integrity": "sha512-0MRt9orgQqo0knyKDy0fGRqnI+alkuK0BUAvHB1/VUJgCKyWBNAUUZO5gPjuj75qCjV4Rw+W6SKDQpn2xOWsXw==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"bn.js": "^5.1.3",
+				"ethers": "^4.0.32",
+				"web3": "1.3.6"
+			}
+		},
+		"node_modules/@truffle/contract/node_modules/@truffle/interface-adapter/node_modules/bn.js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+			"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
 			"dev": true,
 			"optional": true
 		},
@@ -4266,13 +4285,13 @@
 			"dev": true
 		},
 		"node_modules/@truffle/provider": {
-			"version": "0.2.31",
-			"resolved": "https://registry.npmjs.org/@truffle/provider/-/provider-0.2.31.tgz",
-			"integrity": "sha512-IA1EYgwXX3sJgxmOEq6PDbSKaiOs4cSm1AImsZawomDW1MnmQY+6IotRrUsfUZsYPto/2ovNPfawNoxvAM0KzQ==",
+			"version": "0.2.32",
+			"resolved": "https://registry.npmjs.org/@truffle/provider/-/provider-0.2.32.tgz",
+			"integrity": "sha512-dzO7bnCO5iSLfoHH/SIIYQ5dUi9oVxtRE1qJ89dwKuUgtvaWOTPtZK1MLq7Ai+wrgNrYFKBVpxQjkCPXGdMWWw==",
 			"dev": true,
 			"dependencies": {
 				"@truffle/error": "^0.0.14",
-				"@truffle/interface-adapter": "^0.4.24",
+				"@truffle/interface-adapter": "^0.5.0",
 				"web3": "1.3.6"
 			}
 		},
@@ -4281,6 +4300,17 @@
 			"resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.14.tgz",
 			"integrity": "sha512-utJx+SZYoMqk8wldQG4gCVKhV8GwMJbWY7sLXFT/D8wWZTnE2peX7URFJh/cxkjTRCO328z1s2qewkhyVsu2HA==",
 			"dev": true
+		},
+		"node_modules/@truffle/provider/node_modules/@truffle/interface-adapter": {
+			"version": "0.5.0",
+			"resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.5.0.tgz",
+			"integrity": "sha512-0MRt9orgQqo0knyKDy0fGRqnI+alkuK0BUAvHB1/VUJgCKyWBNAUUZO5gPjuj75qCjV4Rw+W6SKDQpn2xOWsXw==",
+			"dev": true,
+			"dependencies": {
+				"bn.js": "^5.1.3",
+				"ethers": "^4.0.32",
+				"web3": "1.3.6"
+			}
 		},
 		"node_modules/@truffle/provider/node_modules/@types/bn.js": {
 			"version": "4.11.6",
@@ -4307,6 +4337,27 @@
 			}
 		},
 		"node_modules/@truffle/provider/node_modules/bn.js": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+			"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+			"dev": true
+		},
+		"node_modules/@truffle/provider/node_modules/elliptic": {
+			"version": "6.5.3",
+			"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+			"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+			"dev": true,
+			"dependencies": {
+				"bn.js": "^4.4.0",
+				"brorand": "^1.0.1",
+				"hash.js": "^1.0.0",
+				"hmac-drbg": "^1.0.0",
+				"inherits": "^2.0.1",
+				"minimalistic-assert": "^1.0.0",
+				"minimalistic-crypto-utils": "^1.0.0"
+			}
+		},
+		"node_modules/@truffle/provider/node_modules/elliptic/node_modules/bn.js": {
 			"version": "4.12.0",
 			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
 			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
@@ -4323,6 +4374,63 @@
 				"xhr-request-promise": "^0.1.2"
 			}
 		},
+		"node_modules/@truffle/provider/node_modules/eth-lib/node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"dev": true
+		},
+		"node_modules/@truffle/provider/node_modules/ethers": {
+			"version": "4.0.48",
+			"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+			"integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
+			"dev": true,
+			"dependencies": {
+				"aes-js": "3.0.0",
+				"bn.js": "^4.4.0",
+				"elliptic": "6.5.3",
+				"hash.js": "1.1.3",
+				"js-sha3": "0.5.7",
+				"scrypt-js": "2.0.4",
+				"setimmediate": "1.0.4",
+				"uuid": "2.0.1",
+				"xmlhttprequest": "1.8.0"
+			}
+		},
+		"node_modules/@truffle/provider/node_modules/ethers/node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"dev": true
+		},
+		"node_modules/@truffle/provider/node_modules/hash.js": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+			"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+			"dev": true,
+			"dependencies": {
+				"inherits": "^2.0.3",
+				"minimalistic-assert": "^1.0.0"
+			}
+		},
+		"node_modules/@truffle/provider/node_modules/js-sha3": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+			"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+			"dev": true
+		},
+		"node_modules/@truffle/provider/node_modules/scrypt-js": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+			"integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+			"dev": true
+		},
+		"node_modules/@truffle/provider/node_modules/setimmediate": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+			"integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+			"dev": true
+		},
 		"node_modules/@truffle/provider/node_modules/underscore": {
 			"version": "1.12.1",
 			"resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
@@ -4330,14 +4438,11 @@
 			"dev": true
 		},
 		"node_modules/@truffle/provider/node_modules/uuid": {
-			"version": "3.3.2",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+			"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
 			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-			"dev": true,
-			"bin": {
-				"uuid": "bin/uuid"
-			}
+			"dev": true
 		},
 		"node_modules/@truffle/provider/node_modules/web3": {
 			"version": "1.3.6",
@@ -4484,6 +4589,22 @@
 			},
 			"engines": {
 				"node": ">=8.0.0"
+			}
+		},
+		"node_modules/@truffle/provider/node_modules/web3-eth-accounts/node_modules/scrypt-js": {
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+			"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+			"dev": true
+		},
+		"node_modules/@truffle/provider/node_modules/web3-eth-accounts/node_modules/uuid": {
+			"version": "3.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+			"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"dev": true,
+			"bin": {
+				"uuid": "bin/uuid"
 			}
 		},
 		"node_modules/@truffle/provider/node_modules/web3-eth-contract": {
@@ -4633,6 +4754,12 @@
 			"engines": {
 				"node": ">=8.0.0"
 			}
+		},
+		"node_modules/@truffle/provider/node_modules/web3-utils/node_modules/bn.js": {
+			"version": "4.12.0",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+			"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+			"dev": true
 		},
 		"node_modules/@trufflesuite/chromafi": {
 			"version": "2.2.2",
@@ -7116,9 +7243,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.13.0.tgz",
-			"integrity": "sha512-7VTvXbsMxROvzPAVczLgfizR8CyYnvWPrb1eGrtlZAJfjQWEHLofVfCKljLHdpazTfpaziRORwUH/kfGDKvpdA==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.13.1.tgz",
+			"integrity": "sha512-wVlh0IAi2t1iOEh16y4u1TRk6ubd4KvLE8dlMi+3QUI6SfKphQUh7tAwihGGSQ8affxEXpVIPpOdf9kjR4v4Pw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -28979,12 +29106,12 @@
 			}
 		},
 		"node_modules/solhint": {
-			"version": "3.3.5",
-			"resolved": "https://registry.npmjs.org/solhint/-/solhint-3.3.5.tgz",
-			"integrity": "sha512-GhEZS/C5O6U34fYKc63nyqCQ7/F5qTZ9YWjfBTUOVE8OXy4E8raApwk4jXplv+CoM8olQdRgTm0o4gsmte8JmA==",
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/solhint/-/solhint-3.3.6.tgz",
+			"integrity": "sha512-HWUxTAv2h7hx3s3hAab3ifnlwb02ZWhwFU/wSudUHqteMS3ll9c+m1FlGn9V8ztE2rf3Z82fQZA005Wv7KpcFA==",
 			"dev": true,
 			"dependencies": {
-				"@solidity-parser/parser": "^0.13.0-rc.8",
+				"@solidity-parser/parser": "^0.13.2",
 				"ajv": "^6.6.1",
 				"antlr4": "4.7.1",
 				"ast-parents": "0.0.1",
@@ -29007,9 +29134,9 @@
 			}
 		},
 		"node_modules/solhint/node_modules/@solidity-parser/parser": {
-			"version": "0.13.1",
-			"resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.13.1.tgz",
-			"integrity": "sha512-V2iBpgVOgWGDQa221hiPjdhKnLcFYltQH1uwT42nu6qn4VX+jq7KLr6Fs31pmIpxaGbOmiKneKHXJ+BL8rO+xQ==",
+			"version": "0.13.2",
+			"resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.13.2.tgz",
+			"integrity": "sha512-RwHnpRnfrnD2MSPveYoPh8nhofEvX7fgjHk1Oq+NNvCcLx4r1js91CO9o+F/F3fBzOCyvm8kKRTriFICX/odWw==",
 			"dev": true,
 			"dependencies": {
 				"antlr4ts": "^0.5.0-alpha.4"
@@ -40123,17 +40250,17 @@
 			}
 		},
 		"@truffle/contract": {
-			"version": "4.3.17",
-			"resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.3.17.tgz",
-			"integrity": "sha512-O/an0UdKgHfsPK9sdCEsbOAPE7Wke9s4pjh9ceXKaqMFyTYIhpnb41dXduyCgepfabZfUEZiwsOa18xy/YCdTg==",
+			"version": "4.3.18",
+			"resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.3.18.tgz",
+			"integrity": "sha512-CvP6iTC/sz3rAfy3awFdDsvE6Q8xfjfW/7oM3OMD49nZnBNHKGQUG5CVKeAa180IVxbA8MGFr3KDCPtN2p0zMw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
 				"@truffle/blockchain-utils": "^0.0.30",
 				"@truffle/contract-schema": "^3.4.1",
-				"@truffle/debug-utils": "^5.0.17",
+				"@truffle/debug-utils": "^5.0.18",
 				"@truffle/error": "^0.0.14",
-				"@truffle/interface-adapter": "^0.4.24",
+				"@truffle/interface-adapter": "^0.5.0",
 				"bignumber.js": "^7.2.1",
 				"ethereum-ens": "^0.8.0",
 				"ethers": "^4.0.32",
@@ -40152,9 +40279,9 @@
 					"optional": true
 				},
 				"@truffle/codec": {
-					"version": "0.10.7",
-					"resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.10.7.tgz",
-					"integrity": "sha512-mKoAzv2VOjIlRc8VD6rQBVj75cqUUVs8O4LzHNw6lnXHIas7NgBYsCixPGoanuVQ6HEu3NzRWfXDtJPHBUZJcg==",
+					"version": "0.10.8",
+					"resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.10.8.tgz",
+					"integrity": "sha512-S4fxInoPH+gTF5zTawiqgFqU2tOIfob2dk0Zc/wqATH8hf1AmRjoYSL6hazk9mdynvmsvNM/QjO6XKCMX3pYYw==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -40181,13 +40308,13 @@
 					}
 				},
 				"@truffle/debug-utils": {
-					"version": "5.0.17",
-					"resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-5.0.17.tgz",
-					"integrity": "sha512-0d6rc20id3UN/rH8VU1MckDhmiUX4iZZvH4Z1SqG4h/c22WqpiNmRRJBPetA2dDo2IhPMRa7/4W0/fVKD/v20A==",
+					"version": "5.0.18",
+					"resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-5.0.18.tgz",
+					"integrity": "sha512-uBPjp6w3LQK8bfSKU1vw1JjNeDn/DX2SnDH0bLNMZg224bhdcDOBhKQBPx3PhrYS01Yhktfu5kDhxgeGQzQfWg==",
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"@truffle/codec": "^0.10.7",
+						"@truffle/codec": "^0.10.8",
 						"@trufflesuite/chromafi": "^2.2.2",
 						"bn.js": "^5.1.3",
 						"chalk": "^2.4.2",
@@ -40211,6 +40338,27 @@
 					"integrity": "sha512-utJx+SZYoMqk8wldQG4gCVKhV8GwMJbWY7sLXFT/D8wWZTnE2peX7URFJh/cxkjTRCO328z1s2qewkhyVsu2HA==",
 					"dev": true,
 					"optional": true
+				},
+				"@truffle/interface-adapter": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.5.0.tgz",
+					"integrity": "sha512-0MRt9orgQqo0knyKDy0fGRqnI+alkuK0BUAvHB1/VUJgCKyWBNAUUZO5gPjuj75qCjV4Rw+W6SKDQpn2xOWsXw==",
+					"dev": true,
+					"optional": true,
+					"requires": {
+						"bn.js": "^5.1.3",
+						"ethers": "^4.0.32",
+						"web3": "1.3.6"
+					},
+					"dependencies": {
+						"bn.js": {
+							"version": "5.2.0",
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+							"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
+							"dev": true,
+							"optional": true
+						}
+					}
 				},
 				"@types/bn.js": {
 					"version": "4.11.6",
@@ -41089,13 +41237,13 @@
 			}
 		},
 		"@truffle/provider": {
-			"version": "0.2.31",
-			"resolved": "https://registry.npmjs.org/@truffle/provider/-/provider-0.2.31.tgz",
-			"integrity": "sha512-IA1EYgwXX3sJgxmOEq6PDbSKaiOs4cSm1AImsZawomDW1MnmQY+6IotRrUsfUZsYPto/2ovNPfawNoxvAM0KzQ==",
+			"version": "0.2.32",
+			"resolved": "https://registry.npmjs.org/@truffle/provider/-/provider-0.2.32.tgz",
+			"integrity": "sha512-dzO7bnCO5iSLfoHH/SIIYQ5dUi9oVxtRE1qJ89dwKuUgtvaWOTPtZK1MLq7Ai+wrgNrYFKBVpxQjkCPXGdMWWw==",
 			"dev": true,
 			"requires": {
 				"@truffle/error": "^0.0.14",
-				"@truffle/interface-adapter": "^0.4.24",
+				"@truffle/interface-adapter": "^0.5.0",
 				"web3": "1.3.6"
 			},
 			"dependencies": {
@@ -41104,6 +41252,17 @@
 					"resolved": "https://registry.npmjs.org/@truffle/error/-/error-0.0.14.tgz",
 					"integrity": "sha512-utJx+SZYoMqk8wldQG4gCVKhV8GwMJbWY7sLXFT/D8wWZTnE2peX7URFJh/cxkjTRCO328z1s2qewkhyVsu2HA==",
 					"dev": true
+				},
+				"@truffle/interface-adapter": {
+					"version": "0.5.0",
+					"resolved": "https://registry.npmjs.org/@truffle/interface-adapter/-/interface-adapter-0.5.0.tgz",
+					"integrity": "sha512-0MRt9orgQqo0knyKDy0fGRqnI+alkuK0BUAvHB1/VUJgCKyWBNAUUZO5gPjuj75qCjV4Rw+W6SKDQpn2xOWsXw==",
+					"dev": true,
+					"requires": {
+						"bn.js": "^5.1.3",
+						"ethers": "^4.0.32",
+						"web3": "1.3.6"
+					}
 				},
 				"@types/bn.js": {
 					"version": "4.11.6",
@@ -41127,10 +41286,33 @@
 					"dev": true
 				},
 				"bn.js": {
-					"version": "4.12.0",
-					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
-					"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+					"version": "5.2.0",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+					"integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw==",
 					"dev": true
+				},
+				"elliptic": {
+					"version": "6.5.3",
+					"resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+					"integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+					"dev": true,
+					"requires": {
+						"bn.js": "^4.4.0",
+						"brorand": "^1.0.1",
+						"hash.js": "^1.0.0",
+						"hmac-drbg": "^1.0.0",
+						"inherits": "^2.0.1",
+						"minimalistic-assert": "^1.0.0",
+						"minimalistic-crypto-utils": "^1.0.0"
+					},
+					"dependencies": {
+						"bn.js": {
+							"version": "4.12.0",
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+							"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+							"dev": true
+						}
+					}
 				},
 				"eth-lib": {
 					"version": "0.2.8",
@@ -41141,7 +41323,68 @@
 						"bn.js": "^4.11.6",
 						"elliptic": "^6.4.0",
 						"xhr-request-promise": "^0.1.2"
+					},
+					"dependencies": {
+						"bn.js": {
+							"version": "4.12.0",
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+							"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+							"dev": true
+						}
 					}
+				},
+				"ethers": {
+					"version": "4.0.48",
+					"resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+					"integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
+					"dev": true,
+					"requires": {
+						"aes-js": "3.0.0",
+						"bn.js": "^4.4.0",
+						"elliptic": "6.5.3",
+						"hash.js": "1.1.3",
+						"js-sha3": "0.5.7",
+						"scrypt-js": "2.0.4",
+						"setimmediate": "1.0.4",
+						"uuid": "2.0.1",
+						"xmlhttprequest": "1.8.0"
+					},
+					"dependencies": {
+						"bn.js": {
+							"version": "4.12.0",
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+							"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+							"dev": true
+						}
+					}
+				},
+				"hash.js": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+					"integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"minimalistic-assert": "^1.0.0"
+					}
+				},
+				"js-sha3": {
+					"version": "0.5.7",
+					"resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+					"integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc=",
+					"dev": true
+				},
+				"scrypt-js": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+					"integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw==",
+					"dev": true
+				},
+				"setimmediate": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+					"integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48=",
+					"dev": true
 				},
 				"underscore": {
 					"version": "1.12.1",
@@ -41150,9 +41393,9 @@
 					"dev": true
 				},
 				"uuid": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+					"integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w=",
 					"dev": true
 				},
 				"web3": {
@@ -41274,6 +41517,20 @@
 						"web3-core-helpers": "1.3.6",
 						"web3-core-method": "1.3.6",
 						"web3-utils": "1.3.6"
+					},
+					"dependencies": {
+						"scrypt-js": {
+							"version": "3.0.1",
+							"resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-3.0.1.tgz",
+							"integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA==",
+							"dev": true
+						},
+						"uuid": {
+							"version": "3.3.2",
+							"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+							"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+							"dev": true
+						}
 					}
 				},
 				"web3-eth-contract": {
@@ -41394,6 +41651,14 @@
 						"randombytes": "^2.1.0",
 						"underscore": "1.12.1",
 						"utf8": "3.0.0"
+					},
+					"dependencies": {
+						"bn.js": {
+							"version": "4.12.0",
+							"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+							"integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==",
+							"dev": true
+						}
 					}
 				}
 			}
@@ -43548,9 +43813,9 @@
 			"dev": true
 		},
 		"core-js-pure": {
-			"version": "3.13.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.13.0.tgz",
-			"integrity": "sha512-7VTvXbsMxROvzPAVczLgfizR8CyYnvWPrb1eGrtlZAJfjQWEHLofVfCKljLHdpazTfpaziRORwUH/kfGDKvpdA==",
+			"version": "3.13.1",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.13.1.tgz",
+			"integrity": "sha512-wVlh0IAi2t1iOEh16y4u1TRk6ubd4KvLE8dlMi+3QUI6SfKphQUh7tAwihGGSQ8affxEXpVIPpOdf9kjR4v4Pw==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -60671,12 +60936,12 @@
 			}
 		},
 		"solhint": {
-			"version": "3.3.5",
-			"resolved": "https://registry.npmjs.org/solhint/-/solhint-3.3.5.tgz",
-			"integrity": "sha512-GhEZS/C5O6U34fYKc63nyqCQ7/F5qTZ9YWjfBTUOVE8OXy4E8raApwk4jXplv+CoM8olQdRgTm0o4gsmte8JmA==",
+			"version": "3.3.6",
+			"resolved": "https://registry.npmjs.org/solhint/-/solhint-3.3.6.tgz",
+			"integrity": "sha512-HWUxTAv2h7hx3s3hAab3ifnlwb02ZWhwFU/wSudUHqteMS3ll9c+m1FlGn9V8ztE2rf3Z82fQZA005Wv7KpcFA==",
 			"dev": true,
 			"requires": {
-				"@solidity-parser/parser": "^0.13.0-rc.8",
+				"@solidity-parser/parser": "^0.13.2",
 				"ajv": "^6.6.1",
 				"antlr4": "4.7.1",
 				"ast-parents": "0.0.1",
@@ -60694,9 +60959,9 @@
 			},
 			"dependencies": {
 				"@solidity-parser/parser": {
-					"version": "0.13.1",
-					"resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.13.1.tgz",
-					"integrity": "sha512-V2iBpgVOgWGDQa221hiPjdhKnLcFYltQH1uwT42nu6qn4VX+jq7KLr6Fs31pmIpxaGbOmiKneKHXJ+BL8rO+xQ==",
+					"version": "0.13.2",
+					"resolved": "https://registry.npmjs.org/@solidity-parser/parser/-/parser-0.13.2.tgz",
+					"integrity": "sha512-RwHnpRnfrnD2MSPveYoPh8nhofEvX7fgjHk1Oq+NNvCcLx4r1js91CO9o+F/F3fBzOCyvm8kKRTriFICX/odWw==",
 					"dev": true,
 					"requires": {
 						"antlr4ts": "^0.5.0-alpha.4"

--- a/test/integration/behaviors/stake.behavior.js
+++ b/test/integration/behaviors/stake.behavior.js
@@ -54,7 +54,12 @@ function itCanMintAndBurn({ ctx }) {
 			});
 
 			it('burnt the expected amount of sUSD', async () => {
-				assert.bnEqual(await SynthsUSD.balanceOf(user.address), balancesUSD.sub(sUSDamount));
+				const newBalancesUSD = await SynthsUSD.balanceOf(user.address);
+				const expected = balancesUSD.sub(sUSDamount);
+				const delta = newBalancesUSD.sub(expected);
+				const variance = ethers.utils.parseUnits('2', 'gwei');
+
+				assert.bnLt(delta, variance);
 			});
 		});
 	});

--- a/test/integration/utils/bootstrap.js
+++ b/test/integration/utils/bootstrap.js
@@ -10,6 +10,7 @@ const { ensureBalance } = require('./balances');
 function bootstrapL1({ ctx }) {
 	before('bootstrap layer 1 instance', async () => {
 		ctx.useOvm = false;
+		ctx.fork = hre.config.fork;
 
 		ctx.provider = _setupProvider({ url: `${hre.config.providerUrl}:${hre.config.providerPort}` });
 

--- a/test/integration/utils/contracts.js
+++ b/test/integration/utils/contracts.js
@@ -5,7 +5,7 @@ const { getSource, getTarget } = require('../../..');
 
 function connectContracts({ ctx }) {
 	const { useOvm } = ctx;
-	const network = 'local';
+	const network = ctx.fork ? 'mainnet' : 'local';
 
 	const allTargets = getTarget({ fs, path, network, useOvm });
 

--- a/test/integration/utils/deploy.js
+++ b/test/integration/utils/deploy.js
@@ -4,6 +4,7 @@ const { getPrivateKey } = require('./users');
 const commands = {
 	build: require('../../../publish/src/commands/build').build,
 	deploy: require('../../../publish/src/commands/deploy').deploy,
+	prepareDeploy: require('../../../publish/src/commands/prepare-deploy').prepareDeploy,
 	connectBridge: require('../../../publish/src/commands/connect-bridge').connectBridge,
 };
 
@@ -19,18 +20,26 @@ async function compileInstance({ useOvm }) {
 	});
 }
 
+async function prepareDeploy() {
+	await commands.prepareDeploy({ network: 'mainnet' });
+}
+
 async function deployInstance({
 	useOvm,
 	providerUrl,
 	providerPort,
+	useFork = false,
+	network = 'local',
+	freshDeploy = true,
 	ignoreCustomParameters = false,
 }) {
 	const privateKey = getPrivateKey({ index: 0 });
 
 	await commands.deploy({
 		concurrency: 1,
-		network: 'local',
-		freshDeploy: true,
+		network,
+		useFork,
+		freshDeploy,
 		yes: true,
 		providerUrl: `${providerUrl}:${providerPort}`,
 		gasPrice: useOvm ? '0' : '1',
@@ -76,4 +85,5 @@ module.exports = {
 	compileInstance,
 	deployInstance,
 	connectInstances,
+	prepareDeploy,
 };

--- a/test/integration/utils/users.js
+++ b/test/integration/utils/users.js
@@ -1,11 +1,34 @@
 const ethers = require('ethers');
+const { getUsers } = require('../../../index');
 
 async function loadUsers({ ctx, network }) {
-	const wallets = _createWallets({ provider: ctx.provider });
+	let wallets;
+
+	if (!ctx.fork) {
+		wallets = _createWallets({ provider: ctx.provider });
+	} else {
+		wallets = _getWallets({ provider: ctx.provider });
+	}
 
 	ctx.users = {};
 	ctx.users.owner = wallets[0];
 	ctx.users.someUser = wallets[1];
+}
+
+function _getWallets({ provider }) {
+	const users = getUsers({ network: 'mainnet' });
+
+	const signers = users
+		.filter(user => user.name !== 'fee')
+		.filter(user => user.name !== 'zero')
+		.map(user => {
+			const signer = provider.getSigner(user.address);
+			signer.address = signer._address;
+
+			return signer;
+		});
+
+	return signers;
 }
 
 function _createWallets({ provider }) {


### PR DESCRIPTION
This PR introduces the ability to simulate an L1 deploy and run integration tests against it, with:
1. `npm run fork`
2. `npx hardhat test:integration:l1 --fork --compile --deploy`

Which runs tests in `test/integration/l1` against a fork of mainnet. The PR also introduces a CI job for the test. Note that not specifying `--deploy` will simply run the integration tests against the current mainnet deployment.

PS: This also fixes a problem with the old ovm prod tests.