### PR TITLE
Only execute job-validate-deployments if mainnet/deployment.json file changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -275,6 +275,13 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - run:
+          name: Only run when publish/deployed/*/deployment.json changes
+          command: |
+            changes=$(git diff --name-status origin/develop | grep 'publish\/deployed\/[a-z0-9\-]*\/deployment\.json$' || true)
+            if [ -z "$changes" ]; then
+              circleci-agent step halt
+            fi;
       - run: npm run test:deployments
   job-validate-etherscan:
     working_directory: ~/repo

--- a/.circleci/src/jobs/job-validate-deployments.yml
+++ b/.circleci/src/jobs/job-validate-deployments.yml
@@ -4,4 +4,11 @@ steps:
   - checkout
   - attach_workspace:
       at: .
+  - run:
+      name: Only run when publish/deployed/*/deployment.json changes
+      command: |
+        changes=$(git diff --name-status origin/develop | grep 'publish\/deployed\/[a-z0-9\-]*\/deployment\.json$' || true)
+        if [ -z "$changes" ]; then
+          circleci-agent step halt
+        fi;
   - run: npm run test:deployments


### PR DESCRIPTION
Closes https://github.com/Synthetixio/synthetix-pm/issues/166

Avoid to execute the `job-validate-deployments` job on every PR, and instead execute it when `publish/deployed/mainnet/deployment.json` file changes.

__Notice:__ This PR takes into account that changes to `publish/deployed/mainnet/deployment.json` are done only through the `develop` branch, because if we make a PR to directly `master` to modify that file, this filter would not work correctly.

### Testing
For testing purposes I created a fake change on the `deployments.json` file, and it correctly executed the tests:
* https://app.circleci.com/pipelines/github/Synthetixio/synthetix/7545/workflows/b11df7d2-6840-4737-bf62-61ba2e1cb3b5/jobs/71437

And, after I restored the `deployments.json` file, the check worked correctly:
* https://app.circleci.com/pipelines/github/Synthetixio/synthetix/7544/workflows/0f8a8fe9-16c2-42e7-a1e5-4a3f2aa45ee0/jobs/71432