### PR TITLE
Add ability to accept ownership on an array of contracts in the owner relay

### DIFF
--- a/contracts/OwnerRelayOnOptimism.sol
+++ b/contracts/OwnerRelayOnOptimism.sol
@@ -40,6 +40,12 @@ contract OwnerRelayOnOptimism is MixinResolver {
 
     /* ========== EXTERNAL ========== */
 
+    function acceptOwnershipOnBatch(address[] calldata targets) external {
+        for (uint i = 0; i < targets.length; i++) {
+            IOwned(targets[i]).acceptOwnership();
+        }
+    }
+
     function acceptOwnershipOn(address target) external {
         IOwned(target).acceptOwnership();
     }

--- a/test/contracts/OwnerRelayOnOptimism.js
+++ b/test/contracts/OwnerRelayOnOptimism.js
@@ -70,7 +70,7 @@ contract('OwnerRelayOnOptimism', () => {
 		ensureOnlyExpectedMutativeFunctions({
 			abi: artifacts.require('OwnerRelayOnOptimism').abi,
 			ignoreParents: ['Owned', 'MixinResolver'],
-			expected: ['finalizeRelay', 'acceptOwnershipOn'],
+			expected: ['finalizeRelay', 'acceptOwnershipOn', 'acceptOwnershipOnBatch'],
 		});
 	});
 
@@ -87,17 +87,46 @@ contract('OwnerRelayOnOptimism', () => {
 	});
 
 	describe('when accepting ownership by calling OwnerRelayOnOptimism directly', () => {
-		before('mock the target contract acceptOwnership() function', async () => {
-			MockedOwnedL2.smocked.acceptOwnership.will.return();
+		describe('when calling acceptOwnershipOn', () => {
+			before('mock the target contract acceptOwnership() function', async () => {
+				MockedOwnedL2.smocked.acceptOwnership.will.return();
+			});
+
+			before('call the target acceptOwnership() function via OwnerRelayOnOptimism', async () => {
+				const tx = await OwnerRelayOnOptimism.connect(owner).acceptOwnershipOn(
+					MockedOwnedL2.address
+				);
+				await tx.wait();
+			});
+
+			it('called the function on the target contract', async () => {
+				assert.equal(MockedOwnedL2.smocked.acceptOwnership.calls.length, 1);
+			});
 		});
 
-		before('call the target acceptOwnership() function via OwnerRelayOnOptimism', async () => {
-			const tx = await OwnerRelayOnOptimism.connect(owner).acceptOwnershipOn(MockedOwnedL2.address);
-			await tx.wait();
-		});
+		describe('when calling acceptOwnershipOnBatch', () => {
+			let MockedOwnedL2Alt1, MockedOwnedL2Alt2;
 
-		it('called the function on the target contract', async () => {
-			assert.equal(MockedOwnedL2.smocked.acceptOwnership.calls.length, 1);
+			before('mock a couple more contracts', async () => {
+				MockedOwnedL2Alt1 = await smockit(artifacts.require('Owned').abi, ethers.provider);
+				MockedOwnedL2Alt2 = await smockit(artifacts.require('Owned').abi, ethers.provider);
+			});
+
+			before(
+				'call the target acceptOwnership() function via OwnerRelayOnOptimism batched',
+				async () => {
+					const tx = await OwnerRelayOnOptimism.connect(owner).acceptOwnershipOnBatch([
+						MockedOwnedL2Alt1.address,
+						MockedOwnedL2Alt2.address,
+					]);
+					await tx.wait();
+				}
+			);
+
+			it('called the function on the target contracts', async () => {
+				assert.equal(MockedOwnedL2Alt1.smocked.acceptOwnership.calls.length, 1);
+				assert.equal(MockedOwnedL2Alt2.smocked.acceptOwnership.calls.length, 1);
+			});
 		});
 	});
 


### PR DESCRIPTION
Adds a `OwnerRelayOnOptimism.acceptOwnershipOnBatch` function to facilitate the action on many contracts.