### PR TITLE
Update stakingRewards to remove updatePeriodFinish

### DIFF
--- a/contracts/StakingRewards.sol
+++ b/contracts/StakingRewards.sol
@@ -132,11 +132,6 @@ contract StakingRewards is IStakingRewards, RewardsDistributionRecipient, Reentr
         emit RewardAdded(reward);
     }
 
-    // End rewards emission earlier
-    function updatePeriodFinish(uint timestamp) external onlyOwner updateReward(address(0)) {
-        periodFinish = timestamp;
-    }
-
     // Added to support recovering LP Rewards from other systems such as BAL to be distributed to holders
     function recoverERC20(address tokenAddress, uint256 tokenAmount) external onlyOwner {
         require(tokenAddress != address(stakingToken), "Cannot withdraw the staking token");

--- a/test/contracts/StakingRewards.js
+++ b/test/contracts/StakingRewards.js
@@ -567,26 +567,6 @@ contract('StakingRewards', accounts => {
 		});
 	});
 
-	describe('updatePeriodFinish()', () => {
-		const updateTimeStamp = toUnit('100');
-
-		before(async () => {
-			await stakingRewards.updatePeriodFinish(updateTimeStamp, {
-				from: owner,
-			});
-		});
-
-		it('should update periodFinish', async () => {
-			const periodFinish = await stakingRewards.periodFinish();
-			assert.bnEqual(periodFinish, updateTimeStamp);
-		});
-
-		it('should update rewardRate to zero', async () => {
-			const rewardRate = await stakingRewards.rewardRate();
-			assert.bnEqual(rewardRate, ZERO_BN);
-		});
-	});
-
 	describe('exit()', () => {
 		it('should retrieve all earned and increase rewards bal', async () => {
 			const totalToStake = toUnit('100');

--- a/test/contracts/StakingRewards.js
+++ b/test/contracts/StakingRewards.js
@@ -106,7 +106,6 @@ contract('StakingRewards', accounts => {
 				'setRewardsDistribution',
 				'setRewardsDuration',
 				'recoverERC20',
-				'updatePeriodFinish',
 			],
 		});
 	});
@@ -165,15 +164,6 @@ contract('StakingRewards', accounts => {
 			await onlyGivenAddressCanInvoke({
 				fnc: stakingRewards.setPaused,
 				args: [true],
-				address: owner,
-				accounts,
-			});
-		});
-
-		it('only owner can call updatePeriodFinish', async () => {
-			await onlyGivenAddressCanInvoke({
-				fnc: stakingRewards.updatePeriodFinish,
-				args: [0],
 				address: owner,
 				accounts,
 			});


### PR DESCRIPTION
Remove `updatePeriodFinish` owner function that had issue when the input timestamp was not validated and could result in the contract unable to update staker's rewards and withdraw their staked tokens.  

Owner only function should validate the timestamp input to be > block.timestamp. 

Remove function as required only for stopping reward emission on iETH and iBTC staking rewards which are no longer used.