### PR TITLE
Disables prod tests from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -433,21 +433,6 @@ workflows:
       - job-integration-tests:
           requires:
             - job-prepare
-      - job-prod-tests:
-          requires:
-            - job-prepare
-      - job-prod-tests-ovm:
-          name: job-prod-tests-ovm
-          requires:
-            - job-prepare
-      - job-prod-diff-tests-local:
-          name: job-prod-diff-tests-local
-          requires:
-            - job-prepare
-      - job-prod-diff-tests:
-          name: job-prod-diff-tests-mainnet
-          requires:
-            - job-prepare
       - job-pack-browser:
           requires:
             - job-prepare

--- a/.circleci/src/workflows/workflow-all.yml
+++ b/.circleci/src/workflows/workflow-all.yml
@@ -39,17 +39,17 @@ jobs:
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Prod tests
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  - job-prod-tests:
-      {{> require-prepare.yml}}
-  - job-prod-tests-ovm:
-      name: job-prod-tests-ovm
-      {{> require-prepare.yml}}
-  - job-prod-diff-tests-local:
-      name: job-prod-diff-tests-local
-      {{> require-prepare.yml}}
-  - job-prod-diff-tests:
-      name: job-prod-diff-tests-mainnet
-      {{> require-prepare.yml}}
+  # - job-prod-tests:
+  #     {{> require-prepare.yml}}
+  # - job-prod-tests-ovm:
+  #     name: job-prod-tests-ovm
+  #     {{> require-prepare.yml}}
+  # - job-prod-diff-tests-local:
+  #     name: job-prod-diff-tests-local
+  #     {{> require-prepare.yml}}
+  # - job-prod-diff-tests:
+  #     name: job-prod-diff-tests-mainnet
+  #     {{> require-prepare.yml}}
 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Packaging


### PR DESCRIPTION
Simply disables the tests, but doesn't delete the files because we need them while we finish porting everything to the new integration tests format.