### PR TITLE
Unpins the usage of the Optimism ops tool and starts managing L2 gas

### DIFF
--- a/hardhat/tasks/task-ops.js
+++ b/hardhat/tasks/task-ops.js
@@ -24,7 +24,7 @@ task('ops', 'Run Optimism chain')
 	.addOptionalParam(
 		'optimismCommit',
 		'Commit to checkout',
-		'86708bb5758cd2b647b3ca2be698beb5aa3af81f'
+		undefined // Define here to pin to that specific commit
 	)
 	.setAction(async (taskArguments, hre, runSuper) => {
 		const opsPath = taskArguments.optimismPath.replace('~', homedir);
@@ -142,7 +142,9 @@ function _build({ opsPath, opsCommit }) {
 	execa.sync('sh', ['-c', `cd ${opsPath} && git fetch `]);
 	execa.sync('sh', ['-c', `cd ${opsPath} && git checkout master `]);
 	execa.sync('sh', ['-c', `cd ${opsPath} && git pull origin master `]);
-	execa.sync('sh', ['-c', `cd ${opsPath} && git checkout ${opsCommit}`]);
+	if (opsCommit) {
+		execa.sync('sh', ['-c', `cd ${opsPath} && git checkout ${opsCommit}`]);
+	}
 	console.log(gray('  get dependencies'));
 	execa.sync('sh', ['-c', `cd ${opsPath} && yarn `]);
 	console.log(gray('  build'));

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ const constants = {
 	ZERO_ADDRESS: '0x' + '0'.repeat(40),
 	ZERO_BYTES32: '0x' + '0'.repeat(64),
 
-	OVM_MAX_GAS_LIMIT: '8999999',
+	OVM_GAS_PRICE_GWEI: '0.0',
 
 	inflationStartTimestampInSecs: 1551830400, // 2019-03-06T00:00:00Z
 };

--- a/publish/src/Deployer.js
+++ b/publish/src/Deployer.js
@@ -57,8 +57,7 @@ class Deployer {
 		 */
 		this.provider = { web3: {}, ethers: {} };
 		this.provider.web3 = new Web3(new Web3.providers.HttpProvider(providerUrl));
-		this.provider.ethers.ro = ethers.getDefaultProvider(providerUrl);
-		this.provider.ethers.transactional = null;
+		this.provider.ethers.provider = new ethers.providers.JsonRpcProvider(providerUrl);
 
 		if (useFork || (!privateKey && network === 'local')) {
 			this.provider.web3.eth.defaultAccount = getUsers({ network, user: 'owner' }).address; // protocolDAO
@@ -68,7 +67,7 @@ class Deployer {
 			this.provider.web3.eth.accounts.wallet.add(privateKey);
 			this.provider.web3.eth.defaultAccount = this.provider.web3.eth.accounts.wallet[0].address;
 
-			this.provider.ethers.wallet = new ethers.Wallet(privateKey);
+			this.provider.ethers.wallet = new ethers.Wallet(privateKey, this.provider.ethers.provider);
 			this.provider.ethers.defaultAccount = this.provider.ethers.wallet.address;
 		}
 		this.account = this.provider.ethers.defaultAccount;
@@ -140,9 +139,15 @@ class Deployer {
 	}
 
 	async sendParameters(type = 'method-call') {
+		const gas = this.useOvm
+			? undefined
+			: type === 'method-call'
+			? this.methodCallGasLimit
+			: this.contractDeploymentGasLimit;
+
 		const params = {
 			from: this.account,
-			gas: type === 'method-call' ? this.methodCallGasLimit : this.contractDeploymentGasLimit,
+			gas,
 			gasPrice: ethers.utils.parseUnits(this.gasPrice.toString(), 'gwei'),
 		};
 
@@ -278,12 +283,17 @@ class Deployer {
 				}
 
 				const newContract = new this.provider.web3.eth.Contract(compiled.abi);
-				deployedContract = await newContract
-					.deploy({
-						data: '0x' + bytecode,
-						arguments: args,
-					})
-					.send(await this.sendParameters('contract-deployment'))
+
+				const deploymentTx = await newContract.deploy({
+					data: '0x' + bytecode,
+					arguments: args,
+				});
+
+				const params = await this.sendParameters('contract-deployment');
+				params.gas = await deploymentTx.estimateGas();
+
+				deployedContract = await deploymentTx
+					.send(params)
 					.on('receipt', receipt => (gasUsed = receipt.gasUsed));
 
 				if (this.nonceManager) {

--- a/publish/src/commands/connect-bridge.js
+++ b/publish/src/commands/connect-bridge.js
@@ -1,8 +1,12 @@
 const fs = require('fs');
 const path = require('path');
-const Web3 = require('web3');
+const ethers = require('ethers');
 const { gray, red, yellow } = require('chalk');
-const { wrap, toBytes32 } = require('../../..');
+const {
+	wrap,
+	toBytes32,
+	constants: { OVM_GAS_PRICE_GWEI },
+} = require('../../..');
 const { confirmAction } = require('../util');
 const {
 	ensureNetwork,
@@ -26,8 +30,7 @@ const connectBridge = async ({
 	l2Messenger,
 	dryRun,
 	l1GasPrice,
-	l2GasPrice,
-	gasLimit,
+	l1GasLimit,
 }) => {
 	// ---------------------------------
 	// Setup L1 instance
@@ -35,9 +38,9 @@ const connectBridge = async ({
 
 	console.log(gray('* Setting up L1 instance...'));
 	const {
+		wallet: walletL1,
 		AddressResolver: AddressResolverL1,
 		SynthetixBridge: SynthetixBridgeToOptimism,
-		account: accountL1,
 	} = await setupInstance({
 		network: l1Network,
 		providerUrl: l1ProviderUrl,
@@ -54,9 +57,9 @@ const connectBridge = async ({
 
 	console.log(gray('* Setting up L2 instance...'));
 	const {
+		wallet: walletL2,
 		AddressResolver: AddressResolverL2,
 		SynthetixBridge: SynthetixBridgeToBase,
-		account: accountL2,
 	} = await setupInstance({
 		network: l2Network,
 		providerUrl: l2ProviderUrl,
@@ -73,11 +76,11 @@ const connectBridge = async ({
 
 	console.log(gray('* Connecting bridge on L1...'));
 	await connectLayer({
-		account: accountL1,
+		wallet: walletL1,
 		gasPrice: l1GasPrice,
-		gasLimit,
+		gasLimit: l1GasLimit,
 		names: ['ext:Messenger', 'ovm:SynthetixBridgeToBase'],
-		addresses: [l1Messenger, SynthetixBridgeToBase.options.address],
+		addresses: [l1Messenger, SynthetixBridgeToBase.address],
 		AddressResolver: AddressResolverL1,
 		SynthetixBridge: SynthetixBridgeToOptimism,
 		dryRun,
@@ -89,11 +92,11 @@ const connectBridge = async ({
 
 	console.log(gray('* Connecting bridge on L2...'));
 	await connectLayer({
-		account: accountL2,
-		gasPrice: l2GasPrice,
-		gasLimit,
+		wallet: walletL2,
+		gasPrice: OVM_GAS_PRICE_GWEI,
+		gasLimit: undefined,
 		names: ['ext:Messenger', 'base:SynthetixBridgeToOptimism'],
-		addresses: [l2Messenger, SynthetixBridgeToOptimism.options.address],
+		addresses: [l2Messenger, SynthetixBridgeToOptimism.address],
 		AddressResolver: AddressResolverL2,
 		SynthetixBridge: SynthetixBridgeToBase,
 		dryRun,
@@ -101,7 +104,7 @@ const connectBridge = async ({
 };
 
 const connectLayer = async ({
-	account,
+	wallet,
 	gasPrice,
 	gasLimit,
 	names,
@@ -121,7 +124,7 @@ const connectLayer = async ({
 		const address = addresses[i];
 		console.log(gray(`  * Checking if ${name} is already set to ${address}`));
 
-		const readAddress = await AddressResolver.methods.getAddress(toBytes32(name)).call();
+		const readAddress = await AddressResolver.getAddress(toBytes32(name));
 
 		if (readAddress.toLowerCase() !== address.toLowerCase()) {
 			console.log(yellow(`    > ${name} is not set, including it...`));
@@ -137,12 +140,11 @@ const connectLayer = async ({
 	// ---------------------------------
 
 	const params = {
-		from: account,
-		gasPrice: Web3.utils.toWei(gasPrice.toString(), 'gwei'),
+		gasPrice: ethers.utils.parseUnits(gasPrice.toString(), 'gwei'),
 		gas: gasLimit,
 	};
 
-	let tx;
+	let tx, receipt;
 
 	if (needToImportAddresses) {
 		const ids = names.map(toBytes32);
@@ -155,25 +157,24 @@ const connectLayer = async ({
 				yellow.inverse(`  * CALLING AddressResolver.importAddresses([${ids}], [${addresses}])`)
 			);
 
-			const owner = await AddressResolver.methods.owner().call();
-			if (account.toLowerCase() !== owner.toLowerCase()) {
+			const owner = await AddressResolver.owner();
+			if (wallet.address.toLowerCase() !== owner.toLowerCase()) {
 				await confirmAction(
 					yellow(
-						`    ⚠️  AddressResolver is owned by ${owner} and the current signer is $${account}. Please execute the above transaction and press "y" when done.`
+						`    ⚠️  AddressResolver is owned by ${owner} and the current signer is $${wallet.address}. Please execute the above transaction and press "y" when done.`
 					)
 				);
 			} else {
-				tx = await AddressResolver.methods
-					.importAddresses(names.map(toBytes32), addresses)
-					.send(params);
-				console.log(gray(`    > tx hash: ${tx.transactionHash}`));
+				tx = await AddressResolver.importAddresses(names.map(toBytes32), addresses, params);
+				receipt = await tx.wait();
+				console.log(gray(`    > tx hash: ${receipt.transactionHash}`));
 			}
 		} else {
 			console.log(yellow('  * Skipping, since this is a DRY RUN'));
 		}
 	} else {
 		console.log(
-			gray('  * Bridge is already does not need to import any addresses in this layer. Skipping...')
+			gray('  * Bridge does not need to import any addresses in this layer. Skipping...')
 		);
 	}
 
@@ -183,7 +184,7 @@ const connectLayer = async ({
 
 	let needToSyncCacheOnBridge = needToImportAddresses;
 	if (!needToSyncCacheOnBridge) {
-		const isResolverCached = await SynthetixBridge.methods.isResolverCached().call();
+		const isResolverCached = await SynthetixBridge.isResolverCached();
 		if (!isResolverCached) {
 			needToSyncCacheOnBridge = true;
 		}
@@ -194,7 +195,8 @@ const connectLayer = async ({
 
 		if (!dryRun) {
 			console.log(yellow.inverse('  * CALLING SynthetixBridge.rebuildCache()...'));
-			tx = await SynthetixBridge.methods.rebuildCache().send(params);
+			tx = await SynthetixBridge.rebuildCache(params);
+			receipt = await tx.wait();
 			console.log(gray(`    > tx hash: ${tx.transactionHash}`));
 		} else {
 			console.log(yellow('  * Skipping, since this is a DRY RUN'));
@@ -218,7 +220,7 @@ const setupInstance = async ({
 	console.log(gray('  > useFork:', useFork));
 	console.log(gray('  > useOvm:', useOvm));
 
-	const { web3, getSource, getTarget, providerUrl, account } = bootstrapConnection({
+	const { wallet, provider, getSource, getTarget } = bootstrapConnection({
 		network,
 		providerUrl: specifiedProviderUrl,
 		deploymentPath,
@@ -226,17 +228,17 @@ const setupInstance = async ({
 		useFork,
 		useOvm,
 	});
-	console.log(gray('  > provider:', providerUrl));
-	console.log(gray('  > account:', account));
+	console.log(gray('  > provider:', provider.url));
+	console.log(gray('  > account:', wallet.address));
 
 	const AddressResolver = getContract({
 		contract: 'AddressResolver',
 		getTarget,
 		getSource,
 		deploymentPath,
-		web3,
+		wallet,
 	});
-	console.log(gray('  > AddressResolver:', AddressResolver.options.address));
+	console.log(gray('  > AddressResolver:', AddressResolver.address));
 
 	const bridgeName = useOvm ? 'SynthetixBridgeToBase' : 'SynthetixBridgeToOptimism';
 	const SynthetixBridge = getContract({
@@ -244,14 +246,14 @@ const setupInstance = async ({
 		getTarget,
 		getSource,
 		deploymentPath,
-		web3,
+		wallet,
 	});
-	console.log(gray(`  > ${bridgeName}:`, SynthetixBridge.options.address));
+	console.log(gray(`  > ${bridgeName}:`, SynthetixBridge.address));
 
 	return {
+		wallet,
 		AddressResolver,
 		SynthetixBridge,
-		account,
 	};
 };
 
@@ -278,31 +280,31 @@ const bootstrapConnection = ({
 	}
 
 	const providerUrl = specifiedProviderUrl || defaultProviderUrl;
-	const web3 = new Web3(new Web3.providers.HttpProvider(providerUrl));
+	const provider = new ethers.providers.JsonRpcProvider(providerUrl);
 
 	const { getUsers, getTarget, getSource } = wrap({ network, useOvm, fs, path });
 
-	let account;
+	let wallet;
 	if (useFork) {
-		account = getUsers({ network, user: 'owner' }).address; // protocolDAO
+		const account = getUsers({ network, user: 'owner' }).address;
+		wallet = provider.getSigner(account);
 	} else {
-		web3.eth.accounts.wallet.add(privateKey);
-		account = web3.eth.accounts.wallet[0].address;
+		wallet = new ethers.Wallet(privateKey, provider);
 	}
 
 	return {
 		deploymentPath,
 		providerUrl,
 		privateKey,
-		web3,
-		account,
+		provider,
+		wallet,
 		getTarget,
 		getSource,
 		getUsers,
 	};
 };
 
-const getContract = ({ contract, deploymentPath, getTarget, getSource, web3 }) => {
+const getContract = ({ contract, deploymentPath, getTarget, getSource, wallet }) => {
 	const target = getTarget({ deploymentPath, contract });
 	if (!target) {
 		throw new Error(`Unable to find deployed target for ${contract} in ${deploymentPath}`);
@@ -313,7 +315,7 @@ const getContract = ({ contract, deploymentPath, getTarget, getSource, web3 }) =
 		throw new Error(`Unable to find source for ${contract}`);
 	}
 
-	return new web3.eth.Contract(source.abi, target.address);
+	return new ethers.Contract(target.address, source.abi, wallet);
 };
 
 module.exports = {
@@ -334,9 +336,8 @@ module.exports = {
 			.option('--l2-use-fork', 'Wether to use a fork for the L2 connection', false)
 			.option('--l1-messenger <value>', 'L1 cross domain messenger to use')
 			.option('--l2-messenger <value>', 'L2 cross domain messenger to use')
-			.option('-g, --l1-gas-price <value>', 'Gas price to set when performing transfers in L1', 1)
-			.option('-g, --l2-gas-price <value>', 'Gas price to set when performing transfers in L2', 1)
-			.option('-l, --gas-limit <value>', 'Max gas to use when signing transactions', 8000000)
+			.option('--l1-gas-price <value>', 'Gas price to set when performing transfers in L1', 1)
+			.option('--l1-gas-limit <value>', 'Max gas to use when signing transactions to l1', 8000000)
 			.option('--dry-run', 'Do not execute any transactions')
 			.action(async (...args) => {
 				try {

--- a/publish/src/commands/deploy/index.js
+++ b/publish/src/commands/deploy/index.js
@@ -2,7 +2,6 @@
 
 const path = require('path');
 const { gray, red } = require('chalk');
-const { constants } = require('ethers');
 const pLimit = require('p-limit');
 const Deployer = require('../../Deployer');
 const NonceManager = require('../../NonceManager');
@@ -19,7 +18,13 @@ const {
 } = require('../../util');
 
 const {
-	constants: { BUILD_FOLDER, CONFIG_FILENAME, SYNTHS_FILENAME, DEPLOYMENT_FILENAME },
+	constants: {
+		BUILD_FOLDER,
+		CONFIG_FILENAME,
+		SYNTHS_FILENAME,
+		DEPLOYMENT_FILENAME,
+		OVM_GAS_PRICE_GWEI,
+	},
 } = require('../../../..');
 
 const performSafetyChecks = require('./perform-safety-checks');
@@ -78,9 +83,14 @@ const deploy = async ({
 	deploymentPath = deploymentPath || getDeploymentPathForNetwork({ network, useOvm });
 	ensureDeploymentPath(deploymentPath);
 
-	// OVM uses a gas price of 0 (unless --gas explicitely defined).
-	if (useOvm && gasPrice === DEFAULTS.gasPrice) {
-		gasPrice = constants.Zero;
+	// Gas price needs to be set to 0.015 gwei in Optimism,
+	// and gas limits need to be dynamically set by the provider.
+	// More info:
+	// https://www.notion.so/How-to-pay-Fees-in-Optimistic-Ethereum-f706f4e5b13e460fa5671af48ce9a695
+	if (useOvm) {
+		gasPrice = OVM_GAS_PRICE_GWEI;
+		methodCallGasLimit = undefined;
+		contractDeploymentGasLimit = undefined;
 	}
 
 	const limitPromise = pLimit(concurrency);
@@ -132,6 +142,7 @@ const deploy = async ({
 		ignoreSafetyChecks,
 		manageNonces,
 		methodCallGasLimit,
+		gasPrice,
 		network,
 		useOvm,
 	});

--- a/publish/src/commands/deploy/rebuild-resolver-caches.js
+++ b/publish/src/commands/deploy/rebuild-resolver-caches.js
@@ -3,7 +3,7 @@
 const { gray, red, yellow, redBright } = require('chalk');
 const {
 	fromBytes32,
-	constants: { OVM_MAX_GAS_LIMIT, ZERO_ADDRESS },
+	constants: { ZERO_ADDRESS },
 } = require('../../../..');
 
 module.exports = async ({
@@ -105,7 +105,7 @@ module.exports = async ({
 			if (unknownAddress) {
 				console.log(
 					redBright(
-						`WARINING: Not invoking ${name}.rebuildCache() because ${fromBytes32(
+						`WARNING: Not invoking ${name}.rebuildCache() because ${fromBytes32(
 							unknownAddress
 						)} is unknown. This contract requires: ${requiredAddresses.map(id => fromBytes32(id))}`
 					)
@@ -120,7 +120,7 @@ module.exports = async ({
 	for (let i = 0; i < contractsToRebuildCache.length; i += addressesChunkSize) {
 		const chunk = contractsToRebuildCache.slice(i, i + addressesChunkSize);
 		await runStep({
-			gasLimit: useOvm ? OVM_MAX_GAS_LIMIT : 7e6,
+			gasLimit: useOvm ? undefined : 7e6,
 			contract: `AddressResolver`,
 			target: AddressResolver,
 			publiclyCallable: true, // does not require owner
@@ -262,7 +262,7 @@ module.exports = async ({
 		for (let i = 0; i < binaryOptionMarketsToRebuildCacheOn.length; i += addressesChunkSize) {
 			const chunk = binaryOptionMarketsToRebuildCacheOn.slice(i, i + addressesChunkSize);
 			await runStep({
-				gasLimit: useOvm ? OVM_MAX_GAS_LIMIT : 7e6,
+				gasLimit: useOvm ? undefined : 7e6,
 				contract: `BinaryOptionMarketManager`,
 				target: BinaryOptionMarketManager,
 				publiclyCallable: true, // does not require owner

--- a/publish/src/util.js
+++ b/publish/src/util.js
@@ -244,7 +244,9 @@ const performTransactionalStep = async ({
 		} else {
 			const params = {
 				from: account,
-				gas: Number(gasLimit),
+				gas:
+					Number(gasLimit) ||
+					(await target.methods[write](...argumentsForWriteFunction).estimateGas()),
 				gasPrice: w3utils.toWei(gasPrice.toString(), 'gwei'),
 			};
 

--- a/test/integration/utils/deploy.js
+++ b/test/integration/utils/deploy.js
@@ -1,16 +1,16 @@
 const axios = require('axios');
 const { getLocalPrivateKey } = require('../../test-utils/wallets');
 
+const {
+	constants: { OVM_GAS_PRICE },
+} = require('../../..');
+
 const commands = {
 	build: require('../../../publish/src/commands/build').build,
 	deploy: require('../../../publish/src/commands/deploy').deploy,
 	prepareDeploy: require('../../../publish/src/commands/prepare-deploy').prepareDeploy,
 	connectBridge: require('../../../publish/src/commands/connect-bridge').connectBridge,
 };
-
-const {
-	constants: { OVM_MAX_GAS_LIMIT },
-} = require('../../../.');
 
 async function compileInstance({ useOvm, buildPath }) {
 	await commands.build({
@@ -44,11 +44,11 @@ async function deployInstance({
 		freshDeploy,
 		yes: true,
 		providerUrl: `${providerUrl}:${providerPort}`,
-		gasPrice: useOvm ? '0' : '1',
+		gasPrice: useOvm ? OVM_GAS_PRICE : '1',
 		useOvm,
 		privateKey,
-		methodCallGasLimit: '3500000',
-		contractDeploymentGasLimit: useOvm ? OVM_MAX_GAS_LIMIT : '9500000',
+		methodCallGasLimit: useOvm ? undefined : '3500000',
+		contractDeploymentGasLimit: useOvm ? undefined : '9500000',
 		ignoreCustomParameters,
 		buildPath,
 	});
@@ -69,7 +69,7 @@ async function connectInstances({ providerUrl, providerPortL1, providerPortL2 })
 		l1PrivateKey: privateKey,
 		l2PrivateKey: privateKey,
 		l1GasPrice: 1,
-		l2GasPrice: 0,
+		l2GasPrice: OVM_GAS_PRICE,
 		gasLimit: 8000000,
 	});
 }


### PR DESCRIPTION
Allows us to run integration tests and deploy with the latest Optimism ops tool, which begins to use the new L2 gas rules:
https://www.notion.so/How-to-pay-Fees-in-Optimistic-Ethereum-f706f4e5b13e460fa5671af48ce9a695

This is achieved by:
* Not specifying a gas limit and using estimateGas in web3 instead.
* Removing the default ops commit in `npx hardhat ops`
* Removing web3 in `connect-bridge.js` in favour of ethers, because ethers auto estimates gas.