### PR TITLE
Fix issue 1403 - npx hardhat ops doesn't detect if ops node running correctly

### DIFF
--- a/hardhat/tasks/task-ops.js
+++ b/hardhat/tasks/task-ops.js
@@ -114,6 +114,10 @@ function _isRunning({ opsPath }) {
 			if (err.exitCode === 1) {
 				result = false;
 			}
+			if (err.exitCode === 2) {
+				// Usually the grep cmd failed because there's no output from docker-compose ps -q ...
+				result = false;
+			}
 		}
 	});
 	return result;

--- a/hardhat/tasks/task-ops.js
+++ b/hardhat/tasks/task-ops.js
@@ -111,11 +111,7 @@ function _isRunning({ opsPath }) {
 				result = false;
 			}
 		} catch (err) {
-			if (err.exitCode === 1) {
-				result = false;
-			}
-			if (err.exitCode === 2) {
-				// Usually the grep cmd failed because there's no output from docker-compose ps -q ...
+			if (err.exitCode) {
 				result = false;
 			}
 		}


### PR DESCRIPTION
This PR fixes the issue found by Liam [Issue-1403](https://github.com/Synthetixio/synthetix/issues/1403) where ops is not detecting correctly if ops is running when other docker-compose based image is running.