### PR TITLE
Adding the next few releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,7 +45,7 @@ jobs:
       - run:
           name: Run integration tests on l1
           command: |
-            NEW_CONTRACTS=$(node bin.js releases --no-released)
+            NEW_CONTRACTS=$(node bin.js releases --unreleased --with-sources)
             if [ -z "$NEW_CONTRACTS" ]; then
               npx hardhat test:integration:l1 --use-fork
             else

--- a/.circleci/src/jobs/job-fork-tests.yml
+++ b/.circleci/src/jobs/job-fork-tests.yml
@@ -13,7 +13,7 @@ steps:
       name: Run integration tests on l1
       command: |
         # Only compile and deploy when there are new contracts
-        NEW_CONTRACTS=$(node bin.js releases --no-released)
+        NEW_CONTRACTS=$(node bin.js releases --unreleased --with-sources)
         if [ -z "$NEW_CONTRACTS" ]; then
           npx hardhat test:integration:l1 --use-fork
         else

--- a/bin.js
+++ b/bin.js
@@ -185,9 +185,12 @@ program
 program
 	.command('releases')
 	.description('Get the list of releases')
-	.option('--no-released', 'Only retreive the unreleased ones.')
-	.action(async ({ released }) => {
-		const result = releases.filter(release => release.released === released);
+	.option('--unreleased', 'Only retrieve the unreleased ones.')
+	.option('--with-sources', 'Only retrieve ones with files.')
+	.action(async ({ unreleased, withSources }) => {
+		const result = releases
+			.filter(release => release.released === !unreleased)
+			.filter(({ sources }) => (withSources ? sources.length > 0 : true));
 
 		if (result.length > 0) {
 			console.log(JSON.stringify(result, null, 2));

--- a/index.js
+++ b/index.js
@@ -84,6 +84,7 @@ const constants = {
 	AST_FOLDER: 'ast',
 
 	CONFIG_FILENAME: 'config.json',
+	RELEASES_FILENAME: 'releases.json',
 	PARAMS_FILENAME: 'params.json',
 	SYNTHS_FILENAME: 'synths.json',
 	STAKING_REWARDS_FILENAME: 'rewards.json',

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"license": "MIT",
 			"dependencies": {
 				"abi-decoder": "2.3.0",
-				"commander": "5.1.0",
+				"commander": "8.1.0",
 				"inquirer": "^6.5.2",
 				"inquirer-list-search-prompt": "^1.0.2",
 				"js-levenshtein": "^1.1.6",
@@ -6583,11 +6583,11 @@
 			"dev": true
 		},
 		"node_modules/commander": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.1.0.tgz",
+			"integrity": "sha512-mf45ldcuHSYShkplHHGKWb4TrmwQadxOn7v4WuhDJy0ZVoY5JFajaRDKD0PNe5qXzBX0rhovjTnP6Kz9LETcuA==",
 			"engines": {
-				"node": ">= 6"
+				"node": ">= 12"
 			}
 		},
 		"node_modules/commondir": {
@@ -33500,9 +33500,9 @@
 			"dev": true
 		},
 		"commander": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-			"integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg=="
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.1.0.tgz",
+			"integrity": "sha512-mf45ldcuHSYShkplHHGKWb4TrmwQadxOn7v4WuhDJy0ZVoY5JFajaRDKD0PNe5qXzBX0rhovjTnP6Kz9LETcuA=="
 		},
 		"commondir": {
 			"version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
 	},
 	"dependencies": {
 		"abi-decoder": "2.3.0",
-		"commander": "5.1.0",
+		"commander": "8.1.0",
 		"inquirer": "^6.5.2",
 		"inquirer-list-search-prompt": "^1.0.2",
 		"js-levenshtein": "^1.1.6",

--- a/publish/index.js
+++ b/publish/index.js
@@ -7,9 +7,11 @@ require('dotenv').config();
 
 require('./src/commands/build').cmd(program);
 require('./src/commands/connect-bridge').cmd(program);
+require('./src/commands/deploy-shorting-rewards').cmd(program);
 require('./src/commands/deploy-staking-rewards').cmd(program);
 require('./src/commands/deploy').cmd(program);
 require('./src/commands/extract-staking-balances').cmd(program);
+require('./src/commands/finalize-release').cmd(program);
 require('./src/commands/import-fee-periods').cmd(program);
 require('./src/commands/migrate-binary-option-markets').cmd(program);
 require('./src/commands/nominate').cmd(program);
@@ -25,6 +27,5 @@ require('./src/commands/settle').cmd(program);
 require('./src/commands/verify').cmd(program);
 require('./src/commands/versions-history').cmd(program);
 require('./src/commands/versions-update').cmd(program);
-require('./src/commands/deploy-shorting-rewards').cmd(program);
 
 program.parse(process.argv);

--- a/publish/releases.json
+++ b/publish/releases.json
@@ -306,6 +306,7 @@
 	},
 	{
 		"name": "Mirfak (Optimism)",
+		"ovm": true,
 		"released": false,
 		"version": {
 			"major": 2,

--- a/publish/releases.json
+++ b/publish/releases.json
@@ -389,7 +389,7 @@
 		"sips": []
 	},
 	{
-		"name": "Avoir (Optimism)",
+		"name": "Avior (Optimism)",
 		"ovm": true,
 		"released": false,
 		"version": {

--- a/publish/releases.json
+++ b/publish/releases.json
@@ -303,5 +303,141 @@
 			"SynthsUSD"
 		],
 		"sips": [142, 145, 170]
+	},
+	{
+		"name": "Mirfak (Optimism)",
+		"released": false,
+		"version": {
+			"major": 2,
+			"minor": 48
+		},
+		"sources": [],
+		"sips": []
+	},
+	{
+		"name": "Wezen",
+		"released": false,
+		"version": {
+			"major": 2,
+			"minor": 49
+		},
+		"sources": [],
+		"sips": []
+	},
+	{
+		"name": "Wezen (Optimism)",
+		"ovm": true,
+		"released": false,
+		"version": {
+			"major": 2,
+			"minor": 49
+		},
+		"sources": [],
+		"sips": []
+	},
+	{
+		"name": "Sargas",
+		"released": false,
+		"version": {
+			"major": 2,
+			"minor": 50
+		},
+		"sources": [],
+		"sips": []
+	},
+	{
+		"name": "Sargas (Optimism)",
+		"ovm": true,
+		"released": false,
+		"version": {
+			"major": 2,
+			"minor": 50
+		},
+		"sources": [],
+		"sips": []
+	},
+	{
+		"name": "Kaus",
+		"released": false,
+		"version": {
+			"major": 2,
+			"minor": 51
+		},
+		"sources": [],
+		"sips": []
+	},
+	{
+		"name": "Kaus (Optimism)",
+		"ovm": true,
+		"released": false,
+		"version": {
+			"major": 2,
+			"minor": 51
+		},
+		"sources": [],
+		"sips": []
+	},
+	{
+		"name": "Avior",
+		"released": false,
+		"version": {
+			"major": 2,
+			"minor": 52
+		},
+		"sources": [],
+		"sips": []
+	},
+	{
+		"name": "Avoir (Optimism)",
+		"ovm": true,
+		"released": false,
+		"version": {
+			"major": 2,
+			"minor": 52
+		},
+		"sources": [],
+		"sips": []
+	},
+	{
+		"name": "Alkaid",
+		"released": false,
+		"version": {
+			"major": 2,
+			"minor": 53
+		},
+		"sources": [],
+		"sips": []
+	},
+	{
+		"name": "Alkaid (Optimism)",
+		"ovm": true,
+		"released": false,
+		"version": {
+			"major": 2,
+			"minor": 53
+		},
+		"sources": [],
+		"sips": []
+	},
+	{
+		"name": "Menkalinan",
+		"released": false,
+		"version": {
+			"major": 2,
+			"minor": 54
+		},
+		"sources": [],
+		"sips": []
+	},
+	{
+		"name": "Menkalinan (Optimism)",
+		"ovm": true,
+		"released": false,
+		"version": {
+			"major": 2,
+			"minor": 54
+		},
+		"sources": [],
+		"sips": []
 	}
 ]

--- a/publish/src/commands/finalize-release.js
+++ b/publish/src/commands/finalize-release.js
@@ -6,7 +6,6 @@ const semver = require('semver');
 
 const prettier = require('prettier');
 
-// const { gray, yellow } = require('chalk');
 const { versionsUpdate } = require('./versions-update');
 const { stringify } = require('../util');
 

--- a/publish/src/commands/finalize-release.js
+++ b/publish/src/commands/finalize-release.js
@@ -1,0 +1,68 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const semver = require('semver');
+
+const prettier = require('prettier');
+
+// const { gray, yellow } = require('chalk');
+const { versionsUpdate } = require('./versions-update');
+const { stringify } = require('../util');
+
+const {
+	constants: { RELEASES_FILENAME },
+	releases,
+} = require('../../../.');
+
+const finalizeRelease = async ({ layer, release, versionTag, yes }) => {
+	// Write versions.json for whichever layer requires it
+	if (layer === 'base' || layer === 'both') {
+		await versionsUpdate({ release, useOvm: false, versionTag });
+	}
+	if (layer === 'ovm' || layer === 'both') {
+		await versionsUpdate({ release, useOvm: true, versionTag });
+	}
+
+	// Now modify releases.json locally for the released version
+	const major = semver.major(versionTag);
+	const minor = semver.minor(versionTag);
+
+	for (const release of releases) {
+		const versionMatch = release.version.major === major && release.version.minor === minor;
+
+		const layerMatch = (release.ovm && layer !== 'base') || (!release.ovm && layer !== 'ovm');
+
+		if (versionMatch && layerMatch) {
+			release.released = true;
+		}
+	}
+
+	// get json options
+	const options = await prettier.resolveConfig('.json');
+
+	// format correctly
+	const output = prettier.format(stringify(releases), Object.assign({ parser: 'json' }, options));
+
+	// write releases back
+	fs.writeFileSync(path.join(__dirname, '..', '..', RELEASES_FILENAME), output);
+};
+
+module.exports = {
+	finalizeRelease,
+	cmd: program =>
+		program
+			.command('finalize-release')
+			.description(
+				'Finalize a new release. This changes the files locally but does not commit anything.'
+			)
+			.addOption(
+				new program.Option('-l, --layer <value>', `The layer to release`)
+					.choices(['base', 'ovm', 'both'])
+					.makeOptionMandatory()
+			)
+			.requiredOption('-r, --release <value>', `The name of this release (e.g. Hadar)`)
+			.requiredOption('-v, --version-tag <value>', `The version number (e.g. "2.21.13-alpha")`)
+			.option('-y, --yes', "Don't prompt, just reply yes.")
+			.action(finalizeRelease),
+};

--- a/publish/src/commands/release.js
+++ b/publish/src/commands/release.js
@@ -5,23 +5,17 @@ const axios = require('axios').default; // use .default for ts typings
 
 const { confirmAction } = require('../util');
 
-const release = async ({ branch, release, version, yes }) => {
-	if (!branch) {
-		throw Error('Branch is missing');
-	} else if (!version) {
-		throw Error('Version is missing');
-	} else if (!release) {
-		throw Error('Release is missing');
-	} else if (!process.env.CIRCLECI_TOKEN) {
+const release = async ({ branch, release, version, layer, yes }) => {
+	if (!process.env.CIRCLECI_TOKEN) {
 		throw Error('Missing CIRCLECI_TOKEN - required to trigger the release');
 	}
 
 	if (!yes) {
 		try {
 			await confirmAction(
-				`\nWARNING: This will initiate a release of ${yellow(version)} from branch ${yellow(
-					branch
-				)} named ${yellow(release)}\n` +
+				`\nWARNING: This will initiate a ${yellow(layer)} release of ${yellow(
+					version
+				)} from branch ${yellow(branch)} named ${yellow(release)}\n` +
 					gray('-'.repeat(50)) +
 					'\nDo you want to continue? (y/n) '
 			);
@@ -45,6 +39,7 @@ const release = async ({ branch, release, version, yes }) => {
 				branch,
 				release,
 				version,
+				layer,
 			},
 		},
 	});
@@ -56,12 +51,17 @@ module.exports = {
 		program
 			.command('release')
 			.description('Initiate a new release')
-			.option(
+			.requiredOption(
 				'-b, --branch <value>',
 				'The branch of synthetix to release from (e.g. master, staging or develop)'
 			)
-			.option('-r, --release <value>', `The name of this release (e.g. Hadar)`)
-			.option('-v, --version <value>', `The version number (e.g. "2.21.13-alpha")`)
-			.option('-y, --yes', 'Dont prompt, just reply yes.')
+			.addOption(
+				new program.Option('-l, --layer <value>', `The layer to release`)
+					.choices(['base', 'ovm', 'both'])
+					.makeOptionMandatory()
+			)
+			.requiredOption('-r, --release <value>', `The name of this release (e.g. Hadar)`)
+			.requiredOption('-v, --version <value>', `The version number (e.g. "2.21.13-alpha")`)
+			.option('-y, --yes', "Don't prompt, just reply yes.")
 			.action(release),
 };

--- a/publish/src/commands/versions-update.js
+++ b/publish/src/commands/versions-update.js
@@ -30,7 +30,7 @@ const versionsUpdate = async ({ versionTag, release, useOvm }) => {
 		for (const tag of Object.keys(versions)) {
 			if (tag === versionTag) {
 				throw Error(`Version: ${versionTag} already used in network: ${network}`);
-			} else if (semver.lt(versionTag, semver.coerce(tag))) {
+			} else if (semver.lt(versionTag, semver.coerce(tag)) && !/-ovm$/.test(versionTag)) {
 				throw Error(
 					`Version: ${versionTag} is less than existing version ${tag} in network: ${network}`
 				);


### PR DESCRIPTION
In order to prevent confusion of adding and selecting releases, this PR preps a handful of upcoming releases. It also adds entries for each release in both L1 and OVM. 

The trick is ensuring that the release is marked as `true` once complete. So when a release is kicked off, either it starts `node publish release .... --layer ovm` or `--layer base` or `--layer both`.

## Tasks
1. Added `finalize-release` command to be run by releases pipeline (which both updates the version files and the releases.json) (the updating of the version files [was previously run by the releases pipeline](https://github.com/Synthetixio/releases/blob/master/.circleci/config.yml#L163) so this will be managed here going forward)
1. Updated the `releases` binary command to a) use `--unreleased` and b) use `--with-sources` and configured `job-fork-tests` to use this - so it only compiles and deploys when there are new sources to deploy
3. Upgraded `commander` to latest in order to get required choiced options
4. Added an additional parameter to the `releases` command to be sent to the releases CI pipeline.

## TODO Once merged

- [ ] Add step in releases CI pipeline to mark the deploy done (https://github.com/Synthetixio/releases/blob/master/.circleci/config.yml#L163) 