### PR TITLE
Enables separate folder compilation for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,7 @@ jobs:
       - run:
           name: Run dual layer 1 and layer 2 integration tests
           command: |
-            npx hardhat test:integration:dual --deploy
+            npx hardhat test:integration:dual --deploy-evm --deploy-ovm --connect
   job-lint:
     working_directory: ~/repo
     docker:

--- a/.circleci/src/jobs/job-integration-tests.yml
+++ b/.circleci/src/jobs/job-integration-tests.yml
@@ -40,4 +40,4 @@ steps:
   - run:
       name: Run dual layer 1 and layer 2 integration tests
       command: |
-        npx hardhat test:integration:dual --deploy
+        npx hardhat test:integration:dual --deploy-evm --deploy-ovm --connect

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@ deploy_settings.py
 
 # gitignore - Truffle proj
 .idea/
-build
 bin/
 node_modules
 yarn-error.log
@@ -17,7 +16,7 @@ site/
 .env
 
 # Build artifacts
-flattened-contracts/
+build*/
 
 # For eth-gas-reporter in tests
 test-gas-used.log

--- a/hardhat/tasks/task-test-integration-dual.js
+++ b/hardhat/tasks/task-test-integration-dual.js
@@ -1,3 +1,7 @@
+const path = require('path');
+const {
+	constants: { BUILD_FOLDER },
+} = require('../..');
 const { task } = require('hardhat/config');
 const {
 	compileInstance,
@@ -6,28 +10,58 @@ const {
 } = require('../../test/integration/utils/deploy');
 
 task('test:integration:dual', 'run integrated layer 1 and layer 2 production tests')
-	.addFlag('deploy', 'Deploy l1 and l2 instances before running the tests')
+	.addFlag('compileEvm', 'Compile the l1 instance before running the tests')
+	.addFlag('compileOvm', 'Compile the l2 instance before running the tests')
+	.addFlag('deployEvm', 'Deploy the l1 instance before running the tests')
+	.addFlag('deployOvm', 'Deploy the l2 instance before running the tests')
+	.addFlag('connect', 'Connect deployed l1 and l2 instances before running the tests')
+	.addOptionalParam('buildPathEvm', 'The target build path for the evm artifacts')
+	.addOptionalParam('buildPathOvm', 'The target build path for the ovm artifacts')
 	.setAction(async (taskArguments, hre) => {
 		hre.config.paths.tests = './test/integration/dual/';
 
 		const providerUrl = (hre.config.providerUrl = 'http://localhost');
 		const providerPortL1 = (hre.config.providerPortL1 = '9545');
 		const providerPortL2 = (hre.config.providerPortL2 = '8545');
+		const buildPathEvm =
+			taskArguments.buildPathEvm || path.join(__dirname, '..', '..', BUILD_FOLDER);
+		const buildPathOvm =
+			taskArguments.buildPathOvm || path.join(__dirname, '..', '..', `${BUILD_FOLDER}-ovm`);
 
 		const timeout = 5 * 60 * 1000;
 		hre.config.mocha.timeout = timeout;
-		hre.config.mocha.bail = false;
+		hre.config.mocha.bail = true;
 		hre.config.networks.localhost.timeout = timeout;
 
 		taskArguments.maxMemory = true;
 
-		if (taskArguments.deploy) {
-			await compileInstance({ useOvm: false });
-			await deployInstance({ useOvm: false, providerUrl, providerPort: providerPortL1 });
+		if (taskArguments.compileEvm) {
+			await compileInstance({ useOvm: false, buildPath: buildPathEvm });
+		}
 
-			await compileInstance({ useOvm: true });
-			await deployInstance({ useOvm: true, providerUrl, providerPort: providerPortL2 });
+		if (taskArguments.compileOvm) {
+			await compileInstance({ useOvm: true, buildPath: buildPathEvm });
+		}
 
+		if (taskArguments.deployEvm) {
+			await deployInstance({
+				useOvm: false,
+				providerUrl,
+				providerPort: providerPortL1,
+				buildPath: buildPathEvm,
+			});
+		}
+
+		if (taskArguments.deployOvm) {
+			await deployInstance({
+				useOvm: true,
+				providerUrl,
+				providerPort: providerPortL2,
+				buildPath: buildPathOvm,
+			});
+		}
+
+		if (taskArguments.connect) {
 			await connectInstances({ providerUrl, providerPortL1, providerPortL2 });
 		}
 

--- a/hardhat/tasks/task-test-integration-l2.js
+++ b/hardhat/tasks/task-test-integration-l2.js
@@ -1,3 +1,7 @@
+const path = require('path');
+const {
+	constants: { BUILD_FOLDER },
+} = require('../..');
 const { task } = require('hardhat/config');
 const { compileInstance, deployInstance } = require('../../test/integration/utils/deploy');
 
@@ -9,21 +13,24 @@ task('test:integration:l2', 'run isolated layer 2 production tests')
 		'The target port for the running local chain to test on',
 		'8545'
 	)
+	.addOptionalParam('buildPath', 'The target build path for the ovm artifacts')
 	.setAction(async (taskArguments, hre) => {
 		hre.config.paths.tests = './test/integration/l2/';
 
 		const providerUrl = (hre.config.providerUrl = 'http://localhost');
 		const providerPort = (hre.config.providerPort = taskArguments.providerPort);
+		const buildPath =
+			taskArguments.buildPath || path.join(__dirname, '..', '..', `${BUILD_FOLDER}-ovm`);
 
 		const timeout = 5 * 60 * 1000;
 		hre.config.mocha.timeout = timeout;
-		hre.config.mocha.bail = false;
+		hre.config.mocha.bail = true;
 		hre.config.networks.localhost.timeout = timeout;
 
 		taskArguments.maxMemory = true;
 
 		if (taskArguments.compile) {
-			await compileInstance({ useOvm: true });
+			await compileInstance({ useOvm: true, buildPath });
 		}
 
 		if (taskArguments.deploy) {
@@ -31,6 +38,7 @@ task('test:integration:l2', 'run isolated layer 2 production tests')
 				useOvm: true,
 				providerUrl,
 				providerPort,
+				buildPath,
 			});
 		}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "synthetix",
 			"version": "2.45.2",
 			"license": "MIT",
 			"dependencies": {
@@ -2549,15 +2550,15 @@
 			}
 		},
 		"node_modules/@truffle/contract": {
-			"version": "4.3.18",
-			"resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.3.18.tgz",
-			"integrity": "sha512-CvP6iTC/sz3rAfy3awFdDsvE6Q8xfjfW/7oM3OMD49nZnBNHKGQUG5CVKeAa180IVxbA8MGFr3KDCPtN2p0zMw==",
+			"version": "4.3.19",
+			"resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.3.19.tgz",
+			"integrity": "sha512-asBwoxUePLwNAuYfHO/SvyZyqFQ9QMeUieJ6PXD9DBrUdNpjgJvk+WHYnXH4bWHgHakbTpL1MEBa1qmcAL+LMw==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
 				"@truffle/blockchain-utils": "^0.0.30",
 				"@truffle/contract-schema": "^3.4.1",
-				"@truffle/debug-utils": "^5.0.18",
+				"@truffle/debug-utils": "^5.0.19",
 				"@truffle/error": "^0.0.14",
 				"@truffle/interface-adapter": "^0.5.0",
 				"bignumber.js": "^7.2.1",
@@ -2589,9 +2590,9 @@
 			"optional": true
 		},
 		"node_modules/@truffle/contract/node_modules/@truffle/codec": {
-			"version": "0.10.8",
-			"resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.10.8.tgz",
-			"integrity": "sha512-S4fxInoPH+gTF5zTawiqgFqU2tOIfob2dk0Zc/wqATH8hf1AmRjoYSL6hazk9mdynvmsvNM/QjO6XKCMX3pYYw==",
+			"version": "0.10.9",
+			"resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.10.9.tgz",
+			"integrity": "sha512-+xBcn1mTAqBhVaFULkMC+pJnUp3prL9QZtE5I4XhlCar3QLkSGR9Oy+Bm5qZwH72rctBRD/lGp2ezUo/oFc2MQ==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
@@ -2616,13 +2617,13 @@
 			"optional": true
 		},
 		"node_modules/@truffle/contract/node_modules/@truffle/debug-utils": {
-			"version": "5.0.18",
-			"resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-5.0.18.tgz",
-			"integrity": "sha512-uBPjp6w3LQK8bfSKU1vw1JjNeDn/DX2SnDH0bLNMZg224bhdcDOBhKQBPx3PhrYS01Yhktfu5kDhxgeGQzQfWg==",
+			"version": "5.0.19",
+			"resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-5.0.19.tgz",
+			"integrity": "sha512-wCF5fwyJTHGBwQD+m8npRCrUIgSPw9jRiZlvyuE+TDcVNBpV4A1NcdsTJR/E5lAViLDTp9lpelsgA/Mw65kU+w==",
 			"dev": true,
 			"optional": true,
 			"dependencies": {
-				"@truffle/codec": "^0.10.8",
+				"@truffle/codec": "^0.10.9",
 				"@trufflesuite/chromafi": "^2.2.2",
 				"bn.js": "^5.1.3",
 				"chalk": "^2.4.2",
@@ -2665,9 +2666,9 @@
 			"optional": true
 		},
 		"node_modules/@truffle/contract/node_modules/@types/node": {
-			"version": "12.20.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
-			"integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+			"version": "12.20.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
+			"integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
 			"dev": true,
 			"optional": true
 		},
@@ -3189,9 +3190,9 @@
 			}
 		},
 		"node_modules/@truffle/interface-adapter/node_modules/@types/node": {
-			"version": "12.20.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
-			"integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+			"version": "12.20.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
+			"integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
 			"dev": true
 		},
 		"node_modules/@truffle/interface-adapter/node_modules/bignumber.js": {
@@ -3657,9 +3658,9 @@
 			}
 		},
 		"node_modules/@truffle/provider/node_modules/@types/node": {
-			"version": "12.20.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
-			"integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+			"version": "12.20.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
+			"integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
 			"dev": true
 		},
 		"node_modules/@truffle/provider/node_modules/bignumber.js": {
@@ -4215,9 +4216,9 @@
 			"dev": true
 		},
 		"node_modules/@types/node": {
-			"version": "15.12.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.0.tgz",
-			"integrity": "sha512-+aHJvoCsVhO2ZCuT4o5JtcPrCPyDE3+1nvbDprYes+pPkEsbjH7AGUCNtjMOXS0fqH14t+B7yLzaqSz92FPWyw==",
+			"version": "15.12.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
+			"integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
 			"dev": true
 		},
 		"node_modules/@types/parse-json": {
@@ -5794,16 +5795,16 @@
 			}
 		},
 		"node_modules/cheerio-select": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.4.0.tgz",
-			"integrity": "sha512-sobR3Yqz27L553Qa7cK6rtJlMDbiKPdNywtR95Sj/YgfpLfy0u6CGJuaBKe5YE/vTc23SCRKxWSdlon/w6I/Ew==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
+			"integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
 			"dev": true,
 			"dependencies": {
-				"css-select": "^4.1.2",
-				"css-what": "^5.0.0",
+				"css-select": "^4.1.3",
+				"css-what": "^5.0.1",
 				"domelementtype": "^2.2.0",
 				"domhandler": "^4.2.0",
-				"domutils": "^2.6.0"
+				"domutils": "^2.7.0"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/fb55"
@@ -6391,9 +6392,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.13.1.tgz",
-			"integrity": "sha512-wVlh0IAi2t1iOEh16y4u1TRk6ubd4KvLE8dlMi+3QUI6SfKphQUh7tAwihGGSQ8affxEXpVIPpOdf9kjR4v4Pw==",
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.14.0.tgz",
+			"integrity": "sha512-YVh+LN2FgNU0odThzm61BsdkwrbrchumFq3oztnE9vTKC4KS2fvnPmcx8t6jnqAyOTCTF4ZSiuK8Qhh7SNcL4g==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -6541,9 +6542,9 @@
 			"dev": true
 		},
 		"node_modules/css-select": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.2.tgz",
-			"integrity": "sha512-nu5ye2Hg/4ISq4XqdLY2bEatAcLIdt3OYGFc9Tm9n7VSlFBcfRv0gBNksHRgSdUDQGtN3XrZ94ztW+NfzkFSUw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+			"integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
 			"dev": true,
 			"dependencies": {
 				"boolbase": "^1.0.0",
@@ -6933,9 +6934,9 @@
 			}
 		},
 		"node_modules/domutils": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-			"integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+			"integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
 			"dev": true,
 			"dependencies": {
 				"dom-serializer": "^1.0.1",
@@ -16672,9 +16673,9 @@
 			}
 		},
 		"node_modules/prettier-plugin-solidity/node_modules/prettier": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
-			"integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
+			"integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin-prettier.js"
@@ -20457,9 +20458,9 @@
 			}
 		},
 		"node_modules/uglify-js": {
-			"version": "3.13.8",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
-			"integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
+			"version": "3.13.9",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.9.tgz",
+			"integrity": "sha512-wZbyTQ1w6Y7fHdt8sJnHfSIuWeDgk6B5rCb4E/AM6QNNPbOMIZph21PW5dRB3h7Df0GszN+t7RuUH6sWK5bF0g==",
 			"dev": true,
 			"optional": true,
 			"bin": {
@@ -21215,9 +21216,9 @@
 			}
 		},
 		"node_modules/web3-bzz/node_modules/@types/node": {
-			"version": "12.20.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
-			"integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+			"version": "12.20.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
+			"integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
 			"dev": true
 		},
 		"node_modules/web3-bzz/node_modules/underscore": {
@@ -21580,9 +21581,9 @@
 			}
 		},
 		"node_modules/web3-core/node_modules/@types/node": {
-			"version": "12.20.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
-			"integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+			"version": "12.20.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
+			"integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
 			"dev": true
 		},
 		"node_modules/web3-core/node_modules/bignumber.js": {
@@ -22192,9 +22193,9 @@
 			}
 		},
 		"node_modules/web3-eth-personal/node_modules/@types/node": {
-			"version": "12.20.14",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
-			"integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+			"version": "12.20.15",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
+			"integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
 			"dev": true
 		},
 		"node_modules/web3-eth-personal/node_modules/bn.js": {
@@ -29073,15 +29074,15 @@
 			}
 		},
 		"@truffle/contract": {
-			"version": "4.3.18",
-			"resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.3.18.tgz",
-			"integrity": "sha512-CvP6iTC/sz3rAfy3awFdDsvE6Q8xfjfW/7oM3OMD49nZnBNHKGQUG5CVKeAa180IVxbA8MGFr3KDCPtN2p0zMw==",
+			"version": "4.3.19",
+			"resolved": "https://registry.npmjs.org/@truffle/contract/-/contract-4.3.19.tgz",
+			"integrity": "sha512-asBwoxUePLwNAuYfHO/SvyZyqFQ9QMeUieJ6PXD9DBrUdNpjgJvk+WHYnXH4bWHgHakbTpL1MEBa1qmcAL+LMw==",
 			"dev": true,
 			"optional": true,
 			"requires": {
 				"@truffle/blockchain-utils": "^0.0.30",
 				"@truffle/contract-schema": "^3.4.1",
-				"@truffle/debug-utils": "^5.0.18",
+				"@truffle/debug-utils": "^5.0.19",
 				"@truffle/error": "^0.0.14",
 				"@truffle/interface-adapter": "^0.5.0",
 				"bignumber.js": "^7.2.1",
@@ -29102,9 +29103,9 @@
 					"optional": true
 				},
 				"@truffle/codec": {
-					"version": "0.10.8",
-					"resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.10.8.tgz",
-					"integrity": "sha512-S4fxInoPH+gTF5zTawiqgFqU2tOIfob2dk0Zc/wqATH8hf1AmRjoYSL6hazk9mdynvmsvNM/QjO6XKCMX3pYYw==",
+					"version": "0.10.9",
+					"resolved": "https://registry.npmjs.org/@truffle/codec/-/codec-0.10.9.tgz",
+					"integrity": "sha512-+xBcn1mTAqBhVaFULkMC+pJnUp3prL9QZtE5I4XhlCar3QLkSGR9Oy+Bm5qZwH72rctBRD/lGp2ezUo/oFc2MQ==",
 					"dev": true,
 					"optional": true,
 					"requires": {
@@ -29131,13 +29132,13 @@
 					}
 				},
 				"@truffle/debug-utils": {
-					"version": "5.0.18",
-					"resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-5.0.18.tgz",
-					"integrity": "sha512-uBPjp6w3LQK8bfSKU1vw1JjNeDn/DX2SnDH0bLNMZg224bhdcDOBhKQBPx3PhrYS01Yhktfu5kDhxgeGQzQfWg==",
+					"version": "5.0.19",
+					"resolved": "https://registry.npmjs.org/@truffle/debug-utils/-/debug-utils-5.0.19.tgz",
+					"integrity": "sha512-wCF5fwyJTHGBwQD+m8npRCrUIgSPw9jRiZlvyuE+TDcVNBpV4A1NcdsTJR/E5lAViLDTp9lpelsgA/Mw65kU+w==",
 					"dev": true,
 					"optional": true,
 					"requires": {
-						"@truffle/codec": "^0.10.8",
+						"@truffle/codec": "^0.10.9",
 						"@trufflesuite/chromafi": "^2.2.2",
 						"bn.js": "^5.1.3",
 						"chalk": "^2.4.2",
@@ -29184,9 +29185,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
-					"integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+					"version": "12.20.15",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
+					"integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
 					"dev": true,
 					"optional": true
 				},
@@ -29651,9 +29652,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.20.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
-					"integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+					"version": "12.20.15",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
+					"integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
 					"dev": true
 				},
 				"bignumber.js": {
@@ -30069,9 +30070,9 @@
 					}
 				},
 				"@types/node": {
-					"version": "12.20.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
-					"integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+					"version": "12.20.15",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
+					"integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
 					"dev": true
 				},
 				"bignumber.js": {
@@ -30575,9 +30576,9 @@
 			"dev": true
 		},
 		"@types/node": {
-			"version": "15.12.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.0.tgz",
-			"integrity": "sha512-+aHJvoCsVhO2ZCuT4o5JtcPrCPyDE3+1nvbDprYes+pPkEsbjH7AGUCNtjMOXS0fqH14t+B7yLzaqSz92FPWyw==",
+			"version": "15.12.2",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-15.12.2.tgz",
+			"integrity": "sha512-zjQ69G564OCIWIOHSXyQEEDpdpGl+G348RAKY0XXy9Z5kU9Vzv1GMNnkar/ZJ8dzXB3COzD9Mo9NtRZ4xfgUww==",
 			"dev": true
 		},
 		"@types/parse-json": {
@@ -31920,16 +31921,16 @@
 			}
 		},
 		"cheerio-select": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.4.0.tgz",
-			"integrity": "sha512-sobR3Yqz27L553Qa7cK6rtJlMDbiKPdNywtR95Sj/YgfpLfy0u6CGJuaBKe5YE/vTc23SCRKxWSdlon/w6I/Ew==",
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-1.5.0.tgz",
+			"integrity": "sha512-qocaHPv5ypefh6YNxvnbABM07KMxExbtbfuJoIie3iZXX1ERwYmJcIiRrr9H05ucQP1k28dav8rpdDgjQd8drg==",
 			"dev": true,
 			"requires": {
-				"css-select": "^4.1.2",
-				"css-what": "^5.0.0",
+				"css-select": "^4.1.3",
+				"css-what": "^5.0.1",
 				"domelementtype": "^2.2.0",
 				"domhandler": "^4.2.0",
-				"domutils": "^2.6.0"
+				"domutils": "^2.7.0"
 			}
 		},
 		"chokidar": {
@@ -32433,9 +32434,9 @@
 			"dev": true
 		},
 		"core-js-pure": {
-			"version": "3.13.1",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.13.1.tgz",
-			"integrity": "sha512-wVlh0IAi2t1iOEh16y4u1TRk6ubd4KvLE8dlMi+3QUI6SfKphQUh7tAwihGGSQ8affxEXpVIPpOdf9kjR4v4Pw==",
+			"version": "3.14.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.14.0.tgz",
+			"integrity": "sha512-YVh+LN2FgNU0odThzm61BsdkwrbrchumFq3oztnE9vTKC4KS2fvnPmcx8t6jnqAyOTCTF4ZSiuK8Qhh7SNcL4g==",
 			"dev": true
 		},
 		"core-util-is": {
@@ -32557,9 +32558,9 @@
 			"dev": true
 		},
 		"css-select": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.2.tgz",
-			"integrity": "sha512-nu5ye2Hg/4ISq4XqdLY2bEatAcLIdt3OYGFc9Tm9n7VSlFBcfRv0gBNksHRgSdUDQGtN3XrZ94ztW+NfzkFSUw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/css-select/-/css-select-4.1.3.tgz",
+			"integrity": "sha512-gT3wBNd9Nj49rAbmtFHj1cljIAOLYSX1nZ8CB7TBO3INYckygm5B7LISU/szY//YmdiSLbJvDLOx9VnMVpMBxA==",
 			"dev": true,
 			"requires": {
 				"boolbase": "^1.0.0",
@@ -32858,9 +32859,9 @@
 			}
 		},
 		"domutils": {
-			"version": "2.6.0",
-			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.6.0.tgz",
-			"integrity": "sha512-y0BezHuy4MDYxh6OvolXYsH+1EMGmFbwv5FKW7ovwMG6zTPWqNPq3WF9ayZssFq+UlKdffGLbOEaghNdaOm1WA==",
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-2.7.0.tgz",
+			"integrity": "sha512-8eaHa17IwJUPAiB+SoTYBo5mCdeMgdcAoXJ59m6DT1vw+5iLS3gNoqYaRowaBKtGVrOF1Jz4yDTgYKLK2kvfJg==",
 			"dev": true,
 			"requires": {
 				"dom-serializer": "^1.0.1",
@@ -40598,9 +40599,9 @@
 					}
 				},
 				"prettier": {
-					"version": "2.3.0",
-					"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.0.tgz",
-					"integrity": "sha512-kXtO4s0Lz/DW/IJ9QdWhAf7/NmPWQXkFr/r/WkR3vyI+0v8amTDxiaQSLzs8NBlytfLWX/7uQUMIW677yLKl4w==",
+					"version": "2.3.1",
+					"resolved": "https://registry.npmjs.org/prettier/-/prettier-2.3.1.tgz",
+					"integrity": "sha512-p+vNbgpLjif/+D+DwAZAbndtRrR0md0MwfmOVN9N+2RgyACMT+7tfaRnT+WDPkqnuVwleyuBIG2XBxKDme3hPA==",
 					"dev": true
 				},
 				"semver": {
@@ -43674,9 +43675,9 @@
 			"peer": true
 		},
 		"uglify-js": {
-			"version": "3.13.8",
-			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.8.tgz",
-			"integrity": "sha512-PvFLMFIQHfIjFFlvAch69U2IvIxK9TNzNWt1SxZGp9JZ/v70yvqIQuiJeVPPtUMOzoNt+aNRDk4wgxb34wvEqA==",
+			"version": "3.13.9",
+			"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.9.tgz",
+			"integrity": "sha512-wZbyTQ1w6Y7fHdt8sJnHfSIuWeDgk6B5rCb4E/AM6QNNPbOMIZph21PW5dRB3h7Df0GszN+t7RuUH6sWK5bF0g==",
 			"dev": true,
 			"optional": true
 		},
@@ -44364,9 +44365,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.20.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
-					"integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+					"version": "12.20.15",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
+					"integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
 					"dev": true
 				},
 				"underscore": {
@@ -44393,9 +44394,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.20.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
-					"integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+					"version": "12.20.15",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
+					"integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
 					"dev": true
 				},
 				"bignumber.js": {
@@ -45320,9 +45321,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.20.14",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.14.tgz",
-					"integrity": "sha512-iFJOS5Q470FF+r4Ol2pSley7/wCNVqf+jgjhtxLLaJcDs+To2iCxlXIkJXrGLD9w9G/oJ9ibySu7z92DCwr7Pg==",
+					"version": "12.20.15",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
+					"integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg==",
 					"dev": true
 				},
 				"bn.js": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -367,9 +367,9 @@
 			}
 		},
 		"node_modules/@eth-optimism/core-utils": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/@eth-optimism/core-utils/-/core-utils-0.4.4.tgz",
-			"integrity": "sha512-dax6Omy1+x9iAuAg34wirzW6fCdlrxosi5r0ilxj7JoD92zue8i9fdFa6OBmeJpWYdC8LReRuz+g13iMmHSZHw==",
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/@eth-optimism/core-utils/-/core-utils-0.4.5.tgz",
+			"integrity": "sha512-nG5bj3Okk9z8ALLS3fbBpAzU3tMZIDbwB32zQejGy0ZFqIA8XWNbuhC1i53qPQCwKJITtSufXYPCDGXu1exlqQ==",
 			"dev": true,
 			"dependencies": {
 				"@ethersproject/abstract-provider": "^5.0.9",
@@ -5774,13 +5774,13 @@
 			}
 		},
 		"node_modules/cheerio": {
-			"version": "1.0.0-rc.9",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.9.tgz",
-			"integrity": "sha512-QF6XVdrLONO6DXRF5iaolY+odmhj2CLj+xzNod7INPWMi/x9X4SOylH0S/vaPpX+AUU6t04s34SQNh7DbkuCng==",
+			"version": "1.0.0-rc.10",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+			"integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
 			"dev": true,
 			"dependencies": {
-				"cheerio-select": "^1.4.0",
-				"dom-serializer": "^1.3.1",
+				"cheerio-select": "^1.5.0",
+				"dom-serializer": "^1.3.2",
 				"domhandler": "^4.2.0",
 				"htmlparser2": "^6.1.0",
 				"parse5": "^6.0.1",
@@ -27341,9 +27341,9 @@
 			}
 		},
 		"@eth-optimism/core-utils": {
-			"version": "0.4.4",
-			"resolved": "https://registry.npmjs.org/@eth-optimism/core-utils/-/core-utils-0.4.4.tgz",
-			"integrity": "sha512-dax6Omy1+x9iAuAg34wirzW6fCdlrxosi5r0ilxj7JoD92zue8i9fdFa6OBmeJpWYdC8LReRuz+g13iMmHSZHw==",
+			"version": "0.4.5",
+			"resolved": "https://registry.npmjs.org/@eth-optimism/core-utils/-/core-utils-0.4.5.tgz",
+			"integrity": "sha512-nG5bj3Okk9z8ALLS3fbBpAzU3tMZIDbwB32zQejGy0ZFqIA8XWNbuhC1i53qPQCwKJITtSufXYPCDGXu1exlqQ==",
 			"dev": true,
 			"requires": {
 				"@ethersproject/abstract-provider": "^5.0.9",
@@ -31906,13 +31906,13 @@
 			}
 		},
 		"cheerio": {
-			"version": "1.0.0-rc.9",
-			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.9.tgz",
-			"integrity": "sha512-QF6XVdrLONO6DXRF5iaolY+odmhj2CLj+xzNod7INPWMi/x9X4SOylH0S/vaPpX+AUU6t04s34SQNh7DbkuCng==",
+			"version": "1.0.0-rc.10",
+			"resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.10.tgz",
+			"integrity": "sha512-g0J0q/O6mW8z5zxQ3A8E8J1hUgp4SMOvEoW/x84OwyHKe/Zccz83PVT4y5Crcr530FV6NgmKI1qvGTKVl9XXVw==",
 			"dev": true,
 			"requires": {
-				"cheerio-select": "^1.4.0",
-				"dom-serializer": "^1.3.1",
+				"cheerio-select": "^1.5.0",
+				"dom-serializer": "^1.3.2",
 				"domhandler": "^4.2.0",
 				"htmlparser2": "^6.1.0",
 				"parse5": "^6.0.1",

--- a/publish/src/commands/build.js
+++ b/publish/src/commands/build.js
@@ -35,7 +35,7 @@ const build = async ({
 	useOvm,
 	cleanBuild,
 } = {}) => {
-	console.log(gray(`Starting build${useOvm ? ' using OVM' : ''}...`));
+	console.log(gray(`Starting build${useOvm ? ' using OVM' : ''} at path ${buildPath}...`));
 
 	if (cleanBuild && fs.existsSync(buildPath)) {
 		fs.rmdirSync(buildPath, { recursive: true });

--- a/test/integration/utils/deploy.js
+++ b/test/integration/utils/deploy.js
@@ -12,11 +12,12 @@ const {
 	constants: { OVM_MAX_GAS_LIMIT },
 } = require('../../../.');
 
-async function compileInstance({ useOvm }) {
+async function compileInstance({ useOvm, buildPath }) {
 	await commands.build({
 		useOvm,
 		optimizerRuns: useOvm ? 1 : 200,
 		testHelpers: true,
+		buildPath,
 	});
 }
 
@@ -32,6 +33,7 @@ async function deployInstance({
 	network = 'local',
 	freshDeploy = true,
 	ignoreCustomParameters = false,
+	buildPath,
 }) {
 	const privateKey = getPrivateKey({ index: 0 });
 
@@ -48,6 +50,7 @@ async function deployInstance({
 		methodCallGasLimit: '3500000',
 		contractDeploymentGasLimit: useOvm ? OVM_MAX_GAS_LIMIT : '9500000',
 		ignoreCustomParameters,
+		buildPath,
 	});
 }
 


### PR DESCRIPTION
This allows integration tests to reuse compilation artifacts in `./build` and `./build-ovm` folders, greatly increasing the flexibility of integration tests.

For example, previously you could run `npx hardhat test:integration:l1 --compile --deploy`, and then re-run without `--compile` or even without `--deploy`.

Then you could do the same with the l2 tests. However, if you went back to l1, or dual, you'd be forced to compile again every time.

Holding the artifacts in different folders, allows you to only have to compile when contracts change, and not when switching between l1, l2, or dual integration tests.