### PR TITLE
Removes web3 from nominate script

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
 	"requires": true,
 	"packages": {
 		"": {
+			"name": "synthetix",
 			"version": "2.45.2",
 			"license": "MIT",
 			"dependencies": {

--- a/publish/src/commands/deploy/index.js
+++ b/publish/src/commands/deploy/index.js
@@ -224,6 +224,7 @@ const deploy = async ({
 		oracleAddress,
 	} = await systemAndParameterCheck({
 		account,
+		buildPath,
 		addNewSynths,
 		concurrency,
 		config,

--- a/publish/src/commands/deploy/system-and-parameter-check.js
+++ b/publish/src/commands/deploy/system-and-parameter-check.js
@@ -42,6 +42,7 @@ module.exports = async ({
 	useFork,
 	useOvm,
 	yes,
+	buildPath,
 }) => {
 	let oracleAddress;
 	let currentSynthetixSupply;
@@ -196,6 +197,7 @@ module.exports = async ({
 		'Gas price to use': `${gasPrice} GWEI`,
 		'Method call gas limit': `${methodCallGasLimit} gas`,
 		'Contract deployment gas limit': `${contractDeploymentGasLimit} gas`,
+		'Build Path': buildPath,
 		'Deployment Path': new RegExp(network, 'gi').test(deploymentPath)
 			? deploymentPath
 			: yellow('⚠⚠⚠ cant find network name in path. Please double check this! ') + deploymentPath,

--- a/publish/src/commands/nominate.js
+++ b/publish/src/commands/nominate.js
@@ -131,6 +131,12 @@ const nominate = async ({
 			console.log(cyan(`Cannot nominateNewOwner for ${contract} as you aren't the owner!`));
 		} else if (currentOwner !== newOwner && nominatedOwner !== newOwner) {
 			console.log(yellow(`Invoking ${contract}.nominateNewOwner(${newOwner})`));
+			if (useOvm) {
+				gasLimit = await deployedContract.methods
+					.nominateNewOwner(newOwner)
+					.estimateGas({ from: account });
+			}
+
 			await deployedContract.methods.nominateNewOwner(newOwner).send({
 				from: account,
 				gas: gasLimit,

--- a/publish/src/commands/nominate.js
+++ b/publish/src/commands/nominate.js
@@ -5,7 +5,7 @@ const { gray, yellow, red, cyan } = require('chalk');
 
 const {
 	getUsers,
-	constants: { CONFIG_FILENAME, DEPLOYMENT_FILENAME, OVM_GAS_PRICE_GWEI },
+	constants: { CONFIG_FILENAME, DEPLOYMENT_FILENAME },
 } = require('../../..');
 
 const {
@@ -135,8 +135,8 @@ const nominate = async ({
 		} else if (currentOwner !== newOwner && nominatedOwner !== newOwner) {
 			console.log(yellow(`Invoking ${contract}.nominateNewOwner(${newOwner})`));
 			const overrides = {
-				gasLimit: useOvm ? undefined : gasLimit,
-				gasPrice: useOvm ? OVM_GAS_PRICE_GWEI : ethers.utils.parseUnits(gasPrice, 'gwei'),
+				gasLimit,
+				gasPrice: ethers.utils.parseUnits(gasPrice, 'gwei'),
 			};
 
 			const tx = await deployedContract.nominateNewOwner(newOwner, overrides);

--- a/test/integration/behaviors/nominate.behavior.js
+++ b/test/integration/behaviors/nominate.behavior.js
@@ -1,0 +1,81 @@
+const { getLocalPrivateKey } = require('../../test-utils/wallets');
+const { assert } = require('../../contracts/common');
+
+const {
+	constants: { OVM_GAS_PRICE_GWEI },
+} = require('../../..');
+
+const commands = {
+	nominate: require('../../../publish/src/commands/nominate').nominate,
+};
+
+function itCanNominate({ ctx }) {
+	let user1, user2;
+
+	describe('nomination functionality', () => {
+		before('identify users', async () => {
+			user1 = ctx.users.someUser;
+			user2 = ctx.users.otherUser;
+		});
+
+		function _applicableContracts({ ctx }) {
+			return Object.entries(ctx.contracts)
+				.filter(([name, contract]) => !['WETH'].includes(name))
+				.filter(([name, contract]) => contract.functions.nominatedOwner)
+				.map(([name, contract]) => name);
+		}
+
+		async function _nominate({ ctx, address }) {
+			const privateKey = getLocalPrivateKey({ index: 0 });
+
+			await commands.nominate({
+				network: 'local',
+				privateKey,
+				yes: true,
+				newOwner: address,
+				contracts: _applicableContracts({ ctx }),
+				useFork: ctx.useFork,
+				gasPrice: ctx.useOvm ? OVM_GAS_PRICE_GWEI : '1',
+				gasLimit: ctx.useOvm ? undefined : '8000000',
+				useOvm: ctx.useOvm,
+				providerUrl: ctx.provider.connection.url,
+			});
+		}
+
+		async function _verify({ ctx, address }) {
+			const contractNames = _applicableContracts({ ctx });
+			for (const name of contractNames) {
+				const contract = ctx.contracts[name];
+
+				if (contract.functions.nominatedOwner) {
+					const nominated = await contract.nominatedOwner();
+					assert.equal(nominated, address);
+				}
+			}
+		}
+
+		describe('when user1 is nominated', () => {
+			before('nominate user1', async () => {
+				await _nominate({ ctx, address: user1.address });
+			});
+
+			it('shows that user1 is nominated', async () => {
+				await _verify({ ctx, address: user1.address });
+			});
+
+			describe('when user2 is nominated', () => {
+				before('nominate user2', async () => {
+					await _nominate({ ctx, address: user2.address });
+				});
+
+				it('shows that user2 is nominated', async () => {
+					await _verify({ ctx, address: user2.address });
+				});
+			});
+		});
+	});
+}
+
+module.exports = {
+	itCanNominate,
+};

--- a/test/integration/behaviors/nominate.behavior.js
+++ b/test/integration/behaviors/nominate.behavior.js
@@ -32,6 +32,7 @@ function itCanNominate({ ctx }) {
 				network: 'local',
 				privateKey,
 				yes: true,
+				quiet: true,
 				newOwner: address,
 				contracts: _applicableContracts({ ctx }),
 				useFork: ctx.useFork,

--- a/test/integration/l1/Owned.l1.integration.js
+++ b/test/integration/l1/Owned.l1.integration.js
@@ -1,80 +1,9 @@
 const { bootstrapL1 } = require('../utils/bootstrap');
-const { getLocalPrivateKey } = require('../../test-utils/wallets');
+const { itCanNominate } = require('../behaviors/nominate.behavior');
 
-const {
-	constants: { OVM_GAS_PRICE_GWEI },
-} = require('../../..');
-
-const commands = {
-	nominate: require('../../../publish/src/commands/nominate').nominate,
-};
-
-describe.only('Owned integration tests (L1)', () => {
+describe('Owned integration tests (L1)', () => {
 	const ctx = this;
 	bootstrapL1({ ctx });
 
-	let user1, user2;
-
-	describe('nomination functionality', () => {
-		before('identify users', async () => {
-			user1 = ctx.users.someUser;
-			user2 = ctx.users.otherUser;
-		});
-
-		function _applicableContracts({ ctx }) {
-			return Object.entries(ctx.contracts)
-				.filter(([name, contract]) => !['WETH'].includes(name))
-				.filter(([name, contract]) => contract.functions.nominatedOwner)
-				.map(([name, contract]) => name);
-		}
-
-		async function _nominate({ ctx, address }) {
-			const privateKey = getLocalPrivateKey({ index: 0 });
-
-			await commands.nominate({
-				network: 'local',
-				privateKey,
-				yes: true,
-				newOwner: address,
-				contracts: _applicableContracts({ ctx }),
-				useFork: ctx.useFork,
-				gasPrice: ctx.useOvm ? OVM_GAS_PRICE_GWEI : '1',
-				gasLimit: ctx.useOvm ? undefined : '8000000',
-				useOvm: ctx.useOvm,
-				providerUrl: ctx.provider.connection.url,
-			});
-		}
-
-		async function _verify({ ctx, address }) {
-			const contractNames = _applicableContracts({ ctx });
-			for (const name of contractNames) {
-				const contract = ctx.contracts[name];
-
-				if (contract.functions.nominatedOwner) {
-					const nominated = await contract.nominatedOwner();
-					assert.equal(nominated, address);
-				}
-			}
-		}
-
-		describe('when user1 is nominated', () => {
-			before('nominate user1', async () => {
-				await _nominate({ ctx, address: user1.address });
-			});
-
-			it('shows that user1 is nominated', async () => {
-				await _verify({ ctx, address: user1.address });
-			});
-
-			describe('when user2 is nominated', () => {
-				before('nominate user2', async () => {
-					await _nominate({ ctx, address: user2.address });
-				});
-
-				it('shows that user2 is nominated', async () => {
-					await _verify({ ctx, address: user2.address });
-				});
-			});
-		});
-	});
+	itCanNominate({ ctx });
 });

--- a/test/integration/l1/Owned.l1.integration.js
+++ b/test/integration/l1/Owned.l1.integration.js
@@ -1,0 +1,80 @@
+const { bootstrapL1 } = require('../utils/bootstrap');
+const { getLocalPrivateKey } = require('../../test-utils/wallets');
+
+const {
+	constants: { OVM_GAS_PRICE_GWEI },
+} = require('../../..');
+
+const commands = {
+	nominate: require('../../../publish/src/commands/nominate').nominate,
+};
+
+describe.only('Owned integration tests (L1)', () => {
+	const ctx = this;
+	bootstrapL1({ ctx });
+
+	let user1, user2;
+
+	describe('nomination functionality', () => {
+		before('identify users', async () => {
+			user1 = ctx.users.someUser;
+			user2 = ctx.users.otherUser;
+		});
+
+		function _applicableContracts({ ctx }) {
+			return Object.entries(ctx.contracts)
+				.filter(([name, contract]) => !['WETH'].includes(name))
+				.filter(([name, contract]) => contract.functions.nominatedOwner)
+				.map(([name, contract]) => name);
+		}
+
+		async function _nominate({ ctx, address }) {
+			const privateKey = getLocalPrivateKey({ index: 0 });
+
+			await commands.nominate({
+				network: 'local',
+				privateKey,
+				yes: true,
+				newOwner: address,
+				contracts: _applicableContracts({ ctx }),
+				useFork: ctx.useFork,
+				gasPrice: ctx.useOvm ? OVM_GAS_PRICE_GWEI : '1',
+				gasLimit: ctx.useOvm ? undefined : '8000000',
+				useOvm: ctx.useOvm,
+				providerUrl: ctx.provider.connection.url,
+			});
+		}
+
+		async function _verify({ ctx, address }) {
+			const contractNames = _applicableContracts({ ctx });
+			for (const name of contractNames) {
+				const contract = ctx.contracts[name];
+
+				if (contract.functions.nominatedOwner) {
+					const nominated = await contract.nominatedOwner();
+					assert.equal(nominated, address);
+				}
+			}
+		}
+
+		describe('when user1 is nominated', () => {
+			before('nominate user1', async () => {
+				await _nominate({ ctx, address: user1.address });
+			});
+
+			it('shows that user1 is nominated', async () => {
+				await _verify({ ctx, address: user1.address });
+			});
+
+			describe('when user2 is nominated', () => {
+				before('nominate user2', async () => {
+					await _nominate({ ctx, address: user2.address });
+				});
+
+				it('shows that user2 is nominated', async () => {
+					await _verify({ ctx, address: user2.address });
+				});
+			});
+		});
+	});
+});

--- a/test/integration/l2/Owned.l2.integration.js
+++ b/test/integration/l2/Owned.l2.integration.js
@@ -1,0 +1,9 @@
+const { bootstrapL2 } = require('../utils/bootstrap');
+const { itCanNominate } = require('../behaviors/nominate.behavior');
+
+describe('Owned integration tests (L2)', () => {
+	const ctx = this;
+	bootstrapL2({ ctx });
+
+	itCanNominate({ ctx });
+});

--- a/test/integration/utils/deploy.js
+++ b/test/integration/utils/deploy.js
@@ -15,6 +15,7 @@ const commands = {
 async function compileInstance({ useOvm, buildPath }) {
 	await commands.build({
 		useOvm,
+		cleanBuild: true,
 		optimizerRuns: useOvm ? 1 : 200,
 		testHelpers: true,
 		buildPath,


### PR DESCRIPTION
Web3 is easy to remove from admin scripts like nominate.js. This PR adds an integration test for it, then replaces usage of web3 to ethers.