### PR TITLE
add local-ovm to synthetix package

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,10 @@ const chainIdMapping = Object.entries({
 	42: {
 		network: 'kovan',
 	},
+	420: {
+		network: 'local',
+		useOvm: true,
+	},
 
 	// Hardhat fork of mainnet: https://hardhat.org/config/#hardhat-network
 	31337: {

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const data = {
 	mainnet: require('./publish/deployed/mainnet'),
 	goerli: require('./publish/deployed/goerli'),
 	'goerli-ovm': require('./publish/deployed/goerli-ovm'),
+	'local-ovm': require('./publish/deployed/local-ovm'),
 	'kovan-ovm': require('./publish/deployed/kovan-ovm'),
 	'mainnet-ovm': require('./publish/deployed/mainnet-ovm'),
 };

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
 		"publish/deployed/mainnet/*",
 		"publish/deployed/mainnet-ovm/*",
 		"publish/deployed/goerli/*",
-		"publish/deployed/goerli-ovm/*"
+		"publish/deployed/goerli-ovm/*",
+		"publish/deployed/local-ovm/*"
 	],
 	"bin": {
 		"snx": "bin.js"

--- a/publish/deployed/local-ovm/index.js
+++ b/publish/deployed/local-ovm/index.js
@@ -1,0 +1,6 @@
+module.exports = {
+    deployment: require('./deployment.json'),
+    synths: require('./synths.json'),
+    rewards: require('./rewards.json'),
+    feeds: require('./feeds.json'),
+};


### PR DESCRIPTION
We are currently deploying the futures on a local OVM instance. We may move to using this more in future,
for now, until Kovan is deployed, this will allow the frontend and the futures-keepers repo to access
the locally deployed contracts.