### PR TITLE
use websocket provider throughout tasks/tests

### DIFF
--- a/hardhat/tasks/task-test-integration.js
+++ b/hardhat/tasks/task-test-integration.js
@@ -17,14 +17,14 @@ task('test:integration:l1', 'run isolated layer 1 production tests')
 	.addOptionalParam(
 		'providerPort',
 		'The target port for the running local chain to test on',
-		'8545'
+		'8546'
 	)
 	.setAction(async (taskArguments, hre) => {
 		hre.config.paths.tests = './test/integration/l1/';
 
 		_commonIntegrationTestSettings({ hre, taskArguments });
 
-		const providerUrl = (hre.config.providerUrl = 'http://localhost');
+		const providerUrl = (hre.config.providerUrl = 'ws://localhost');
 		const providerPort = (hre.config.providerPort = taskArguments.providerPort);
 		const useOvm = false;
 		const buildPath = path.join(__dirname, '..', '..', BUILD_FOLDER);
@@ -61,8 +61,8 @@ task('test:integration:l2', 'run isolated layer 2 production tests')
 
 		_commonIntegrationTestSettings({ hre, taskArguments });
 
-		const providerUrl = (hre.config.providerUrl = 'http://localhost');
-		const providerPort = (hre.config.providerPort = '8545');
+		const providerUrl = (hre.config.providerUrl = 'ws://localhost');
+		const providerPort = (hre.config.providerPort = '8546');
 		const useOvm = true;
 		const buildPath = path.join(__dirname, '..', '..', `${BUILD_FOLDER}-ovm`);
 
@@ -90,9 +90,9 @@ task('test:integration:dual', 'run integrated layer 1 and layer 2 production tes
 
 		_commonIntegrationTestSettings({ hre, taskArguments });
 
-		const providerUrl = (hre.config.providerUrl = 'http://localhost');
-		const providerPortL1 = (hre.config.providerPortL1 = '9545');
-		const providerPortL2 = (hre.config.providerPortL2 = '8545');
+		const providerUrl = (hre.config.providerUrl = 'ws://localhost');
+		const providerPortL1 = (hre.config.providerPortL1 = '9546');
+		const providerPortL2 = (hre.config.providerPortL2 = '8546');
 		const buildPathEvm = path.join(__dirname, '..', '..', BUILD_FOLDER);
 		const buildPathOvm = path.join(__dirname, '..', '..', `${BUILD_FOLDER}-ovm`);
 

--- a/publish/src/Deployer.js
+++ b/publish/src/Deployer.js
@@ -56,8 +56,8 @@ class Deployer {
 		 web3 and/or ethers is needed to interact with the contracts and sing transactions
 		 */
 		this.provider = { web3: {}, ethers: {} };
-		this.provider.web3 = new Web3(new Web3.providers.HttpProvider(providerUrl));
-		this.provider.ethers.provider = new ethers.providers.JsonRpcProvider(providerUrl);
+		this.provider.web3 = new Web3(new Web3.providers.WebsocketProvider(providerUrl));
+		this.provider.ethers.provider = new ethers.providers.WebSocketProvider(providerUrl);
 
 		if (useFork || (!privateKey && network === 'local')) {
 			this.provider.web3.eth.defaultAccount = getUsers({ network, user: 'owner' }).address; // protocolDAO

--- a/publish/src/commands/connect-bridge.js
+++ b/publish/src/commands/connect-bridge.js
@@ -280,7 +280,7 @@ const bootstrapConnection = ({
 	}
 
 	const providerUrl = specifiedProviderUrl || defaultProviderUrl;
-	const provider = new ethers.providers.JsonRpcProvider(providerUrl);
+	const provider = new ethers.providers.WebSocketProvider(providerUrl);
 
 	const { getUsers, getTarget, getSource } = wrap({ network, useOvm, fs, path });
 

--- a/publish/src/commands/deploy/index.js
+++ b/publish/src/commands/deploy/index.js
@@ -397,6 +397,11 @@ const deploy = async ({
 	console.log(gray(`\n------ DEPLOY COMPLETE ------\n`));
 
 	reportDeployedContracts({ deployer });
+
+	// the process hangs when using the web3 websocket provider,
+	// probably because of an unresolved promise. This attempts to
+	// address that.
+	deployer.provider.web3.currentProvider.disconnect();
 };
 
 module.exports = {

--- a/publish/src/commands/extract-staking-balances.js
+++ b/publish/src/commands/extract-staking-balances.js
@@ -85,7 +85,7 @@ async function extractStakingBalances({ network = DEFAULTS.network, deploymentPa
 		yellow(deploymentBlock)
 	);
 
-	const provider = new ethers.providers.JsonRpcProvider(providerUrl);
+	const provider = new ethers.providers.WebSocketProvider(providerUrl);
 
 	const ExchangeRates = new ethers.Contract(
 		getTarget({ contract: 'ExchangeRates' }).address,

--- a/publish/src/commands/import-fee-periods.js
+++ b/publish/src/commands/import-fee-periods.js
@@ -67,7 +67,7 @@ const importFeePeriods = async ({
 		privateKey = envPrivateKey;
 	}
 
-	const provider = new ethers.providers.JsonRpcProvider(providerUrl);
+	const provider = new ethers.providers.WebSocketProvider(providerUrl);
 	let wallet;
 	if (useFork) {
 		const account = getUsers({ network, user: 'owner' }).address; // protocolDAO

--- a/publish/src/commands/migrate-binary-option-markets.js
+++ b/publish/src/commands/migrate-binary-option-markets.js
@@ -53,7 +53,7 @@ const migrateBinaryOptionMarkets = async ({
 		privateKey = envPrivateKey;
 	}
 
-	const provider = new ethers.providers.JsonRpcProvider(providerUrl);
+	const provider = new ethers.providers.WebSocketProvider(providerUrl);
 	const wallet = new ethers.Wallet(privateKey, provider);
 	if (!wallet.address) wallet.address = wallet._address;
 

--- a/publish/src/commands/nominate.js
+++ b/publish/src/commands/nominate.js
@@ -79,7 +79,7 @@ const nominate = async ({
 		privateKey = envPrivateKey;
 	}
 
-	const provider = new ethers.providers.JsonRpcProvider(providerUrl);
+	const provider = new ethers.providers.WebSocketProvider(providerUrl);
 	let wallet;
 	if (useFork) {
 		const account = getUsers({ network, user: 'owner' }).address; // protocolDAO

--- a/publish/src/commands/owner.js
+++ b/publish/src/commands/owner.js
@@ -88,7 +88,7 @@ const owner = async ({
 		privateKey = envPrivateKey;
 	}
 
-	const provider = new ethers.providers.JsonRpcProvider(providerUrl);
+	const provider = new ethers.providers.WebSocketProvider(providerUrl);
 
 	if (!isContract && !yes) {
 		try {

--- a/publish/src/commands/purge-synths.js
+++ b/publish/src/commands/purge-synths.js
@@ -86,7 +86,7 @@ const purgeSynths = async ({
 	}
 
 	console.log(gray(`Provider url: ${providerUrl}`));
-	const provider = new ethers.providers.JsonRpcProvider(providerUrl);
+	const provider = new ethers.providers.WebSocketProvider(providerUrl);
 
 	let wallet;
 	if (useFork) {

--- a/publish/src/commands/remove-synths.js
+++ b/publish/src/commands/remove-synths.js
@@ -85,7 +85,7 @@ const removeSynths = async ({
 		privateKey = envPrivateKey;
 	}
 
-	const provider = new ethers.providers.JsonRpcProvider(providerUrl);
+	const provider = new ethers.providers.WebSocketProvider(providerUrl);
 	let wallet;
 	if (useFork) {
 		const account = getUsers({ network, user: 'owner' }).address; // protocolDAO

--- a/publish/src/commands/settle.js
+++ b/publish/src/commands/settle.js
@@ -66,7 +66,7 @@ const settle = async ({
 
 	privateKey = privateKey || envPrivateKey;
 
-	const provider = new ethers.providers.JsonRpcProvider(providerUrl);
+	const provider = new ethers.providers.WebSocketProvider(providerUrl);
 
 	console.log(gray('gasPrice'), yellow(gasPrice));
 	gasPrice = ethers.utils.parseUnits(gasPrice, 'gwei');

--- a/publish/src/util.js
+++ b/publish/src/util.js
@@ -145,7 +145,7 @@ const loadConnections = ({ network, useFork }) => {
 	// This is because the fork command is assumed to be running at 'localhost:8545'.
 	let providerUrl;
 	if (network === 'local' || useFork) {
-		providerUrl = 'http://127.0.0.1:8545';
+		providerUrl = 'ws://127.0.0.1:8546';
 	} else {
 		if (network === 'mainnet' && process.env.PROVIDER_URL_MAINNET) {
 			providerUrl = process.env.PROVIDER_URL_MAINNET;

--- a/test/integration/utils/bootstrap.js
+++ b/test/integration/utils/bootstrap.js
@@ -100,7 +100,7 @@ function bootstrapDual({ ctx }) {
 }
 
 function _setupProvider({ url }) {
-	return new ethers.providers.JsonRpcProvider({
+	return new ethers.providers.WebSocketProvider({
 		url,
 		timeout: 600000,
 	});

--- a/test/publish/index.js
+++ b/test/publish/index.js
@@ -130,8 +130,8 @@ describe('publish scripts', () => {
 	beforeEach(async () => {
 		console.log = (...input) => fs.appendFileSync(logfilePath, input.join(' ') + '\n');
 
-		provider = new ethers.providers.JsonRpcProvider({
-			url: 'http://localhost:8545',
+		provider = new ethers.providers.WebSocketProvider({
+			url: 'ws://localhost:8546',
 		});
 
 		const { isCompileRequired } = testUtils();

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -529,7 +529,7 @@ module.exports = ({ web3 } = {}) => {
 	};
 
 	const setupProvider = ({ providerUrl, privateKey, publicKey }) => {
-		const provider = new ethers.providers.JsonRpcProvider(providerUrl);
+		const provider = new ethers.providers.WebSocketProvider(providerUrl);
 
 		let wallet;
 		if (publicKey) {


### PR DESCRIPTION
Benefit: l1/l2 integration tests run much quicker, as no time is spent polling the node for the block, which is usually mined instantly (on hardhat ovm, optimism geth)

Current drawback - ops node does not expose the port for l1 websockets.

Question - does this speed up the unit tests too? We'll wait for CI to pass through them all.