### PR TITLE
Remove web3 from remove-fee-periods

### DIFF
--- a/publish/src/commands/import-fee-periods.js
+++ b/publish/src/commands/import-fee-periods.js
@@ -138,19 +138,19 @@ const importFeePeriods = async ({
 			}
 		}
 
-		console.log(period);
-		console.log(Object.keys(period));
-
 		// remove redundant index keys (returned from struct calls)
+		const filteredPeriod = {};
 		Object.keys(period)
-			.filter(key => /^[0-9]+$/.test(key))
-			.forEach(key => {
-				console.log(key);
-				delete period[key];
-			});
-		feePeriods.push(period);
+			.filter(key => /^[0-9]+$/.test(key) === false)
+			.forEach(key => (filteredPeriod[key] = period[key]));
+
+		feePeriods.push(filteredPeriod);
 		console.log(
-			gray(`loaded feePeriod ${i} from FeePool (startTime: ${new Date(period.startTime * 1000)})`)
+			gray(
+				`loaded feePeriod ${i} from FeePool (startTime: ${new Date(
+					filteredPeriod.startTime * 1000
+				)})`
+			)
 		);
 	}
 
@@ -158,6 +158,7 @@ const importFeePeriods = async ({
 	if (!override) {
 		for (let i = 0; i < feePeriodLength; i++) {
 			const period = await targetContract.recentFeePeriods(i);
+			console.log(period);
 			// ignore any initial entry where feePeriodId is 1 as this is created by the FeePool constructor
 			if (period.feePeriodId !== '1' && period.startTime !== '0') {
 				throw Error(

--- a/publish/src/commands/import-fee-periods.js
+++ b/publish/src/commands/import-fee-periods.js
@@ -97,7 +97,7 @@ const importFeePeriods = async ({
 		} else {
 			throw Error('Cannot determine which is the last version of FeePool for the network');
 		}
-	} else if (!w3utils.isAddress(sourceContractAddress)) {
+	} else if (!ethers.utils.isAddress(sourceContractAddress)) {
 		throw Error(
 			'Invalid address detected for source (please check your inputs): ',
 			sourceContractAddress

--- a/publish/src/commands/import-fee-periods.js
+++ b/publish/src/commands/import-fee-periods.js
@@ -158,9 +158,8 @@ const importFeePeriods = async ({
 	if (!override) {
 		for (let i = 0; i < feePeriodLength; i++) {
 			const period = await targetContract.recentFeePeriods(i);
-			console.log(period);
 			// ignore any initial entry where feePeriodId is 1 as this is created by the FeePool constructor
-			if (period.feePeriodId !== '1' && period.startTime !== '0') {
+			if (period.feePeriodId.toString() !== '1' && period.startTime.toString() !== '0') {
 				throw Error(
 					`The new target FeePool already has imported fee periods (one or more entries has ` +
 						`startTime as 0. Please check to make sure you are using the latest FeePool ` +

--- a/publish/src/commands/purge-synths.js
+++ b/publish/src/commands/purge-synths.js
@@ -95,7 +95,7 @@ const purgeSynths = async ({
 	} else {
 		wallet = new ethers.Wallet(privateKey, provider);
 	}
-	console.log(wallet);
+
 	if (!wallet.address) wallet.address = wallet._address;
 	console.log(gray(`Using account with public key ${wallet.address}`));
 	console.log(gray(`Using gas of ${gasPrice} GWEI with a max of ${gasLimit}`));

--- a/publish/src/util.js
+++ b/publish/src/util.js
@@ -38,7 +38,6 @@ const {
 const { networks } = require('../..');
 const JSONreplacer = (key, value) => {
 	if (typeof value === 'object' && value.type && value.type === 'BigNumber') {
-		//
 		return BigNumber.from(value).toString();
 	}
 	return value;

--- a/publish/src/util.js
+++ b/publish/src/util.js
@@ -6,6 +6,7 @@ const readline = require('readline');
 const { gray, cyan, yellow, redBright, green } = require('chalk');
 const { table } = require('table');
 const w3utils = require('web3-utils');
+const { BigNumber } = require('ethers');
 
 const {
 	constants: {
@@ -35,7 +36,14 @@ const {
 });
 
 const { networks } = require('../..');
-const stringify = input => JSON.stringify(input, null, '\t') + '\n';
+const JSONreplacer = (key, value) => {
+	if (typeof value === 'object' && value.type && value.type === 'BigNumber') {
+		//
+		return BigNumber.from(value).toString();
+	}
+	return value;
+};
+const stringify = input => JSON.stringify(input, JSONreplacer, '\t') + '\n';
 
 const ensureNetwork = network => {
 	if (!networks.includes(network)) {


### PR DESCRIPTION
Another step in the web3 removal process. 

It removes web3 from import-fee-period script and adds the capability of stringify BigNumber from ethers in a human readable format. 
Also small additional fix: remove non-deleted development log from purge-synths 