### PR TITLE
Richer Futures position and margin events

### DIFF
--- a/contracts/FuturesMarket.sol
+++ b/contracts/FuturesMarket.sol
@@ -791,7 +791,7 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
         return (uMargin, Status.Ok);
     }
 
-    function _modifyMargin(
+    function _transferMargin(
         int marginDelta,
         uint price,
         uint fundingIndex,
@@ -830,14 +830,17 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
 
         // Update the account's position with the realised margin.
         position.margin = margin;
-        position.lastPrice = price;
-        position.fundingIndex = fundingIndex;
+        // We only need to update their funding/PnL details if they actually have a position open
+        if (positionSize > 0) {
+            position.lastPrice = price;
+            position.fundingIndex = fundingIndex;
+        }
 
         // The user can decrease their position if they have no position, or as long as:
         //     * they have sufficient margin to do so
         //     * the resulting margin would not be lower than the minimum margin
         //     * the resulting leverage is lower than the maximum leverage
-        if (0 < position.size && marginDelta <= 0) {
+        if (0 < positionSize && marginDelta <= 0) {
             if (margin < _minInitialMargin()) {
                 status = Status.InsufficientMargin;
             } else if (_maxLeverage(baseAsset) < _abs(_currentLeverage(position, price, margin))) {
@@ -845,12 +848,24 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
             }
             _revertIfError(status);
         }
+
+        // Emit relevant events
+        if (marginDelta != 0) {
+            emitMarginTransferred(sender, marginDelta);
+        }
+        emitPositionModified(
+            sender,
+            margin,
+            positionSize,
+            positionSize > 0 ? price : 0,
+            positionSize > 0 ? fundingIndex : 0
+        );
     }
 
-    function modifyMargin(int marginDelta) external optionalProxy {
+    function transferMargin(int marginDelta) external optionalProxy {
         uint price = _assetPriceRequireNotInvalid();
         uint fundingIndex = _recomputeFunding(price);
-        _modifyMargin(marginDelta, price, fundingIndex, messageSender);
+        _transferMargin(marginDelta, price, fundingIndex, messageSender);
     }
 
     function withdrawAllMargin() external optionalProxy {
@@ -858,7 +873,7 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
         uint price = _assetPriceRequireNotInvalid();
         uint fundingIndex = _recomputeFunding(price);
         int marginDelta = -int(_remainingMargin(positions[sender], fundingIndex, price));
-        _modifyMargin(marginDelta, price, fundingIndex, sender);
+        _transferMargin(marginDelta, price, fundingIndex, sender);
     }
 
     function _cancelOrder(address account) internal {
@@ -961,7 +976,7 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
         _submitOrder(0, price, [0, uint(-1)], fundingIndex, messageSender);
     }
 
-    function modifyMarginAndSubmitOrderWithPriceBounds(
+    function transferMarginAndSubmitOrderWithPriceBounds(
         int marginDelta,
         int leverage,
         uint minPrice,
@@ -970,12 +985,12 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
         uint price = _assetPriceRequireNotInvalid();
         uint fundingIndex = _recomputeFunding(price);
         address sender = messageSender;
-        _modifyMargin(marginDelta, price, fundingIndex, sender);
+        _transferMargin(marginDelta, price, fundingIndex, sender);
         _submitOrder(leverage, price, [minPrice, maxPrice], fundingIndex, sender);
     }
 
-    function modifyMarginAndSubmitOrder(int marginDelta, int leverage) external optionalProxy {
-        modifyMarginAndSubmitOrderWithPriceBounds(marginDelta, leverage, 0, uint(-1));
+    function transferMarginAndSubmitOrder(int marginDelta, int leverage) external optionalProxy {
+        transferMarginAndSubmitOrderWithPriceBounds(marginDelta, leverage, 0, uint(-1));
     }
 
     function confirmOrder(address account) external optionalProxy {
@@ -1013,13 +1028,15 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
             delete position.size;
             delete position.lastPrice;
             delete position.fundingIndex;
+            emitPositionModified(account, margin, 0, 0, 0);
         } else {
             position.size = newSize;
             position.lastPrice = price;
             position.fundingIndex = fundingIndex;
+            emitPositionModified(account, margin, newSize, price, fundingIndex);
         }
         Order storage order = orders[account];
-        emitOrderConfirmed(order.id, account, margin, newSize, price, fundingIndex);
+        emitOrderConfirmed(order.id, account, price);
         delete orders[account];
     }
 
@@ -1057,7 +1074,8 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
         // Issue the reward to the liquidator.
         _manager().issueSUSD(liquidator, liquidationFee);
 
-        emitPositionLiquidated(account, liquidator, positionSize, lPrice);
+        emitPositionModified(account, 0, 0, 0, 0);
+        emitPositionLiquidated(account, liquidator, positionSize, lPrice, liquidationFee);
     }
 
     function liquidatePosition(address account) external optionalProxy {
@@ -1079,6 +1097,13 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
 
     function addressToBytes32(address input) internal pure returns (bytes32) {
         return bytes32(uint256(uint160(input)));
+    }
+
+    event MarginTransferred(address indexed account, int marginDelta);
+    bytes32 internal constant SIG_MARGINTRANSFERRED = keccak256("MarginTransferred(address,int256)");
+
+    function emitMarginTransferred(address account, int marginDelta) internal {
+        proxy._emit(abi.encode(marginDelta), 2, SIG_MARGINTRANSFERRED, addressToBytes32(account), 0, 0);
     }
 
     event OrderSubmitted(
@@ -1112,26 +1137,15 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
         );
     }
 
-    event OrderConfirmed(uint indexed id, address indexed account, uint margin, int size, uint price, uint fundingIndex);
-    bytes32 internal constant SIG_ORDERCONFIRMED =
-        keccak256("OrderConfirmed(uint256,address,uint256,int256,uint256,uint256)");
+    event OrderConfirmed(uint indexed id, address indexed account, uint price);
+    bytes32 internal constant SIG_ORDERCONFIRMED = keccak256("OrderConfirmed(uint256,address,uint256)");
 
     function emitOrderConfirmed(
         uint id,
         address account,
-        uint margin,
-        int size,
-        uint price,
-        uint fundingIndex
+        uint price
     ) internal {
-        proxy._emit(
-            abi.encode(margin, size, price, fundingIndex),
-            3,
-            SIG_ORDERCONFIRMED,
-            bytes32(id),
-            addressToBytes32(account),
-            0
-        );
+        proxy._emit(abi.encode(price), 3, SIG_ORDERCONFIRMED, bytes32(id), addressToBytes32(account), 0);
     }
 
     event OrderCancelled(uint indexed id, address indexed account);
@@ -1141,17 +1155,39 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
         proxy._emit(abi.encode(), 3, SIG_ORDERCANCELLED, bytes32(id), addressToBytes32(account), 0);
     }
 
-    event PositionLiquidated(address indexed account, address indexed liquidator, int size, uint price);
-    bytes32 internal constant SIG_POSITIONLIQUIDATED = keccak256("PositionLiquidated(address,address,int256,uint256)");
+    event PositionModified(address indexed account, uint margin, int size, uint lastPrice, uint fundingIndex);
+    bytes32 internal constant SIG_POSITIONMODIFIED = keccak256("PositionModified(address,uint256,int256,uint256,uint256)");
+
+    function emitPositionModified(
+        address account,
+        uint margin,
+        int size,
+        uint lastPrice,
+        uint fundingIndex
+    ) internal {
+        proxy._emit(
+            abi.encode(margin, size, lastPrice, fundingIndex),
+            2,
+            SIG_POSITIONMODIFIED,
+            addressToBytes32(account),
+            0,
+            0
+        );
+    }
+
+    event PositionLiquidated(address indexed account, address indexed liquidator, int size, uint price, uint fee);
+    bytes32 internal constant SIG_POSITIONLIQUIDATED =
+        keccak256("PositionLiquidated(address,address,int256,uint256,uint256)");
 
     function emitPositionLiquidated(
         address account,
         address liquidator,
         int size,
-        uint price
+        uint price,
+        uint fee
     ) internal {
         proxy._emit(
-            abi.encode(size, price),
+            abi.encode(size, price, fee),
             3,
             SIG_POSITIONLIQUIDATED,
             addressToBytes32(account),
@@ -1159,4 +1195,6 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
             0
         );
     }
+
+    // TODO: funding recomputed
 }

--- a/contracts/FuturesMarket.sol
+++ b/contracts/FuturesMarket.sol
@@ -1081,13 +1081,6 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
         return bytes32(uint256(uint160(input)));
     }
 
-    event ParameterUpdated(bytes32 indexed parameter, uint value);
-    bytes32 internal constant SIG_PARAMETERUPDATED = keccak256("ParameterUpdated(bytes32,uint256)");
-
-    function emitParameterUpdated(bytes32 parameter, uint value) internal {
-        proxy._emit(abi.encode(value), 2, SIG_PARAMETERUPDATED, parameter, 0, 0);
-    }
-
     event OrderSubmitted(
         uint indexed id,
         address indexed account,

--- a/contracts/FuturesMarket.sol
+++ b/contracts/FuturesMarket.sol
@@ -745,8 +745,10 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
     function _recomputeFunding(uint price) internal returns (uint lastIndex) {
         uint sequenceLength = fundingSequence.length;
 
-        fundingSequence.push(_nextFundingEntry(sequenceLength, price));
+        int funding = _nextFundingEntry(sequenceLength, price);
+        fundingSequence.push(funding);
         fundingLastRecomputed = block.timestamp;
+        emitFundingRecomputed(funding);
 
         return sequenceLength;
     }
@@ -1196,5 +1198,10 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
         );
     }
 
-    // TODO: funding recomputed
+    event FundingRecomputed(int funding);
+    bytes32 internal constant SIG_FUNDINGRECOMPUTED = keccak256("FundingRecomputed(int256)");
+
+    function emitFundingRecomputed(int funding) internal {
+        proxy._emit(abi.encode(funding), 1, SIG_FUNDINGRECOMPUTED, 0, 0, 0);
+    }
 }

--- a/contracts/interfaces/IFuturesMarket.sol
+++ b/contracts/interfaces/IFuturesMarket.sol
@@ -145,7 +145,7 @@ interface IFuturesMarket {
 
     function recomputeFunding() external returns (uint lastIndex);
 
-    function modifyMargin(int marginDelta) external;
+    function transferMargin(int marginDelta) external;
 
     function withdrawAllMargin() external;
 
@@ -161,14 +161,14 @@ interface IFuturesMarket {
 
     function closePosition() external;
 
-    function modifyMarginAndSubmitOrderWithPriceBounds(
+    function transferMarginAndSubmitOrderWithPriceBounds(
         int marginDelta,
         int leverage,
         uint minPrice,
         uint maxPrice
     ) external;
 
-    function modifyMarginAndSubmitOrder(int marginDelta, int leverage) external;
+    function transferMarginAndSubmitOrder(int marginDelta, int leverage) external;
 
     function confirmOrder(address account) external;
 

--- a/test/contracts/FuturesMarket.js
+++ b/test/contracts/FuturesMarket.js
@@ -93,14 +93,14 @@ contract('FuturesMarket', accounts => {
 		});
 	}
 
-	async function modifyMarginSubmitAndConfirmOrder({
+	async function transferMarginSubmitAndConfirmOrder({
 		market,
 		account,
 		fillPrice,
 		marginDelta,
 		leverage,
 	}) {
-		await market.modifyMarginAndSubmitOrder(marginDelta, leverage, {
+		await market.transferMarginAndSubmitOrder(marginDelta, leverage, {
 			from: account,
 		});
 		await confirmOrder({
@@ -171,14 +171,14 @@ contract('FuturesMarket', accounts => {
 				abi: futuresMarket.abi,
 				ignoreParents: ['Owned', 'Proxyable', 'MixinFuturesMarketSettings'],
 				expected: [
-					'modifyMargin',
+					'transferMargin',
 					'withdrawAllMargin',
 					'submitOrder',
 					'submitOrderWithPriceBounds',
 					'cancelOrder',
 					'closePosition',
-					'modifyMarginAndSubmitOrder',
-					'modifyMarginAndSubmitOrderWithPriceBounds',
+					'transferMarginAndSubmitOrder',
+					'transferMarginAndSubmitOrderWithPriceBounds',
 					'confirmOrder',
 					'liquidatePosition',
 					'recomputeFunding',
@@ -217,7 +217,7 @@ contract('FuturesMarket', accounts => {
 			assert.bnEqual(await futuresMarket.marketSkew(), toUnit('0'));
 			assert.bnEqual(await futuresMarket.proportionalSkew(), toUnit('0'));
 
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader,
 				fillPrice: toUnit('100'),
@@ -232,7 +232,7 @@ contract('FuturesMarket', accounts => {
 			assert.bnEqual(await futuresMarket.marketSkew(), toUnit('50'));
 			assert.bnEqual(await futuresMarket.proportionalSkew(), toUnit('1'));
 
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader2,
 				fillPrice: toUnit('120'),
@@ -313,7 +313,7 @@ contract('FuturesMarket', accounts => {
 
 			describe(`${side}`, () => {
 				it('Ensure that the order fee (both maker and taker) is correct when the order is actually submitted', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader2,
 						fillPrice: toUnit('100'),
@@ -321,7 +321,7 @@ contract('FuturesMarket', accounts => {
 						leverage,
 					});
 
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
@@ -338,7 +338,7 @@ contract('FuturesMarket', accounts => {
 					const fee = multiplyDecimalRound(notionalTaker, takerFee).add(
 						multiplyDecimalRound(notionalMaker, makerFee)
 					);
-					await futuresMarket.modifyMargin(margin.mul(toBN(2)), { from: trader });
+					await futuresMarket.transferMargin(margin.mul(toBN(2)), { from: trader });
 					assert.bnClose(
 						(await futuresMarket.orderFee(trader, leverage.neg()))[0],
 						fee,
@@ -370,7 +370,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('Submit a fresh order on the same side as the skew', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader2,
 						fillPrice: toUnit('100'),
@@ -387,7 +387,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it(`Submit a fresh order on the opposite side to the skew smaller than the skew`, async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader2,
 						fillPrice: toUnit('100'),
@@ -405,7 +405,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('Submit a fresh order on the opposite side to the skew larger than the skew', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader2,
 						fillPrice: toUnit('100'),
@@ -422,7 +422,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('Increase an existing position on the side of the skew', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
@@ -441,7 +441,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('Increase an existing position opposite to the skew smaller than the skew', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader2,
 						fillPrice: toUnit('100'),
@@ -449,7 +449,7 @@ contract('FuturesMarket', accounts => {
 						leverage,
 					});
 
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
@@ -475,7 +475,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('Increase an existing position opposite to the skew larger than the skew', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader2,
 						fillPrice: toUnit('100'),
@@ -483,7 +483,7 @@ contract('FuturesMarket', accounts => {
 						leverage,
 					});
 
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
@@ -511,7 +511,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('reduce an existing position on the side of the skew', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
@@ -534,7 +534,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('reduce an existing position opposite to the skew', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader2,
 						fillPrice: toUnit('100'),
@@ -542,7 +542,7 @@ contract('FuturesMarket', accounts => {
 						leverage,
 					});
 
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
@@ -568,7 +568,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('close an existing position on the side of the skew', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
@@ -592,7 +592,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('close an existing position opposite to the skew', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader2,
 						fillPrice: toUnit('100'),
@@ -600,7 +600,7 @@ contract('FuturesMarket', accounts => {
 						leverage,
 					});
 
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
@@ -624,7 +624,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('Updated order, on the same side as the skew, on the opposite side of an existing position', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader2,
 						fillPrice: toUnit('100'),
@@ -632,7 +632,7 @@ contract('FuturesMarket', accounts => {
 						leverage,
 					});
 
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
@@ -648,7 +648,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('Updated order, opposite and smaller than the skew, on opposite side of an existing position', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader2,
 						fillPrice: toUnit('100'),
@@ -656,7 +656,7 @@ contract('FuturesMarket', accounts => {
 						leverage,
 					});
 
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
@@ -682,7 +682,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('Updated order, opposite and larger than the skew, on the opposite side of an existing position', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader2,
 						fillPrice: toUnit('100'),
@@ -690,7 +690,7 @@ contract('FuturesMarket', accounts => {
 						leverage,
 					});
 
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
@@ -712,7 +712,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('Updated order, opposite and larger than the skew, except that an existing opposite-side order increases the skew when closed', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader2,
 						fillPrice: toUnit('100'),
@@ -720,7 +720,7 @@ contract('FuturesMarket', accounts => {
 						leverage,
 					});
 
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
@@ -746,7 +746,7 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('Updated order, opposite and larger than the skew, on the opposite side of an existing position (2)', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader2,
 						fillPrice: toUnit('100'),
@@ -754,7 +754,7 @@ contract('FuturesMarket', accounts => {
 						leverage,
 					});
 
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader3,
 						fillPrice: toUnit('100'),
@@ -762,7 +762,7 @@ contract('FuturesMarket', accounts => {
 						leverage: leverage.neg(),
 					});
 
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
@@ -794,7 +794,7 @@ contract('FuturesMarket', accounts => {
 					});
 
 					it('reduce an existing position on the side of the skew', async () => {
-						await modifyMarginSubmitAndConfirmOrder({
+						await transferMarginSubmitAndConfirmOrder({
 							market: futuresMarket,
 							account: trader,
 							fillPrice: toUnit('100'),
@@ -827,7 +827,7 @@ contract('FuturesMarket', accounts => {
 					});
 
 					it('reduce an existing position opposite to the skew', async () => {
-						await modifyMarginSubmitAndConfirmOrder({
+						await transferMarginSubmitAndConfirmOrder({
 							market: futuresMarket,
 							account: trader2,
 							fillPrice: toUnit('100'),
@@ -835,7 +835,7 @@ contract('FuturesMarket', accounts => {
 							leverage,
 						});
 
-						await modifyMarginSubmitAndConfirmOrder({
+						await transferMarginSubmitAndConfirmOrder({
 							market: futuresMarket,
 							account: trader,
 							fillPrice: toUnit('100'),
@@ -868,7 +868,7 @@ contract('FuturesMarket', accounts => {
 					});
 
 					it('close an existing position on the side of the skew', async () => {
-						await modifyMarginSubmitAndConfirmOrder({
+						await transferMarginSubmitAndConfirmOrder({
 							market: futuresMarket,
 							account: trader,
 							fillPrice: toUnit('100'),
@@ -903,7 +903,7 @@ contract('FuturesMarket', accounts => {
 					});
 
 					it('close an existing position opposite to the skew', async () => {
-						await modifyMarginSubmitAndConfirmOrder({
+						await transferMarginSubmitAndConfirmOrder({
 							market: futuresMarket,
 							account: trader2,
 							fillPrice: toUnit('100'),
@@ -911,7 +911,7 @@ contract('FuturesMarket', accounts => {
 							leverage,
 						});
 
-						await modifyMarginSubmitAndConfirmOrder({
+						await transferMarginSubmitAndConfirmOrder({
 							market: futuresMarket,
 							account: trader,
 							fillPrice: toUnit('100'),
@@ -944,8 +944,8 @@ contract('FuturesMarket', accounts => {
 		}
 	});
 
-	describe('Modifying margin', () => {
-		it.skip('Modifying margin updates margin, last price, funding index, but not size', async () => {
+	describe('Transferring margin', () => {
+		it.skip('Transferring margin updates margin, last price, funding index, but not size', async () => {
 			assert.isTrue(false);
 		});
 
@@ -953,35 +953,35 @@ contract('FuturesMarket', accounts => {
 			it(`Can't deposit more sUSD than owned`, async () => {
 				const preBalance = await sUSD.balanceOf(trader);
 				await assert.revert(
-					futuresMarket.modifyMargin(preBalance.add(toUnit('1')), { from: trader }),
+					futuresMarket.transferMargin(preBalance.add(toUnit('1')), { from: trader }),
 					'subtraction overflow'
 				);
 			});
 
 			it(`Can't withdraw more sUSD than is in the margin`, async () => {
-				await futuresMarket.modifyMargin(toUnit('100'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('100'), { from: trader });
 				await assert.revert(
-					futuresMarket.modifyMargin(toUnit('-101'), { from: trader }),
+					futuresMarket.transferMargin(toUnit('-101'), { from: trader }),
 					'Insufficient margin'
 				);
 			});
 
 			it('Positive delta -> burn sUSD', async () => {
 				const preBalance = await sUSD.balanceOf(trader);
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				assert.bnEqual(await sUSD.balanceOf(trader), preBalance.sub(toUnit('1000')));
 			});
 
 			it('Negative delta -> mint sUSD', async () => {
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				const preBalance = await sUSD.balanceOf(trader);
-				await futuresMarket.modifyMargin(toUnit('-500'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('-500'), { from: trader });
 				assert.bnEqual(await sUSD.balanceOf(trader), preBalance.add(toUnit('500')));
 			});
 
 			it('Zero delta -> NOP', async () => {
 				const preBalance = await sUSD.balanceOf(trader);
-				await futuresMarket.modifyMargin(toUnit('0'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('0'), { from: trader });
 				assert.bnEqual(await sUSD.balanceOf(trader), preBalance.sub(toUnit('0')));
 			});
 
@@ -1000,60 +1000,132 @@ contract('FuturesMarket', accounts => {
 
 				// Set up a starting balance
 				const preBalance = await sUSD.balanceOf(trader);
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 
 				// Now set a reclamation event
 				await mockExchanger.setReclaim(toUnit('10'));
 				await mockExchanger.setNumEntries('1');
 
 				// Issuance works fine
-				await futuresMarket.modifyMargin(toUnit('-900'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('-900'), { from: trader });
 				assert.bnEqual(await sUSD.balanceOf(trader), preBalance.sub(toUnit('100')));
 				assert.bnEqual((await futuresMarket.remainingMargin(trader))[0], toUnit('100'));
 
 				// But burning properly deducts the reclamation amount
-				await futuresMarket.modifyMargin(preBalance.sub(toUnit('100')), { from: trader });
+				await futuresMarket.transferMargin(preBalance.sub(toUnit('100')), { from: trader });
 				assert.bnEqual(await sUSD.balanceOf(owner), toUnit('0'));
 				assert.bnEqual(
 					(await futuresMarket.remainingMargin(trader))[0],
 					preBalance.sub(toUnit('10'))
 				);
 			});
+
+			it('events are emitted properly', async () => {
+				// Deposit some balance
+				let tx = await futuresMarket.transferMargin(toUnit('1000'), { from: trader3 });
+				let decodedLogs = await getDecodedLogs({
+					hash: tx.tx,
+					contracts: [futuresMarketManager, sUSD, futuresMarket],
+				});
+
+				decodedEventEqual({
+					event: 'Burned',
+					emittedFrom: sUSD.address,
+					args: [trader3, toUnit('1000')],
+					log: decodedLogs[1],
+				});
+
+				decodedEventEqual({
+					event: 'MarginTransferred',
+					emittedFrom: proxyFuturesMarket.address,
+					args: [trader3, toUnit('1000')],
+					log: decodedLogs[2],
+				});
+
+				decodedEventEqual({
+					event: 'PositionModified',
+					emittedFrom: proxyFuturesMarket.address,
+					args: [trader3, toUnit('1000'), toBN('0'), toBN('0'), toBN('0')],
+					log: decodedLogs[3],
+				});
+
+				// Zero delta means no MarginTransferred or sUSD events
+				tx = await futuresMarket.transferMargin(toUnit('0'), { from: trader3 });
+				decodedLogs = await getDecodedLogs({
+					hash: tx.tx,
+					contracts: [futuresMarketManager, sUSD, futuresMarket],
+				});
+
+				decodedEventEqual({
+					event: 'PositionModified',
+					emittedFrom: proxyFuturesMarket.address,
+					args: [trader3, toUnit('1000'), toBN('0'), toBN('0'), toBN('0')],
+					log: decodedLogs[0],
+				});
+
+				// Now withdraw the margin back out
+				tx = await futuresMarket.transferMargin(toUnit('-1000'), { from: trader3 });
+				decodedLogs = await getDecodedLogs({
+					hash: tx.tx,
+					contracts: [futuresMarketManager, sUSD, futuresMarket],
+				});
+
+				decodedEventEqual({
+					event: 'Issued',
+					emittedFrom: sUSD.address,
+					args: [trader3, toUnit('1000')],
+					log: decodedLogs[0],
+				});
+
+				decodedEventEqual({
+					event: 'MarginTransferred',
+					emittedFrom: proxyFuturesMarket.address,
+					args: [trader3, toUnit('-1000')],
+					log: decodedLogs[1],
+				});
+
+				decodedEventEqual({
+					event: 'PositionModified',
+					emittedFrom: proxyFuturesMarket.address,
+					args: [trader3, toUnit('0'), toBN('0'), toBN('0'), toBN('0')],
+					log: decodedLogs[2],
+				});
+			});
 		});
 
 		describe('No position', async () => {
 			it('New margin', async () => {
 				assert.bnEqual((await futuresMarket.positions(trader)).margin, toBN(0));
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				assert.bnEqual((await futuresMarket.positions(trader)).margin, toUnit('1000'));
 			});
 
 			it('Increase margin', async () => {
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				assert.bnEqual((await futuresMarket.positions(trader)).margin, toUnit('2000'));
 			});
 
 			it('Decrease margin', async () => {
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyMargin(toUnit('-500'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('-500'), { from: trader });
 				assert.bnEqual((await futuresMarket.positions(trader)).margin, toUnit('500'));
 			});
 
 			it('Abolish margin', async () => {
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyMargin(toUnit('-1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('-1000'), { from: trader });
 				assert.bnEqual((await futuresMarket.positions(trader)).margin, toUnit('0'));
 			});
 
 			it('Cannot decrease margin past zero.', async () => {
 				await assert.revert(
-					futuresMarket.modifyMargin(toUnit('-1'), { from: trader }),
+					futuresMarket.transferMargin(toUnit('-1'), { from: trader }),
 					'Insufficient margin'
 				);
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				await assert.revert(
-					futuresMarket.modifyMargin(toUnit('-2000'), { from: trader }),
+					futuresMarket.transferMargin(toUnit('-2000'), { from: trader }),
 					'Insufficient margin'
 				);
 			});
@@ -1080,7 +1152,7 @@ contract('FuturesMarket', accounts => {
 				assert.isTrue(false);
 			});
 
-			it.skip('Modifying margin realises profit and funding', async () => {
+			it.skip('Transferring margin realises profit and funding', async () => {
 				assert.isTrue(false);
 			});
 		});
@@ -1089,7 +1161,7 @@ contract('FuturesMarket', accounts => {
 	describe('Submitting orders', () => {
 		it('can successfully submit an order', async () => {
 			const margin = toUnit('1000');
-			await futuresMarket.modifyMargin(margin, { from: trader });
+			await futuresMarket.transferMargin(margin, { from: trader });
 
 			const leverage = toUnit('10');
 			const fee = (await futuresMarket.orderFee(trader, leverage))[0];
@@ -1124,7 +1196,7 @@ contract('FuturesMarket', accounts => {
 		it('order size updates with new prices', async () => {
 			const margin = toUnit('1000');
 			const leverage = toUnit('10');
-			await futuresMarket.modifyMarginAndSubmitOrder(margin, leverage, { from: trader });
+			await futuresMarket.transferMarginAndSubmitOrder(margin, leverage, { from: trader });
 			let orderSize = (await futuresMarket.orderSize(trader))[0];
 
 			const notional = margin.mul(toBN(10));
@@ -1138,8 +1210,8 @@ contract('FuturesMarket', accounts => {
 
 		it('submitting orders increments the order id', async () => {
 			const margin = toUnit('200');
-			await futuresMarket.modifyMargin(margin, { from: trader });
-			await futuresMarket.modifyMargin(margin, { from: trader2 });
+			await futuresMarket.transferMargin(margin, { from: trader });
+			await futuresMarket.transferMargin(margin, { from: trader2 });
 
 			const leverage = toUnit('5');
 
@@ -1153,7 +1225,7 @@ contract('FuturesMarket', accounts => {
 
 		it('submitting a second order cancels the first one.', async () => {
 			const margin = toUnit('1000');
-			await futuresMarket.modifyMargin(margin, { from: trader });
+			await futuresMarket.transferMargin(margin, { from: trader });
 
 			const leverage = toUnit('10');
 			const fee = (await futuresMarket.orderFee(trader, leverage))[0];
@@ -1176,7 +1248,7 @@ contract('FuturesMarket', accounts => {
 			await setPrice(baseAsset, price);
 
 			const margin2 = toUnit('500');
-			await futuresMarket.modifyMargin(margin2.sub(margin), { from: trader });
+			await futuresMarket.transferMargin(margin2.sub(margin), { from: trader });
 			const leverage2 = toUnit('5');
 			const fee2 = (await futuresMarket.orderFee(trader, leverage2))[0];
 
@@ -1220,7 +1292,7 @@ contract('FuturesMarket', accounts => {
 		});
 
 		it('max leverage cannot be exceeded', async () => {
-			await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+			await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 			await assert.revert(
 				futuresMarket.submitOrder(toUnit('10.1'), { from: trader }),
 				'Max leverage exceeded'
@@ -1233,7 +1305,7 @@ contract('FuturesMarket', accounts => {
 		});
 
 		it('min margin must be provided', async () => {
-			await futuresMarket.modifyMargin(toUnit('99'), { from: trader });
+			await futuresMarket.transferMargin(toUnit('99'), { from: trader });
 			await assert.revert(
 				futuresMarket.submitOrder(toUnit('10'), { from: trader }),
 				'Insufficient margin'
@@ -1259,7 +1331,7 @@ contract('FuturesMarket', accounts => {
 
 				// 400 units submitted, out of 666.66.. available
 				newPrice = toUnit('150');
-				await modifyMarginSubmitAndConfirmOrder({
+				await transferMarginSubmitAndConfirmOrder({
 					market: futuresMarket,
 					account: trader,
 					fillPrice: newPrice,
@@ -1275,7 +1347,7 @@ contract('FuturesMarket', accounts => {
 				assert.bnEqual(maxOrderSizes.short, divideDecimalRound(maxMarketValue, newPrice));
 
 				// Submit order on the other side, removing all available supply.
-				await modifyMarginSubmitAndConfirmOrder({
+				await transferMarginSubmitAndConfirmOrder({
 					market: futuresMarket,
 					account: trader2,
 					fillPrice: newPrice,
@@ -1291,7 +1363,7 @@ contract('FuturesMarket', accounts => {
 				assert.bnEqual(maxOrderSizes.short, toUnit('0'));
 
 				// An additional few units on the long side by another trader
-				await modifyMarginSubmitAndConfirmOrder({
+				await transferMarginSubmitAndConfirmOrder({
 					market: futuresMarket,
 					account: trader3,
 					fillPrice: newPrice,
@@ -1344,14 +1416,14 @@ contract('FuturesMarket', accounts => {
 					});
 
 					it('Orders are blocked if they exceed max market size', async () => {
-						await futuresMarket.modifyMargin(maxMargin.add(toUnit('11')), { from: trader });
+						await futuresMarket.transferMargin(maxMargin.add(toUnit('11')), { from: trader });
 						await assert.revert(
 							futuresMarket.submitOrder(leverage, { from: trader }),
 							'Max market size exceeded'
 						);
 
 						// orders are allowed a bit over the formal limit to account for rounding etc.
-						await futuresMarket.modifyMargin(toUnit('1').neg(), { from: trader });
+						await futuresMarket.transferMargin(toUnit('1').neg(), { from: trader });
 						await futuresMarket.submitOrder(leverage, { from: trader });
 					});
 
@@ -1359,7 +1431,7 @@ contract('FuturesMarket', accounts => {
 						const unitLeverage = divideDecimalRound(leverage, leverage.abs());
 
 						// Confirm a big order
-						await futuresMarket.modifyMargin(maxMargin.mul(toBN(8)), {
+						await futuresMarket.transferMargin(maxMargin.mul(toBN(8)), {
 							from: trader,
 						});
 						await futuresMarket.submitOrder(unitLeverage, { from: trader });
@@ -1367,7 +1439,7 @@ contract('FuturesMarket', accounts => {
 						await futuresMarket.confirmOrder(trader);
 
 						// Try to submit an order that's too big for the market
-						await futuresMarket.modifyMargin(maxMargin.mul(toBN(3)), {
+						await futuresMarket.transferMargin(maxMargin.mul(toBN(3)), {
 							from: trader,
 						});
 						await assert.revert(
@@ -1376,7 +1448,7 @@ contract('FuturesMarket', accounts => {
 						);
 
 						// Submit an order that's not too big, then the price will spike
-						await futuresMarket.modifyMargin(maxMargin.mul(toBN(2)).neg(), {
+						await futuresMarket.transferMargin(maxMargin.mul(toBN(2)).neg(), {
 							from: trader,
 						});
 						await futuresMarket.submitOrder(unitLeverage, { from: trader });
@@ -1396,14 +1468,14 @@ contract('FuturesMarket', accounts => {
 
 					it('Orders are allowed a touch of extra size to account for price motion on confirmation', async () => {
 						// Ensure there's some existing order size for prices to shunt around.
-						await futuresMarket.modifyMargin(maxMargin.div(toBN(10)).mul(toBN(7)), {
+						await futuresMarket.transferMargin(maxMargin.div(toBN(10)).mul(toBN(7)), {
 							from: trader2,
 						});
 						await futuresMarket.submitOrder(leverage, { from: trader2 });
 						await setPrice(baseAsset, toUnit('1'));
 						await futuresMarket.confirmOrder(trader2);
 
-						await futuresMarket.modifyMargin(maxMargin.div(toBN(10)).mul(toBN(3)), {
+						await futuresMarket.transferMargin(maxMargin.div(toBN(10)).mul(toBN(3)), {
 							from: trader,
 						});
 						await futuresMarket.submitOrder(leverage, { from: trader });
@@ -1433,7 +1505,7 @@ contract('FuturesMarket', accounts => {
 							.mul(toBN('106'))
 							.div(toBN('3'));
 						for (const trader_ of [trader, trader2, trader3]) {
-							await futuresMarket.modifyMargin(margin, {
+							await futuresMarket.transferMargin(margin, {
 								from: trader_,
 							});
 							await futuresMarket.submitOrder(leverage, { from: trader_ });
@@ -1460,29 +1532,29 @@ contract('FuturesMarket', accounts => {
 
 					it('Orders are allowed to reduce in size (or close) even if the result is still over the max', async () => {
 						const unitLeverage = divideDecimalRound(leverage, leverage.abs());
-						const initialMargin = maxMargin.mul(toBN('5'));
+						const initialMargin = maxMargin.mul(toBN('8'));
 
-						await futuresMarket.modifyMargin(initialMargin, {
+						await futuresMarket.transferMargin(initialMargin, {
 							from: trader,
 						});
 						await futuresMarket.submitOrder(unitLeverage, { from: trader });
 						await setPrice(baseAsset, toUnit('1'));
 						await futuresMarket.confirmOrder(trader);
 
-						// Now exceed max size
-						await setPrice(baseAsset, toUnit('2.5'));
+						// Now exceed max size (but price isn't so high that shorts would be liquidated)
+						await setPrice(baseAsset, toUnit('1.9'));
 
 						const sizes = await futuresMarket.maxOrderSizes();
 						assert.bnEqual(sizes[leverage.gt(toBN('0')) ? 0 : 1], toBN('0'));
 
 						// Reduce the order size, even though we are above the maximum
-						await futuresMarket.modifyMargin(initialMargin.sub(toUnit('0.01')), {
+						await futuresMarket.transferMargin(initialMargin.sub(toUnit('0.01')), {
 							from: trader,
 						});
 						await futuresMarket.submitOrder((await futuresMarket.currentLeverage(trader))[0], {
 							from: trader,
 						});
-						await setPrice(baseAsset, toUnit('2.5'));
+						await setPrice(baseAsset, toUnit('1.9'));
 						assert.isTrue(await futuresMarket.canConfirmOrder(trader));
 						await futuresMarket.confirmOrder(trader);
 					});
@@ -1491,7 +1563,7 @@ contract('FuturesMarket', accounts => {
 		});
 
 		it('Cannot submit an order if an existing position needs to be liquidated', async () => {
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader,
 				fillPrice: toUnit('100'),
@@ -1511,7 +1583,7 @@ contract('FuturesMarket', accounts => {
 	describe('Cancelling orders', () => {
 		it('can successfully cancel an order', async () => {
 			const margin = toUnit('1000');
-			await futuresMarket.modifyMargin(margin, { from: trader });
+			await futuresMarket.transferMargin(margin, { from: trader });
 			const preBalance = await sUSD.balanceOf(trader);
 
 			const leverage = toUnit('10');
@@ -1546,7 +1618,7 @@ contract('FuturesMarket', accounts => {
 		});
 
 		it('Can still cancel an order, even if an existing position needs to be liquidated', async () => {
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader,
 				fillPrice: toUnit('100'),
@@ -1567,7 +1639,7 @@ contract('FuturesMarket', accounts => {
 	describe('Confirming orders', () => {
 		it('can confirm a pending order once a new price arrives', async () => {
 			const margin = toUnit('1000');
-			await futuresMarket.modifyMargin(margin, { from: trader });
+			await futuresMarket.transferMargin(margin, { from: trader });
 			const leverage = toUnit('10');
 			const fee = (await futuresMarket.orderFee(trader, leverage))[0];
 			await futuresMarket.submitOrder(leverage, { from: trader });
@@ -1609,7 +1681,7 @@ contract('FuturesMarket', accounts => {
 			// And the relevant events are properly emitted
 			const id = toBN(1);
 			const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
-			assert.equal(decodedLogs.length, 2);
+			assert.equal(decodedLogs.length, 3);
 			decodedEventEqual({
 				event: 'Issued',
 				emittedFrom: sUSD.address,
@@ -1617,16 +1689,22 @@ contract('FuturesMarket', accounts => {
 				log: decodedLogs[0],
 			});
 			decodedEventEqual({
+				event: 'PositionModified',
+				emittedFrom: proxyFuturesMarket.address,
+				args: [trader, margin.sub(fee), size, price, toBN(2)],
+				log: decodedLogs[1],
+			});
+			decodedEventEqual({
 				event: 'OrderConfirmed',
 				emittedFrom: proxyFuturesMarket.address,
-				args: [id, trader, margin.sub(fee), size, price, toBN(2)],
-				log: decodedLogs[1],
+				args: [id, trader, price],
+				log: decodedLogs[2],
 			});
 		});
 
 		it('cannot confirm a pending order before a price has arrived', async () => {
 			const margin = toUnit('1000');
-			await futuresMarket.modifyMargin(margin, { from: trader });
+			await futuresMarket.transferMargin(margin, { from: trader });
 			const leverage = toUnit('10');
 			await futuresMarket.submitOrder(leverage, { from: trader });
 
@@ -1643,7 +1721,7 @@ contract('FuturesMarket', accounts => {
 
 		it('Cannot confirm an order if the price is invalid', async () => {
 			const margin = toUnit('1000');
-			await futuresMarket.modifyMargin(margin, { from: trader });
+			await futuresMarket.transferMargin(margin, { from: trader });
 			const leverage = toUnit('10');
 			await futuresMarket.submitOrder(leverage, { from: trader });
 
@@ -1665,7 +1743,7 @@ contract('FuturesMarket', accounts => {
 			await setPrice(baseAsset, startPrice);
 
 			const margin = toUnit('1000');
-			await futuresMarket.modifyMargin(margin, { from: trader });
+			await futuresMarket.transferMargin(margin, { from: trader });
 			const leverage = toUnit('10');
 			const maxSlippage = toUnit('0.01'); // 1% in either direction
 			const minPrice = startPrice.mul(toUnit(1).sub(maxSlippage));
@@ -1675,7 +1753,7 @@ contract('FuturesMarket', accounts => {
 				from: trader,
 			});
 
-			await futuresMarket.modifyMarginAndSubmitOrderWithPriceBounds(
+			await futuresMarket.transferMarginAndSubmitOrderWithPriceBounds(
 				margin,
 				leverage,
 				minPrice,
@@ -1701,7 +1779,7 @@ contract('FuturesMarket', accounts => {
 		});
 
 		it('Cannot confirm an order if an existing position is liquidating', async () => {
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader,
 				fillPrice: toUnit('200'),
@@ -1732,7 +1810,7 @@ contract('FuturesMarket', accounts => {
 			const fee = (
 				await futuresMarket.orderFeeWithMarginDelta(trader, toUnit('1000'), toUnit('10'))
 			)[0];
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader,
 				fillPrice: toUnit('200'),
@@ -1748,7 +1826,7 @@ contract('FuturesMarket', accounts => {
 	describe('Closing positions', () => {
 		it('can close an open position once a new price arrives', async () => {
 			const margin = toUnit('1000');
-			await futuresMarket.modifyMargin(margin, { from: trader });
+			await futuresMarket.transferMargin(margin, { from: trader });
 			const leverage = toUnit('10');
 			await futuresMarket.submitOrder(leverage, { from: trader });
 
@@ -1786,7 +1864,7 @@ contract('FuturesMarket', accounts => {
 
 		it('closing positions fails if a new price has not been set.', async () => {
 			const margin = toUnit('1000');
-			await futuresMarket.modifyMargin(margin, { from: trader });
+			await futuresMarket.transferMargin(margin, { from: trader });
 
 			const leverage = toUnit('10');
 			await futuresMarket.submitOrder(leverage, { from: trader });
@@ -1800,7 +1878,7 @@ contract('FuturesMarket', accounts => {
 		});
 
 		it('closing a position cancels any open orders.', async () => {
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader,
 				fillPrice: toUnit('100'),
@@ -1854,7 +1932,7 @@ contract('FuturesMarket', accounts => {
 		});
 
 		it('Cannot close a position if it is liquidating', async () => {
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader,
 				fillPrice: toUnit('200'),
@@ -1870,17 +1948,50 @@ contract('FuturesMarket', accounts => {
 			);
 		});
 
-		it.skip('Can close positions even if the max market size constraints are violated', async () => {
-			assert.isTrue(false);
+		it('confirming a position closure emits the appropriate event', async () => {
+			await transferMarginSubmitAndConfirmOrder({
+				market: futuresMarket,
+				account: trader,
+				fillPrice: toUnit('100'),
+				marginDelta: toUnit('1000'),
+				leverage: toUnit('1'),
+			});
+
+			await futuresMarket.closePosition({ from: trader });
+			const orderId = (await futuresMarket.orders(trader))[0];
+
+			await setPrice(baseAsset, toUnit('200'));
+			const tx = await futuresMarket.confirmOrder(trader);
+
+			const decodedLogs = await getDecodedLogs({
+				hash: tx.tx,
+				contracts: [futuresMarketManager, sUSD, futuresMarket],
+			});
+
+			// No fee => no fee minting log
+			assert.equal(decodedLogs.length, 2);
+			decodedEventEqual({
+				event: 'PositionModified',
+				emittedFrom: proxyFuturesMarket.address,
+				args: [trader, toUnit('2000'), toBN('0'), toBN('0'), toBN('0')],
+				log: decodedLogs[0],
+				bnCloseVariance: toUnit('5'),
+			});
+			decodedEventEqual({
+				event: 'OrderConfirmed',
+				emittedFrom: proxyFuturesMarket.address,
+				args: [orderId, trader, toUnit('200')],
+				log: decodedLogs[1],
+			});
 		});
 	});
 
 	describe('Profit & Loss, margin, leverage', () => {
 		describe('PnL', () => {
 			beforeEach(async () => {
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				await futuresMarket.submitOrder(toUnit('5'), { from: trader });
-				await futuresMarket.modifyMargin(toUnit('4000'), { from: trader2 });
+				await futuresMarket.transferMargin(toUnit('4000'), { from: trader2 });
 				await futuresMarket.submitOrder(toUnit('-1'), { from: trader2 });
 
 				await setPrice(baseAsset, toUnit('100'));
@@ -1927,9 +2038,9 @@ contract('FuturesMarket', accounts => {
 					await futuresMarket.orderFeeWithMarginDelta(trader, toUnit('5000'), toUnit('-1'))
 				)[0];
 
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				await futuresMarket.submitOrder(toUnit('5'), { from: trader });
-				await futuresMarket.modifyMargin(toUnit('5000'), { from: trader2 });
+				await futuresMarket.transferMargin(toUnit('5000'), { from: trader2 });
 				await futuresMarket.submitOrder(toUnit('-1'), { from: trader2 });
 
 				await setPrice(baseAsset, toUnit('100'));
@@ -1995,9 +2106,9 @@ contract('FuturesMarket', accounts => {
 			it('current leverage', async () => {
 				let price = toUnit(100);
 
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				await futuresMarket.submitOrder(toUnit('5'), { from: trader });
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader2 });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
 				await futuresMarket.submitOrder(toUnit('-10'), { from: trader2 });
 
 				await setPrice(baseAsset, price);
@@ -2039,7 +2150,7 @@ contract('FuturesMarket', accounts => {
 			});
 
 			it('current leverage can be less than 1', async () => {
-				await modifyMarginSubmitAndConfirmOrder({
+				await transferMarginSubmitAndConfirmOrder({
 					market: futuresMarket,
 					account: trader,
 					fillPrice: toUnit('100'),
@@ -2094,7 +2205,7 @@ contract('FuturesMarket', accounts => {
 				['10', trader],
 				['-10', trader2],
 			]) {
-				await modifyMarginSubmitAndConfirmOrder({
+				await transferMarginSubmitAndConfirmOrder({
 					market: futuresMarket,
 					account: leverageTrader[1],
 					fillPrice: toUnit('100'),
@@ -2110,7 +2221,7 @@ contract('FuturesMarket', accounts => {
 				['1000', '5', trader],
 				['2000', '-2.5', trader2],
 			]) {
-				await modifyMarginSubmitAndConfirmOrder({
+				await transferMarginSubmitAndConfirmOrder({
 					market: futuresMarket,
 					account: marginLeverageTrader[2],
 					fillPrice: toUnit('100'),
@@ -2125,7 +2236,7 @@ contract('FuturesMarket', accounts => {
 			// Market is balanced
 			assert.bnEqual(await futuresMarket.currentFundingRate(), toUnit(0));
 
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader,
 				fillPrice: toUnit('250'),
@@ -2133,7 +2244,7 @@ contract('FuturesMarket', accounts => {
 				leverage: toUnit('3'),
 			});
 
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader2,
 				fillPrice: toUnit('250'),
@@ -2193,7 +2304,7 @@ contract('FuturesMarket', accounts => {
 			// 0, +-50%, +-100%
 			assert.bnEqual(await futuresMarket.currentFundingRate(), toUnit(0));
 
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader,
 				fillPrice: toUnit('250'),
@@ -2201,7 +2312,7 @@ contract('FuturesMarket', accounts => {
 				leverage: toUnit('3'),
 			});
 
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader2,
 				fillPrice: toUnit('250'),
@@ -2218,7 +2329,7 @@ contract('FuturesMarket', accounts => {
 		});
 
 		it('Altering the max funding rate skew has a proportional effect', async () => {
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader,
 				fillPrice: toUnit('250'),
@@ -2226,7 +2337,7 @@ contract('FuturesMarket', accounts => {
 				leverage: toUnit('-3'),
 			});
 
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader2,
 				fillPrice: toUnit('250'),
@@ -2252,7 +2363,7 @@ contract('FuturesMarket', accounts => {
 
 			describe(`${side}`, () => {
 				it('100% skew induces maximum funding rate', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
@@ -2266,14 +2377,14 @@ contract('FuturesMarket', accounts => {
 				});
 
 				it('Different skew rates induce proportional funding levels', async () => {
-					await modifyMarginSubmitAndConfirmOrder({
+					await transferMarginSubmitAndConfirmOrder({
 						market: futuresMarket,
 						account: trader,
 						fillPrice: toUnit('100'),
 						marginDelta: toUnit('1000'),
 						leverage,
 					});
-					await futuresMarket.modifyMargin(toUnit('1000'), { from: trader2 });
+					await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
 
 					const points = 5;
 
@@ -2353,7 +2464,7 @@ contract('FuturesMarket', accounts => {
 			beforeEach(async () => {
 				// Set up some market skew so that funding is being incurred.
 				// Proportional Skew = 0.5, so funding rate is 0.05 per day.
-				await modifyMarginSubmitAndConfirmOrder({
+				await transferMarginSubmitAndConfirmOrder({
 					market: futuresMarket,
 					account: trader,
 					fillPrice: price,
@@ -2361,7 +2472,7 @@ contract('FuturesMarket', accounts => {
 					leverage: toUnit('9'),
 				});
 
-				await modifyMarginSubmitAndConfirmOrder({
+				await transferMarginSubmitAndConfirmOrder({
 					market: futuresMarket,
 					account: trader2,
 					fillPrice: price,
@@ -2390,7 +2501,7 @@ contract('FuturesMarket', accounts => {
 				assert.isTrue(false);
 			});
 
-			it.skip('Funding sequence is recomputed by margin modification', async () => {
+			it.skip('Funding sequence is recomputed by margin transfers', async () => {
 				assert.isTrue(false);
 			});
 
@@ -2478,7 +2589,7 @@ contract('FuturesMarket', accounts => {
 				await futuresMarket.orderFeeWithMarginDelta(trader, toUnit('1000'), toUnit('5'))
 			)[0];
 
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader,
 				fillPrice: toUnit('100'),
@@ -2493,7 +2604,7 @@ contract('FuturesMarket', accounts => {
 				await futuresMarket.orderFeeWithMarginDelta(trader, toUnit('600'), toUnit('-7'))
 			)[0];
 
-			await modifyMarginSubmitAndConfirmOrder({
+			await transferMarginSubmitAndConfirmOrder({
 				market: futuresMarket,
 				account: trader2,
 				fillPrice: toUnit('120'),
@@ -2578,16 +2689,16 @@ contract('FuturesMarket', accounts => {
 		});
 
 		describe('Market debt is accurately reflected in total system debt', () => {
-			it('Margin modification does not alter total system debt', async () => {
+			it('Margin transfers do not alter total system debt', async () => {
 				const debt = (await debtCache.currentDebt())[0];
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				assert.bnEqual((await debtCache.currentDebt())[0], debt);
-				await futuresMarket.modifyMargin(toUnit('-500'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('-500'), { from: trader });
 				assert.bnEqual((await debtCache.currentDebt())[0], debt);
 			});
 
 			it('Prices altering market debt are reflected in total system debt', async () => {
-				await modifyMarginSubmitAndConfirmOrder({
+				await transferMarginSubmitAndConfirmOrder({
 					market: futuresMarket,
 					account: trader,
 					fillPrice: toUnit('100'),
@@ -2595,7 +2706,7 @@ contract('FuturesMarket', accounts => {
 					leverage: toUnit('10'),
 				});
 
-				await modifyMarginSubmitAndConfirmOrder({
+				await transferMarginSubmitAndConfirmOrder({
 					market: futuresMarket,
 					account: trader2,
 					fillPrice: toUnit('100'),
@@ -2618,9 +2729,9 @@ contract('FuturesMarket', accounts => {
 	describe('Liquidations', () => {
 		describe('Liquidation price', () => {
 			it('Liquidation price is accurate with no funding', async () => {
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				await futuresMarket.submitOrder(toUnit('10'), { from: trader });
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader2 });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
 				await futuresMarket.submitOrder(toUnit('-10'), { from: trader2 });
 
 				await setPrice(baseAsset, toUnit('100'));
@@ -2646,9 +2757,9 @@ contract('FuturesMarket', accounts => {
 			});
 
 			it('Liquidation price is accurate if the liquidation fee changes', async () => {
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				await futuresMarket.submitOrder(toUnit('5'), { from: trader });
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader2 });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
 				await futuresMarket.submitOrder(toUnit('-5'), { from: trader2 });
 
 				await setPrice(baseAsset, toUnit('250'));
@@ -2696,9 +2807,9 @@ contract('FuturesMarket', accounts => {
 
 			it('Liquidation price is accurate with funding', async () => {
 				// Submit orders that induce -0.05 funding rate
-				await futuresMarket.modifyMargin(toUnit('1500'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1500'), { from: trader });
 				await futuresMarket.submitOrder(toUnit('5'), { from: trader });
-				await futuresMarket.modifyMargin(toUnit('500'), { from: trader2 });
+				await futuresMarket.transferMargin(toUnit('500'), { from: trader2 });
 				await futuresMarket.submitOrder(toUnit('-5'), { from: trader2 });
 
 				await setPrice(baseAsset, toUnit('250'));
@@ -2728,9 +2839,9 @@ contract('FuturesMarket', accounts => {
 			});
 
 			it('Liquidation price reports invalidity properly', async () => {
-				await futuresMarket.modifyMargin(toUnit('1500'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1500'), { from: trader });
 				await futuresMarket.submitOrder(toUnit('5'), { from: trader });
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader2 });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
 				await futuresMarket.submitOrder(toUnit('-5'), { from: trader2 });
 
 				await setPrice(baseAsset, toUnit('250'));
@@ -2774,7 +2885,7 @@ contract('FuturesMarket', accounts => {
 
 		describe('canLiquidate', () => {
 			it('Can liquidate an underwater position', async () => {
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				await futuresMarket.submitOrder(toUnit('5'), { from: trader });
 				let price = toUnit('250');
 				await setPrice(baseAsset, price);
@@ -2791,7 +2902,7 @@ contract('FuturesMarket', accounts => {
 			});
 
 			it('No liquidations while prices are invalid', async () => {
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				await futuresMarket.submitOrder(toUnit('5'), { from: trader });
 
 				await setPrice(baseAsset, toUnit('250'));
@@ -2806,11 +2917,11 @@ contract('FuturesMarket', accounts => {
 
 		describe('liquidatePosition', () => {
 			beforeEach(async () => {
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				await futuresMarket.submitOrder(toUnit('10'), { from: trader });
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader2 });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
 				await futuresMarket.submitOrder(toUnit('5'), { from: trader2 });
-				await futuresMarket.modifyMargin(toUnit('1000'), { from: trader3 });
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader3 });
 				await futuresMarket.submitOrder(toUnit('-5'), { from: trader3 });
 
 				await setPrice(baseAsset, toUnit('250'));
@@ -2943,7 +3054,7 @@ contract('FuturesMarket', accounts => {
 
 				const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
 
-				assert.equal(decodedLogs.length, 2);
+				assert.equal(decodedLogs.length, 3);
 				decodedEventEqual({
 					event: 'Issued',
 					emittedFrom: sUSD.address,
@@ -2951,10 +3062,16 @@ contract('FuturesMarket', accounts => {
 					log: decodedLogs[0],
 				});
 				decodedEventEqual({
+					event: 'PositionModified',
+					emittedFrom: proxyFuturesMarket.address,
+					args: [trader, toBN('0'), toBN('0'), toBN('0'), toBN('0')],
+					log: decodedLogs[1],
+				});
+				decodedEventEqual({
 					event: 'PositionLiquidated',
 					emittedFrom: proxyFuturesMarket.address,
-					args: [trader, noBalance, positionSize, price],
-					log: decodedLogs[1],
+					args: [trader, noBalance, positionSize, price, liquidationFee],
+					log: decodedLogs[2],
 					bnCloseVariance: toUnit('0.001'),
 				});
 			});
@@ -2979,7 +3096,7 @@ contract('FuturesMarket', accounts => {
 
 				const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
 
-				assert.equal(decodedLogs.length, 2);
+				assert.equal(decodedLogs.length, 3);
 				decodedEventEqual({
 					event: 'Issued',
 					emittedFrom: sUSD.address,
@@ -2987,10 +3104,16 @@ contract('FuturesMarket', accounts => {
 					log: decodedLogs[0],
 				});
 				decodedEventEqual({
+					event: 'PositionModified',
+					emittedFrom: proxyFuturesMarket.address,
+					args: [trader3, toBN('0'), toBN('0'), toBN('0'), toBN('0')],
+					log: decodedLogs[1],
+				});
+				decodedEventEqual({
 					event: 'PositionLiquidated',
 					emittedFrom: proxyFuturesMarket.address,
-					args: [trader3, noBalance, positionSize, price],
-					log: decodedLogs[1],
+					args: [trader3, noBalance, positionSize, price, liquidationFee],
+					log: decodedLogs[2],
 					bnCloseVariance: toUnit('0.001'),
 				});
 			});
@@ -3018,10 +3141,16 @@ contract('FuturesMarket', accounts => {
 
 				const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
 				decodedEventEqual({
+					event: 'PositionModified',
+					emittedFrom: proxyFuturesMarket.address,
+					args: [trader, toBN('0'), toBN('0'), toBN('0'), toBN('0')],
+					log: decodedLogs[1],
+				});
+				decodedEventEqual({
 					event: 'PositionLiquidated',
 					emittedFrom: proxyFuturesMarket.address,
-					args: [trader, noBalance, positionSize, price],
-					log: decodedLogs[1],
+					args: [trader, noBalance, positionSize, price, toUnit('100')],
+					log: decodedLogs[2],
 					bnCloseVariance: toUnit('0.001'),
 				});
 			});

--- a/test/contracts/FuturesMarket.js
+++ b/test/contracts/FuturesMarket.js
@@ -355,7 +355,7 @@ contract('FuturesMarket', accounts => {
 						event: 'OrderSubmitted',
 						emittedFrom: proxyFuturesMarket.address,
 						args: [toBN(3), trader, leverage.neg(), fee, await futuresMarket.currentRoundId()],
-						log: decodedLogs[0],
+						log: decodedLogs[1],
 						bnCloseVariance: toUnit('0.001'),
 					});
 				});
@@ -946,6 +946,8 @@ contract('FuturesMarket', accounts => {
 
 	describe('Transferring margin', () => {
 		it.skip('Transferring margin updates margin, last price, funding index, but not size', async () => {
+			// We'll need to distinguish between the size = 0 case, when last price and index are not altered,
+			// and the size > 0 case, when last price and index ARE altered.
 			assert.isTrue(false);
 		});
 
@@ -1020,7 +1022,7 @@ contract('FuturesMarket', accounts => {
 				);
 			});
 
-			it('events are emitted properly', async () => {
+			it('events are emitted properly upon margin transfers', async () => {
 				// Deposit some balance
 				let tx = await futuresMarket.transferMargin(toUnit('1000'), { from: trader3 });
 				let decodedLogs = await getDecodedLogs({
@@ -1032,21 +1034,21 @@ contract('FuturesMarket', accounts => {
 					event: 'Burned',
 					emittedFrom: sUSD.address,
 					args: [trader3, toUnit('1000')],
-					log: decodedLogs[1],
+					log: decodedLogs[2],
 				});
 
 				decodedEventEqual({
 					event: 'MarginTransferred',
 					emittedFrom: proxyFuturesMarket.address,
 					args: [trader3, toUnit('1000')],
-					log: decodedLogs[2],
+					log: decodedLogs[3],
 				});
 
 				decodedEventEqual({
 					event: 'PositionModified',
 					emittedFrom: proxyFuturesMarket.address,
 					args: [trader3, toUnit('1000'), toBN('0'), toBN('0'), toBN('0')],
-					log: decodedLogs[3],
+					log: decodedLogs[4],
 				});
 
 				// Zero delta means no MarginTransferred or sUSD events
@@ -1060,7 +1062,7 @@ contract('FuturesMarket', accounts => {
 					event: 'PositionModified',
 					emittedFrom: proxyFuturesMarket.address,
 					args: [trader3, toUnit('1000'), toBN('0'), toBN('0'), toBN('0')],
-					log: decodedLogs[0],
+					log: decodedLogs[1],
 				});
 
 				// Now withdraw the margin back out
@@ -1074,21 +1076,21 @@ contract('FuturesMarket', accounts => {
 					event: 'Issued',
 					emittedFrom: sUSD.address,
 					args: [trader3, toUnit('1000')],
-					log: decodedLogs[0],
+					log: decodedLogs[1],
 				});
 
 				decodedEventEqual({
 					event: 'MarginTransferred',
 					emittedFrom: proxyFuturesMarket.address,
 					args: [trader3, toUnit('-1000')],
-					log: decodedLogs[1],
+					log: decodedLogs[2],
 				});
 
 				decodedEventEqual({
 					event: 'PositionModified',
 					emittedFrom: proxyFuturesMarket.address,
 					args: [trader3, toUnit('0'), toBN('0'), toBN('0'), toBN('0')],
-					log: decodedLogs[2],
+					log: decodedLogs[3],
 				});
 			});
 		});
@@ -1184,12 +1186,12 @@ contract('FuturesMarket', accounts => {
 
 			// And it properly emits the relevant events.
 			const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [futuresMarket] });
-			assert.equal(decodedLogs.length, 1);
+			assert.equal(decodedLogs.length, 2);
 			decodedEventEqual({
 				event: 'OrderSubmitted',
 				emittedFrom: proxyFuturesMarket.address,
 				args: [id, trader, leverage, fee, roundId, defaultPriceBounds[0], defaultPriceBounds[1]],
-				log: decodedLogs[0],
+				log: decodedLogs[1],
 			});
 		});
 
@@ -1268,12 +1270,12 @@ contract('FuturesMarket', accounts => {
 
 			// And it properly emits the relevant events.
 			const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
-			assert.equal(decodedLogs.length, 2);
+			assert.equal(decodedLogs.length, 3);
 			decodedEventEqual({
 				event: 'OrderCancelled',
 				emittedFrom: proxyFuturesMarket.address,
 				args: [id1, trader],
-				log: decodedLogs[0],
+				log: decodedLogs[1],
 			});
 			decodedEventEqual({
 				event: 'OrderSubmitted',
@@ -1287,7 +1289,7 @@ contract('FuturesMarket', accounts => {
 					defaultPriceBounds[0],
 					defaultPriceBounds[1],
 				],
-				log: decodedLogs[1],
+				log: decodedLogs[2],
 			});
 		});
 
@@ -1681,24 +1683,24 @@ contract('FuturesMarket', accounts => {
 			// And the relevant events are properly emitted
 			const id = toBN(1);
 			const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
-			assert.equal(decodedLogs.length, 3);
+			assert.equal(decodedLogs.length, 4);
 			decodedEventEqual({
 				event: 'Issued',
 				emittedFrom: sUSD.address,
 				args: [await feePool.FEE_ADDRESS(), fee],
-				log: decodedLogs[0],
+				log: decodedLogs[1],
 			});
 			decodedEventEqual({
 				event: 'PositionModified',
 				emittedFrom: proxyFuturesMarket.address,
 				args: [trader, margin.sub(fee), size, price, toBN(2)],
-				log: decodedLogs[1],
+				log: decodedLogs[2],
 			});
 			decodedEventEqual({
 				event: 'OrderConfirmed',
 				emittedFrom: proxyFuturesMarket.address,
 				args: [id, trader, price],
-				log: decodedLogs[2],
+				log: decodedLogs[3],
 			});
 		});
 
@@ -1899,12 +1901,12 @@ contract('FuturesMarket', accounts => {
 
 			const tx = await futuresMarket.closePosition({ from: trader });
 			const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
-			assert.equal(decodedLogs.length, 2);
+			assert.equal(decodedLogs.length, 3);
 			decodedEventEqual({
 				event: 'OrderCancelled',
 				emittedFrom: proxyFuturesMarket.address,
 				args: [order.id, trader],
-				log: decodedLogs[0],
+				log: decodedLogs[1],
 			});
 			decodedEventEqual({
 				event: 'OrderSubmitted',
@@ -1918,7 +1920,7 @@ contract('FuturesMarket', accounts => {
 					defaultPriceBounds[0],
 					defaultPriceBounds[1],
 				],
-				log: decodedLogs[1],
+				log: decodedLogs[2],
 			});
 
 			assert.isTrue(await futuresMarket.orderPending(trader));
@@ -1969,19 +1971,19 @@ contract('FuturesMarket', accounts => {
 			});
 
 			// No fee => no fee minting log
-			assert.equal(decodedLogs.length, 2);
+			assert.equal(decodedLogs.length, 3);
 			decodedEventEqual({
 				event: 'PositionModified',
 				emittedFrom: proxyFuturesMarket.address,
 				args: [trader, toUnit('2000'), toBN('0'), toBN('0'), toBN('0')],
-				log: decodedLogs[0],
+				log: decodedLogs[1],
 				bnCloseVariance: toUnit('5'),
 			});
 			decodedEventEqual({
 				event: 'OrderConfirmed',
 				emittedFrom: proxyFuturesMarket.address,
 				args: [orderId, trader, toUnit('200')],
-				log: decodedLogs[1],
+				log: decodedLogs[2],
 			});
 		});
 	});
@@ -3054,24 +3056,24 @@ contract('FuturesMarket', accounts => {
 
 				const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
 
-				assert.equal(decodedLogs.length, 3);
+				assert.equal(decodedLogs.length, 4);
 				decodedEventEqual({
 					event: 'Issued',
 					emittedFrom: sUSD.address,
 					args: [noBalance, liquidationFee],
-					log: decodedLogs[0],
+					log: decodedLogs[1],
 				});
 				decodedEventEqual({
 					event: 'PositionModified',
 					emittedFrom: proxyFuturesMarket.address,
 					args: [trader, toBN('0'), toBN('0'), toBN('0'), toBN('0')],
-					log: decodedLogs[1],
+					log: decodedLogs[2],
 				});
 				decodedEventEqual({
 					event: 'PositionLiquidated',
 					emittedFrom: proxyFuturesMarket.address,
 					args: [trader, noBalance, positionSize, price, liquidationFee],
-					log: decodedLogs[2],
+					log: decodedLogs[3],
 					bnCloseVariance: toUnit('0.001'),
 				});
 			});
@@ -3096,24 +3098,24 @@ contract('FuturesMarket', accounts => {
 
 				const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
 
-				assert.equal(decodedLogs.length, 3);
+				assert.equal(decodedLogs.length, 4);
 				decodedEventEqual({
 					event: 'Issued',
 					emittedFrom: sUSD.address,
 					args: [noBalance, liquidationFee],
-					log: decodedLogs[0],
+					log: decodedLogs[1],
 				});
 				decodedEventEqual({
 					event: 'PositionModified',
 					emittedFrom: proxyFuturesMarket.address,
 					args: [trader3, toBN('0'), toBN('0'), toBN('0'), toBN('0')],
-					log: decodedLogs[1],
+					log: decodedLogs[2],
 				});
 				decodedEventEqual({
 					event: 'PositionLiquidated',
 					emittedFrom: proxyFuturesMarket.address,
 					args: [trader3, noBalance, positionSize, price, liquidationFee],
-					log: decodedLogs[2],
+					log: decodedLogs[3],
 					bnCloseVariance: toUnit('0.001'),
 				});
 			});
@@ -3144,13 +3146,13 @@ contract('FuturesMarket', accounts => {
 					event: 'PositionModified',
 					emittedFrom: proxyFuturesMarket.address,
 					args: [trader, toBN('0'), toBN('0'), toBN('0'), toBN('0')],
-					log: decodedLogs[1],
+					log: decodedLogs[2],
 				});
 				decodedEventEqual({
 					event: 'PositionLiquidated',
 					emittedFrom: proxyFuturesMarket.address,
 					args: [trader, noBalance, positionSize, price, toUnit('100')],
-					log: decodedLogs[2],
+					log: decodedLogs[3],
 					bnCloseVariance: toUnit('0.001'),
 				});
 			});
@@ -3171,7 +3173,7 @@ contract('FuturesMarket', accounts => {
 					event: 'OrderCancelled',
 					emittedFrom: proxyFuturesMarket.address,
 					args: [order.id, trader],
-					log: decodedLogs[0],
+					log: decodedLogs[1],
 					bnCloseVariance: toUnit('0.001'),
 				});
 

--- a/test/contracts/FuturesMarketData.js
+++ b/test/contracts/FuturesMarketData.js
@@ -112,10 +112,10 @@ contract('FuturesMarketData', accounts => {
 		await sUSD.issue(trader3, traderInitialBalance);
 
 		// The traders take positions on market
-		await futuresMarket.modifyMargin(toUnit('1000'), { from: trader1 });
+		await futuresMarket.transferMargin(toUnit('1000'), { from: trader1 });
 		await futuresMarket.submitOrder(toUnit('5'), { from: trader1 });
 
-		await futuresMarket.modifyMargin(toUnit('750'), { from: trader2 });
+		await futuresMarket.transferMargin(toUnit('750'), { from: trader2 });
 		await futuresMarket.submitOrder(toUnit('-10'), { from: trader2 });
 
 		await exchangeRates.updateRates([baseAsset], [toUnit('100')], await currentTime(), {
@@ -124,12 +124,12 @@ contract('FuturesMarketData', accounts => {
 		await futuresMarket.confirmOrder(trader1);
 		await futuresMarket.confirmOrder(trader2);
 
-		await futuresMarket.modifyMargin(toUnit('4000'), { from: trader3 });
+		await futuresMarket.transferMargin(toUnit('4000'), { from: trader3 });
 		await futuresMarket.submitOrder(toUnit('1.25'), { from: trader3 });
 
 		sethMarket = await FuturesMarket.at(await futuresMarketManager.marketForAsset(newAsset));
 
-		await sethMarket.modifyMargin(toUnit('3000'), { from: trader3 });
+		await sethMarket.transferMargin(toUnit('3000'), { from: trader3 });
 		await sethMarket.submitOrder(toUnit('4'), { from: trader3 });
 		await exchangeRates.updateRates([newAsset], [toUnit('999')], await currentTime(), {
 			from: oracle,


### PR DESCRIPTION
- Adds a `PositionModified` event, to keep track of any changes made to a position, including by (involuntary) alterations to the margin balance when it is realised.
- Adds a `MarginTransferred` event, that tracks when a user has voluntarily deposited or withdrawn margin.
- Simplifies the `OrderConfirmed` event, moving most of its contents into the `PositionModified` event.
- 
- Deletes the redundant `ParameterUpdated` event, which was not properly cleaned up when settings were moved into a separate contract.
- Adds a `uint fee` field to the `PositionLiquidated` event, so we can track how much the liquidator was paid.
- Adds the `FundingRecomputed` event, to track all modifications of the funding sequence.
- Fixes a small bug where PnL and funding fields in a position were being updated when margin was being transferred, even if the user had no position open.
- Renames `modifyMargin` and related functions to `transferMargin`, in order to highlight that it was a deposit or a withdrawal, and not a modification due to profit or funding. The latter can now be inspected by examining `PositionModified` events.