### PR TITLE
Remove some solidity warnings

### DIFF
--- a/contracts/BaseSynthetix.sol
+++ b/contracts/BaseSynthetix.sol
@@ -314,7 +314,7 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         bytes32,
         address,
         bytes32
-    ) external returns (uint amountReceive) {
+    ) external returns (uint amountReceived) {
         // FIXME remove parameter name in returns. Just (uint)
         _notImplemented();
     }

--- a/contracts/BaseSynthetix.sol
+++ b/contracts/BaseSynthetix.sol
@@ -314,7 +314,7 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         bytes32,
         address,
         bytes32
-    ) external returns (uint amountReceived) {
+    ) external returns (uint) {
         _notImplemented();
     }
 
@@ -358,7 +358,7 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         _;
     }
 
-    function _systemActive() private {
+    function _systemActive() private view {
         systemStatus().requireSystemActive();
     }
 
@@ -367,7 +367,7 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         _;
     }
 
-    function _issuanceActive() private {
+    function _issuanceActive() private view {
         systemStatus().requireIssuanceActive();
     }
 
@@ -376,7 +376,7 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         _;
     }
 
-    function _exchangeActive(bytes32 src, bytes32 dest) private {
+    function _exchangeActive(bytes32 src, bytes32 dest) private view {
         systemStatus().requireExchangeBetweenSynthsAllowed(src, dest);
     }
 
@@ -385,7 +385,7 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         _;
     }
 
-    function _onlyExchanger() private {
+    function _onlyExchanger() private view {
         require(msg.sender == address(exchanger()), "Only Exchanger can invoke this");
     }
 

--- a/contracts/BaseSynthetix.sol
+++ b/contracts/BaseSynthetix.sol
@@ -314,7 +314,8 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         bytes32,
         address,
         bytes32
-    ) external returns (uint) {
+    ) external returns (uint amountReceive) {
+        // FIXME remove parameter name in returns. Just (uint)
         _notImplemented();
     }
 
@@ -358,7 +359,8 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         _;
     }
 
-    function _systemActive() private view {
+    function _systemActive() private {
+        // FIXME add view modifier
         systemStatus().requireSystemActive();
     }
 
@@ -367,7 +369,8 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         _;
     }
 
-    function _issuanceActive() private view {
+    function _issuanceActive() private {
+        // FIXME add view modifier
         systemStatus().requireIssuanceActive();
     }
 
@@ -376,7 +379,8 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         _;
     }
 
-    function _exchangeActive(bytes32 src, bytes32 dest) private view {
+    function _exchangeActive(bytes32 src, bytes32 dest) private {
+        // FIXME add view modifier
         systemStatus().requireExchangeBetweenSynthsAllowed(src, dest);
     }
 
@@ -385,7 +389,8 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         _;
     }
 
-    function _onlyExchanger() private view {
+    function _onlyExchanger() private {
+        // FIXME add view modifier
         require(msg.sender == address(exchanger()), "Only Exchanger can invoke this");
     }
 

--- a/contracts/EmptyEtherWrapper.sol
+++ b/contracts/EmptyEtherWrapper.sol
@@ -7,7 +7,7 @@ contract EmptyEtherWrapper {
 
     /* ========== VIEWS ========== */
 
-    function totalIssuedSynths() public view returns (uint) {
+    function totalIssuedSynths() public pure returns (uint) {
         return 0;
     }
 

--- a/contracts/EmptyEtherWrapper.sol
+++ b/contracts/EmptyEtherWrapper.sol
@@ -7,7 +7,8 @@ contract EmptyEtherWrapper {
 
     /* ========== VIEWS ========== */
 
-    function totalIssuedSynths() public pure returns (uint) {
+    function totalIssuedSynths() public view returns (uint) {
+        // FIXME change view to pure.
         return 0;
     }
 

--- a/contracts/NativeEtherWrapper.sol
+++ b/contracts/NativeEtherWrapper.sol
@@ -23,11 +23,10 @@ contract NativeEtherWrapper is Owned, MixinResolver {
     /* ========== PUBLIC FUNCTIONS ========== */
 
     /* ========== VIEWS ========== */
-    function resolverAddressesRequired() public view returns (bytes32[] memory) {
-        bytes32[] memory addresses = new bytes32[](2);
+    function resolverAddressesRequired() public view returns (bytes32[] memory addresses) {
+        addresses = new bytes32[](2);
         addresses[0] = CONTRACT_ETHER_WRAPPER;
         addresses[1] = CONTRACT_SYNTHSETH;
-        return addresses;
     }
 
     function etherWrapper() internal view returns (IEtherWrapper) {

--- a/contracts/NativeEtherWrapper.sol
+++ b/contracts/NativeEtherWrapper.sol
@@ -23,7 +23,7 @@ contract NativeEtherWrapper is Owned, MixinResolver {
     /* ========== PUBLIC FUNCTIONS ========== */
 
     /* ========== VIEWS ========== */
-    function resolverAddressesRequired() public view returns (bytes32[] memory addresses) {
+    function resolverAddressesRequired() public view returns (bytes32[] memory) {
         bytes32[] memory addresses = new bytes32[](2);
         addresses[0] = CONTRACT_ETHER_WRAPPER;
         addresses[1] = CONTRACT_SYNTHSETH;
@@ -65,7 +65,7 @@ contract NativeEtherWrapper is Owned, MixinResolver {
 
     function burn(uint amount) public {
         require(amount > 0, "amount must be greater than 0");
-        IWETH weth = weth();
+        IWETH _weth = weth();
 
         // Transfer sETH from the msg.sender.
         synthsETH().transferFrom(msg.sender, address(this), amount);
@@ -77,7 +77,7 @@ contract NativeEtherWrapper is Owned, MixinResolver {
         etherWrapper().burn(amount);
 
         // Convert WETH to ETH and send to msg.sender.
-        weth.withdraw(weth.balanceOf(address(this)));
+        _weth.withdraw(_weth.balanceOf(address(this)));
         // solhint-disable avoid-low-level-calls
         msg.sender.call.value(address(this).balance)("");
 

--- a/contracts/NativeEtherWrapper.sol
+++ b/contracts/NativeEtherWrapper.sol
@@ -24,9 +24,11 @@ contract NativeEtherWrapper is Owned, MixinResolver {
 
     /* ========== VIEWS ========== */
     function resolverAddressesRequired() public view returns (bytes32[] memory addresses) {
-        addresses = new bytes32[](2);
+        bytes32[] memory addresses = new bytes32[](2);
+        // FIXME remove type declaration. Addresses is already declared in the returns parameters (Allign with other contracts)
         addresses[0] = CONTRACT_ETHER_WRAPPER;
         addresses[1] = CONTRACT_SYNTHSETH;
+        return addresses; // FIXME remove return since it's already specified in returns function key
     }
 
     function etherWrapper() internal view returns (IEtherWrapper) {
@@ -64,7 +66,7 @@ contract NativeEtherWrapper is Owned, MixinResolver {
 
     function burn(uint amount) public {
         require(amount > 0, "amount must be greater than 0");
-        IWETH _weth = weth();
+        IWETH weth = weth(); // FIXME weth collides with weth() function. Rename to _weth
 
         // Transfer sETH from the msg.sender.
         synthsETH().transferFrom(msg.sender, address(this), amount);
@@ -76,9 +78,9 @@ contract NativeEtherWrapper is Owned, MixinResolver {
         etherWrapper().burn(amount);
 
         // Convert WETH to ETH and send to msg.sender.
-        _weth.withdraw(_weth.balanceOf(address(this)));
+        weth.withdraw(weth.balanceOf(address(this)));
         // solhint-disable avoid-low-level-calls
-        msg.sender.call.value(address(this).balance)("");
+        msg.sender.call.value(address(this).balance)(""); // FIXME retrieve returned value and catch any error
 
         emit Burned(msg.sender, amount);
     }

--- a/contracts/test-helpers/MockWETH.sol
+++ b/contracts/test-helpers/MockWETH.sol
@@ -10,11 +10,11 @@ contract MockWETH is ERC20, ERC20Detailed {
         _mint(msg.sender, 1000000 * (10**18));
     }
 
-    function deposit() external {
+    function deposit() external pure {
         revert("Unimplemented for OVM");
     }
 
-    function withdraw(uint amount) external {
+    function withdraw(uint amount) external pure {
         amount;
         revert("Unimplemented for OVM");
     }

--- a/contracts/test-helpers/TestableAddressSet.sol
+++ b/contracts/test-helpers/TestableAddressSet.sol
@@ -31,7 +31,7 @@ contract TestableAddressSet {
         return set.elements[index];
     }
 
-    function index(address element) public view returns (uint) {
-        return set.indices[element];
+    function index(address _element) public view returns (uint) {
+        return set.indices[_element];
     }
 }

--- a/contracts/test-helpers/TestableBytes32Set.sol
+++ b/contracts/test-helpers/TestableBytes32Set.sol
@@ -31,7 +31,7 @@ contract TestableBytes32Set {
         return set.elements[index];
     }
 
-    function index(bytes32 element) public view returns (uint) {
-        return set.indices[element];
+    function index(bytes32 _element) public view returns (uint) {
+        return set.indices[_element];
     }
 }


### PR DESCRIPTION
This PR reduces the number of warnings shown when compiling the contracts. 

Some compiler warnings are still present. 

-  **Experimental features are turned on...**: because we use `pragma experimental ABIEncoderV2;`. Those will remain unless we migrate to latest solidity version
- contracts/Exchanger.sol:536:5: Warning: **Function state mutability can be restricted to pure**: that function is overriding in another contract where is not pure.
- contracts/NativeEtherWrapper.sol:82:9: Warning: **Return value of low-level calls not used.**: we can assign the result (and check if the call failed) 
