### PR TITLE
Move job-fork-tests-no-update to master

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -358,9 +358,6 @@ workflows:
       - job-fork-tests:
           requires:
             - job-prepare
-      - job-fork-tests-no-update:
-          requires:
-            - job-prepare
       - job-integration-tests:
           name: job-integration-tests
           requires:
@@ -369,5 +366,18 @@ workflows:
           requires:
             - job-prepare
       - job-validate-deployments:
+          requires:
+            - job-prepare
+  workflow-master:
+    triggers:
+      - schedule:
+          cron: "0 0 * * *"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - job-prepare
+      - job-fork-tests-no-update:
           requires:
             - job-prepare

--- a/.circleci/src/workflows/workflow-all.yml
+++ b/.circleci/src/workflows/workflow-all.yml
@@ -29,8 +29,6 @@ jobs:
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   - job-fork-tests:
       {{> require-prepare.yml}}
-  - job-fork-tests-no-update:
-      {{> require-prepare.yml}}
 
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   # Integration tests
@@ -50,27 +48,3 @@ jobs:
   # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   - job-validate-deployments:
       {{> require-prepare.yml}}
-
-  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  # Etherscan validations
-  # NOTE: Currently disabled because our Etherscan test
-  # needs to be smarter. It needs to be able to handle multiple
-  # versioned ABIs per contract.
-  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  # - job-validate-etherscan:
-  #     name: job-validate-etherscan-mainnet
-  #     network: mainnet
-  #     {{> require-prepare.yml}}
-  # - job-validate-etherscan:
-  #     name: job-validate-etherscan-rinkeby
-  #     network: rinkeby
-  #     {{> require-prepare.yml}}
-  # - job-validate-etherscan:
-  #     name: job-validate-etherscan-kovan
-  #     network: kovan
-  #     {{> require-prepare.yml}}
-  # - job-validate-etherscan:
-  #     name: job-validate-etherscan-ropsten
-  #     network: ropsten
-  #     {{> require-prepare.yml}}
-

--- a/.circleci/src/workflows/workflow-master.yml
+++ b/.circleci/src/workflows/workflow-master.yml
@@ -1,0 +1,16 @@
+# Runs regularly every 24hs,
+# without the need of a commit.
+triggers:
+  - schedule:
+      cron: "0 0 * * *"
+      filters:
+        branches:
+          only:
+            - master
+jobs:
+  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  # Fork tests
+  # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  - job-prepare
+  - job-fork-tests-no-update:
+      {{> require-prepare.yml}}


### PR DESCRIPTION
Non update fork tests, i.e. fork tests that don't do a deploy before running tests can be a problem on branches introducing new features, since their tests will probably be looking for these features, and will not find them in what's in production.

This PR removes such tests from the main CI `workflow-all` and moves them to a `workflow-master`, which by the way, is triggered regularly on a timer instead of on commits.