### PR TITLE
Unify wallet creation and ensure .address is always present

### DIFF
--- a/publish/src/commands/connect-bridge.js
+++ b/publish/src/commands/connect-bridge.js
@@ -293,9 +293,10 @@ const bootstrapConnection = ({
 	const { getUsers, getTarget, getSource } = wrap({ network, useOvm, fs, path });
 
 	let wallet;
-	if (useFork) {
+	if (!privateKey) {
 		const account = getUsers({ network, user: 'owner' }).address;
 		wallet = provider.getSigner(account);
+		wallet.address = wallet._address;
 	} else {
 		wallet = new ethers.Wallet(privateKey, provider);
 	}

--- a/publish/src/commands/import-fee-periods.js
+++ b/publish/src/commands/import-fee-periods.js
@@ -69,14 +69,14 @@ const importFeePeriods = async ({
 
 	const provider = new ethers.providers.JsonRpcProvider(providerUrl);
 	let wallet;
-	if (useFork) {
+	if (!privateKey) {
 		const account = getUsers({ network, user: 'owner' }).address; // protocolDAO
 		wallet = provider.getSigner(account);
+		wallet.address = await wallet.getAddress();
 	} else {
 		wallet = new ethers.Wallet(privateKey, provider);
 	}
 
-	if (!wallet.address) wallet.address = wallet._address;
 	console.log(gray(`Using account with public key ${wallet.address}`));
 
 	const { address: targetContractAddress, source } = deployment.targets['FeePool'];

--- a/publish/src/commands/migrate-binary-option-markets.js
+++ b/publish/src/commands/migrate-binary-option-markets.js
@@ -55,7 +55,6 @@ const migrateBinaryOptionMarkets = async ({
 
 	const provider = new ethers.providers.JsonRpcProvider(providerUrl);
 	const wallet = new ethers.Wallet(privateKey, provider);
-	if (!wallet.address) wallet.address = wallet._address;
 
 	console.log(gray(`Using account with public key ${yellow(wallet.address)}`));
 

--- a/publish/src/commands/nominate.js
+++ b/publish/src/commands/nominate.js
@@ -84,11 +84,12 @@ const nominate = async ({
 	if (!privateKey) {
 		const account = getUsers({ network, user: 'owner' }).address; // protocolDAO
 		wallet = provider.getSigner(account);
+		wallet.address = await wallet.getAddress();
 	} else {
 		wallet = new ethers.Wallet(privateKey, provider);
 	}
 
-	const signerAddress = await wallet.getAddress();
+	const signerAddress = wallet.address;
 
 	console.log(gray(`Using account with public key ${signerAddress}`));
 

--- a/publish/src/commands/owner.js
+++ b/publish/src/commands/owner.js
@@ -104,9 +104,10 @@ const owner = async ({
 	}
 
 	let wallet;
-	if (useFork) {
+	if (!privateKey) {
 		const account = getUsers({ network, user: 'owner' }).address; // protocolDAO
 		wallet = provider.getSigner(account);
+		wallet.address = await wallet.getAddress();
 	} else {
 		wallet = new ethers.Wallet(privateKey, provider);
 	}

--- a/publish/src/commands/purge-synths.js
+++ b/publish/src/commands/purge-synths.js
@@ -89,14 +89,14 @@ const purgeSynths = async ({
 	const provider = new ethers.providers.JsonRpcProvider(providerUrl);
 
 	let wallet;
-	if (useFork) {
+	if (!privateKey) {
 		const account = getUsers({ network, user: 'owner' }).address; // protocolDAO
 		wallet = provider.getSigner(account);
+		wallet.address = await wallet.getAddress();
 	} else {
 		wallet = new ethers.Wallet(privateKey, provider);
 	}
 
-	if (!wallet.address) wallet.address = wallet._address;
 	console.log(gray(`Using account with public key ${wallet.address}`));
 	console.log(gray(`Using gas of ${gasPrice} GWEI with a max of ${gasLimit}`));
 

--- a/publish/src/commands/remove-synths.js
+++ b/publish/src/commands/remove-synths.js
@@ -87,13 +87,13 @@ const removeSynths = async ({
 
 	const provider = new ethers.providers.JsonRpcProvider(providerUrl);
 	let wallet;
-	if (useFork) {
+	if (!privateKey) {
 		const account = getUsers({ network, user: 'owner' }).address; // protocolDAO
 		wallet = provider.getSigner(account);
+		wallet.address = await wallet.getAddress();
 	} else {
 		wallet = new ethers.Wallet(privateKey, provider);
 	}
-	if (!wallet.address) wallet.address = wallet._address;
 
 	console.log(gray(`Using account with public key ${wallet.address}`));
 	console.log(gray(`Using gas of ${gasPrice} GWEI with a max of ${gasLimit}`));

--- a/publish/src/commands/settle.js
+++ b/publish/src/commands/settle.js
@@ -71,14 +71,14 @@ const settle = async ({
 	console.log(gray('gasPrice'), yellow(gasPrice));
 	gasPrice = ethers.utils.parseUnits(gasPrice, 'gwei');
 
-	let deployer;
-	if (useFork) {
+	let wallet;
+	if (!privateKey) {
 		const account = getUsers({ network, user: 'owner' }).address; // protocolDAO
-		deployer = provider.getSigner(account);
+		wallet = provider.getSigner(account);
+		wallet.address = await wallet.getAddress();
 	} else {
-		deployer = new ethers.Wallet(privateKey, provider);
+		wallet = new ethers.Wallet(privateKey, provider);
 	}
-	deployer.address = deployer._address;
 
 	const user = new ethers.Wallet(privateKey, provider);
 
@@ -97,9 +97,9 @@ const settle = async ({
 		} else {
 			console.log(
 				green(`Sending ${yellow(ethToSeed)} ETH to address from`),
-				yellow(deployer.address)
+				yellow(wallet.address)
 			);
-			const { transactionHash } = await deployer.sendTransaction({
+			const { transactionHash } = await wallet.sendTransaction({
 				to: user.address,
 				value: ethers.utils.parseUnits(ethToSeed),
 				gasLimit,


### PR DESCRIPTION
Propagate fix applied in [PR-1354](https://github.com/Synthetixio/synthetix/pull/1354/files) to the rest of the modified scripts as part of the web3 removal. Also unifying the way to get the wallet with or without privateKey and ensuring wallet.address is always present.
