### PR TITLE
Fix nominate and owner scripts

### DIFF
--- a/publish/src/commands/connect-bridge.js
+++ b/publish/src/commands/connect-bridge.js
@@ -238,7 +238,7 @@ const setupInstance = async ({
 		useFork,
 		useOvm,
 	});
-	console.log(gray('  > provider:', provider.url));
+	console.log(gray('  > provider:', provider.connection.url));
 	console.log(gray('  > account:', wallet.address));
 
 	const AddressResolver = getContract({

--- a/publish/src/commands/nominate.js
+++ b/publish/src/commands/nominate.js
@@ -110,7 +110,14 @@ const nominate = async ({
 		}
 	}
 
+	const warnings = [];
 	for (const contract of contracts) {
+		if (!deployment.targets[contract]) {
+			const msg = yellow(`WARNING: contract ${contract} not found in deployment file`);
+			console.log(msg);
+			warnings.push(msg);
+			continue;
+		}
 		const { address, source } = deployment.targets[contract];
 		const { abi } = deployment.sources[source];
 		const deployedContract = new ethers.Contract(address, abi, wallet);
@@ -146,6 +153,12 @@ const nominate = async ({
 		} else {
 			console.log(gray('No change required.'));
 		}
+	}
+	if (warnings.length) {
+		console.log(yellow('\nThere were some issues nominating owner\n'));
+		console.log(yellow('---'));
+		warnings.forEach(warning => console.log(warning));
+		console.log(yellow('---'));
 	}
 };
 

--- a/publish/src/commands/owner.js
+++ b/publish/src/commands/owner.js
@@ -242,7 +242,14 @@ const owner = async ({
 	}
 
 	console.log(gray('Looking for contracts whose ownership we should accept'));
+	const warnings = [];
 	for (const contract of Object.keys(config)) {
+		if (!deployment.targets[contract]) {
+			const msg = yellow(`WARNING: contract ${contract} not found in deployment file`);
+			console.log(msg);
+			warnings.push(msg);
+			continue;
+		}
 		const { address, source } = deployment.targets[contract];
 		const { abi } = deployment.sources[source];
 		const deployedContract = new ethers.Contract(address, abi, provider);
@@ -337,6 +344,12 @@ const owner = async ({
 				)
 			);
 		}
+	}
+	if (warnings.length) {
+		console.log(yellow('\nThere were some issues nominating owner\n'));
+		console.log(yellow('---'));
+		warnings.forEach(warning => console.log(warning));
+		console.log(yellow('---'));
 	}
 };
 


### PR DESCRIPTION
Nominate and Owner scripts fails if any contract in config.json is not deployed (or present in deployment.json).
This PR adds a check on that condition and show a warning while trying to Nominate or Accept ownership.