### PR TITLE
Add caching of docker layers on integration tests job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -53,10 +53,19 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - restore_cache:
+          keys:
+            - optimism-build
       - run:
-          name: Build docker containers
+          name: Build docker containers if necessary
           command: |
-            npx hardhat ops --fresh --build --build-ops --optimism-path ./optimism
+            if [ ! -d ./optimism ]; then
+              npx hardhat ops --fresh --build --build-ops --optimism-path ./optimism
+            fi;
+      - save_cache:
+          key: optimism-build
+          paths:
+            - ./optimism
       - run:
           name: Start docker chains
           background: true

--- a/.circleci/src/jobs/job-integration-tests.yml
+++ b/.circleci/src/jobs/job-integration-tests.yml
@@ -5,19 +5,28 @@ steps:
   - checkout
   - attach_workspace:
       at: .
+  - restore_cache:
+      keys:
+        - optimism-build
   - run:
-      name: Build docker containers
+      name: Build docker containers if necessary
       command: |
-        npx hardhat ops --fresh --build --build-ops --optimism-path ./optimism
+        if [ ! -d ./optimism ]; then
+          npx hardhat ops --fresh --build --build-ops --optimism-path ./optimism
+        fi;
+  - save_cache:
+      key: optimism-build
+      paths:
+        - ./optimism
   - run:
       name: Start docker chains
       background: true
       command: |
         npx hardhat ops --start --optimism-path ./optimism
   - cmd-wait-for-port:
-        port: 8545
+      port: 8545
   - cmd-wait-for-port:
-        port: 9545
+      port: 9545
   - run:
       name: Run isolated layer 1 integration tests
       command: |

--- a/hardhat/tasks/task-ops.js
+++ b/hardhat/tasks/task-ops.js
@@ -127,8 +127,6 @@ function _imagesExist() {
 }
 
 function _fresh({ opsPath }) {
-	console.log(gray('  prune docker'));
-	execa.sync('docker', ['system', 'prune', '-f']);
 	console.log(gray('  clone fresh repository into', opsPath));
 	execa.sync('sh', ['-c', 'rm -drf ' + opsPath]);
 	execa.sync('sh', [


### PR DESCRIPTION
Add a cache on circleci to save the built `./optimism` folder. This cache is going to have the default CircleCI expiration of 15 days.

### Testing
If the cache doesn't exists, it will download and build the optimism services, and will take 8mins~:
* https://app.circleci.com/pipelines/github/Synthetixio/synthetix/7531/workflows/4ebd7a13-58b9-41e0-9e56-7663632f8eb2/jobs/71260

But, after having the cache enabled, we save that build step:
* https://app.circleci.com/pipelines/github/Synthetixio/synthetix/7533/workflows/29f73703-5923-456c-998d-3e0fb81332e4/jobs/71281