### PR TITLE
Add support to use Testnet or Deploy privateKey to CLI

### DIFF
--- a/hardhat/tasks/task-interact.js
+++ b/hardhat/tasks/task-interact.js
@@ -397,22 +397,19 @@ task('interact', 'Interact with a deployed Synthetix instance from the command l
 						result !== undefined
 					) {
 						if (Array.isArray(result) && result.length === 0) {
-							console.log(gray(`  ‚Ü™ Call returned no data`));
+							console.log(gray(`  ↪ Call returned no data`));
 						} else {
 							if (abiItem.outputs.length > 1) {
 								for (let i = 0; i < abiItem.outputs.length; i++) {
 									const output = abiItem.outputs[i];
 									console.log(
-										cyan(`  ‚Ü™${output.name}(${output.type}):`),
+										cyan(`  ↪${output.name}(${output.type}):`),
 										printReturnedValue(result[i])
 									);
 								}
 							} else {
 								const output = abiItem.outputs[0];
-								console.log(
-									cyan(`  ‚Ü™${output.name}(${output.type}):`),
-									printReturnedValue(result)
-								);
+								console.log(cyan(`  ↪${output.name}(${output.type}):`), printReturnedValue(result));
 							}
 						}
 					}

--- a/hardhat/tasks/task-interact.js
+++ b/hardhat/tasks/task-interact.js
@@ -64,8 +64,12 @@ task('interact', 'Interact with a deployed Synthetix instance from the command l
 				publicKey = getUsers({ user: 'owner' }).address;
 			}
 		}
-		if (!privateKey && process.env.PRIVATE_KEY) {
-			privateKey = process.env.PRIVATE_KEY;
+		const envPrivateKey =
+			targetNetwork === 'mainnet'
+				? process.env.DEPLOY_PRIVATE_KEY
+				: process.env.TESTNET_DEPLOY_PRIVATE_KEY;
+		if (!privateKey && envPrivateKey) {
+			privateKey = envPrivateKey;
 		}
 
 		// Determine provider url


### PR DESCRIPTION
Change hh task to use DEPLOY_PRIVATE_KEY or TESTNET_PRIVATE_KEY depending on the targetNetwork instead of just using PRIVATE_KEY 