### PR TITLE
Simplify conditional logic of generate solidity

### DIFF
--- a/publish/src/commands/deploy/generate-solidity-output.js
+++ b/publish/src/commands/deploy/generate-solidity-output.js
@@ -24,7 +24,6 @@ module.exports = async ({
 	deployer,
 	deployment,
 	explorerLinkPrefix,
-	generateSolidity,
 	network,
 	newContractsBeingAdded,
 	useOvm,
@@ -32,10 +31,6 @@ module.exports = async ({
 	sourceOf,
 	addressOf,
 }) => {
-	if (!generateSolidity) {
-		return;
-	}
-
 	const contractsAddedToSoliditySet = new Set();
 	const instructions = [];
 

--- a/publish/src/commands/deploy/index.js
+++ b/publish/src/commands/deploy/index.js
@@ -278,7 +278,7 @@ const deploy = async ({
 			runSteps.push(opts);
 		}
 
-		return { ...rest };
+		return { noop, ...rest };
 	};
 
 	await deployCore({
@@ -420,18 +420,19 @@ const deploy = async ({
 
 	reportDeployedContracts({ deployer });
 
-	generateSolidityOutput({
-		addressOf,
-		deployer,
-		deployment,
-		explorerLinkPrefix,
-		generateSolidity,
-		network,
-		newContractsBeingAdded,
-		runSteps,
-		sourceOf,
-		useOvm,
-	});
+	if (generateSolidity) {
+		generateSolidityOutput({
+			addressOf,
+			deployer,
+			deployment,
+			explorerLinkPrefix,
+			network,
+			newContractsBeingAdded,
+			runSteps,
+			sourceOf,
+			useOvm,
+		});
+	}
 };
 
 module.exports = {

--- a/publish/src/commands/deploy/index.js
+++ b/publish/src/commands/deploy/index.js
@@ -260,7 +260,7 @@ const deploy = async ({
 	const runSteps = [];
 
 	const runStep = async opts => {
-		const { pending, mined, ...rest } = await performTransactionalStepWeb3({
+		const { noop, ...rest } = await performTransactionalStepWeb3({
 			gasLimit: methodCallGasLimit, // allow overriding of gasLimit
 			...opts,
 			account,
@@ -273,11 +273,8 @@ const deploy = async ({
 			ownerActionsFile,
 		});
 
-		// only add to solidity steps when specific conditions are met
-		if (
-			(!opts.skipSolidity && (network === 'local' || useFork) && mined) ||
-			(!useFork && pending)
-		) {
+		// only add to solidity steps when the transaction is NOT a no-op
+		if (!noop) {
 			runSteps.push(opts);
 		}
 

--- a/publish/src/util.js
+++ b/publish/src/util.js
@@ -254,7 +254,7 @@ const performTransactionalStepWeb3 = async ({
 				`[GENERATE_SOLIDITY_SIMULATION] Successfully completed ${action} number ${++_dryRunCounter}.`
 			)
 		);
-		return { mined: true };
+		return {};
 	}
 
 	// otherwise check the owner


### PR DESCRIPTION
The logic for adding to `runSteps` was overly complicated from previous versions and not properly refactored.