### PR TITLE
replace web3 with ethers in NounceManager and others in Deployer

### DIFF
--- a/publish/src/Deployer.js
+++ b/publish/src/Deployer.js
@@ -84,7 +84,7 @@ class Deployer {
 	}
 
 	async evaluateNextDeployedContractAddress() {
-		const nonce = await this.provider.ethers.getTransactionCount(this.account);
+		const nonce = await this.provider.ethers.signer.getTransactionCount();
 		const rlpEncoded = ethers.utils.RLP.encode([this.account, ethers.utils.hexlify(nonce)]);
 		const hashed = ethers.utils.keccak256(rlpEncoded); // const hashed = this.web3.utils.sha3(rlpEncoded);
 

--- a/publish/src/NonceManager.js
+++ b/publish/src/NonceManager.js
@@ -3,8 +3,8 @@
 const { gray } = require('chalk');
 
 class NonceManager {
-	constructor({ web3, account }) {
-		this.web3 = web3;
+	constructor({ ethers, account }) {
+		this.ethers = ethers;
 		this.account = account;
 		this.storedNonces = {};
 	}
@@ -12,7 +12,7 @@ class NonceManager {
 	async getNonce() {
 		if (!this.storedNonces[this.account]) {
 			this.storedNonces[this.account] = parseInt(
-				(await this.web3.eth.getTransactionCount(this.account)).toString(),
+				(await this.ethers.eth.getTransactionCount(this.account)).toString(),
 				10
 			);
 		}

--- a/publish/src/commands/deploy/index.js
+++ b/publish/src/commands/deploy/index.js
@@ -202,7 +202,7 @@ const deploy = async ({
 
 	const { account } = deployer;
 
-	nonceManager.web3 = deployer.provider.web3;
+	nonceManager.ethers = deployer.provider.ethers;
 	nonceManager.account = account;
 
 	const {


### PR DESCRIPTION
This PR is to continue replacing web3 references with ethers.js. In this case the usage of of web3 was removed from NonceManager and it's usages and almost all references of web3 were removed from Deployer (missing only one)