### PR TITLE
Remove price update constraint from order flow

### DIFF
--- a/contracts/FuturesMarketData.sol
+++ b/contracts/FuturesMarketData.sol
@@ -253,9 +253,8 @@ contract FuturesMarketData {
     }
 
     function _order(IFuturesMarket market, address account) internal view returns (IFuturesMarket.Order memory) {
-        (uint orderId, int orderLeverage, uint orderFee, uint orderRoundId, uint minPrice, uint maxPrice) =
-            market.orders(account);
-        return IFuturesMarket.Order(orderId, orderLeverage, orderFee, orderRoundId, minPrice, maxPrice);
+        (uint orderId, int orderLeverage, uint orderFee, uint minPrice, uint maxPrice) = market.orders(account);
+        return IFuturesMarket.Order(orderId, orderLeverage, orderFee, minPrice, maxPrice);
     }
 
     function _positionDetails(IFuturesMarket market, address account) internal view returns (PositionData memory) {

--- a/contracts/interfaces/IFuturesMarket.sol
+++ b/contracts/interfaces/IFuturesMarket.sol
@@ -22,7 +22,6 @@ interface IFuturesMarket {
         uint id;
         int leverage;
         uint fee;
-        uint roundId;
         uint minPrice;
         uint maxPrice;
     }
@@ -57,7 +56,6 @@ interface IFuturesMarket {
             uint id,
             int leverage,
             uint fee,
-            uint roundId,
             uint minPrice,
             uint maxPrice
         );

--- a/test/contracts/FuturesMarketData.js
+++ b/test/contracts/FuturesMarketData.js
@@ -202,7 +202,6 @@ contract('FuturesMarketData', accounts => {
 			assert.bnEqual(details.order.id, order.id);
 			assert.bnEqual(details.order.leverage, order.leverage);
 			assert.bnEqual(details.order.fee, order.fee);
-			assert.bnEqual(details.order.roundId, order.roundId);
 			assert.bnEqual(details.order.minPrice, order.minPrice);
 			assert.bnEqual(details.order.maxPrice, order.maxPrice);
 


### PR DESCRIPTION
We decided on Tuesday in Discord that in order to proceed with resolving https://github.com/Synthetixio/issues/issues/260, we would remove the price update constraint from order flow and use the spot price for order confirmation in futures.


To unblock the monsieur le frontend, this PR only removes logic, and doesn't refactor. I started on refactoring the submitOrder and confirmOrder into one func - there's a lot of work to be done in refactoring the code to work with instant confirms - eg. `canConfirmOrder` and `orderStatus` currently rely on the submitted order in storage, whereas now we should be passing the order as an argument. Same with the tests, moving price updates up before the submitOrder. 
