### PR TITLE
Futures accessible margin

### DIFF
--- a/contracts/FuturesMarket.sol
+++ b/contracts/FuturesMarket.sol
@@ -543,8 +543,8 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
         // Ugly solution to rounding safety: leave up to an extra tenth of a cent in the account/leverage
         // This should guarantee that the value returned here can always been withdrawn, but there may be
         // a little extra actually-accessible value left over, depending on the position size and margin.
-        uint mill = uint(_UNIT / 1000);
-        int maxLeverage = int(_maxLeverage(baseAsset).sub(mill));
+        uint milli = uint(_UNIT / 1000);
+        int maxLeverage = int(_maxLeverage(baseAsset).sub(milli));
         uint inaccessible = _abs(_notionalValue(position, price).divideDecimalRound(maxLeverage));
 
         // If the user has a position open, we'll enforce a min initial margin requirement.
@@ -553,7 +553,7 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
             if (inaccessible < minInitialMargin) {
                 inaccessible = minInitialMargin;
             }
-            inaccessible = inaccessible.add(mill);
+            inaccessible = inaccessible.add(milli);
         }
 
         uint remaining = _remainingMargin(position, fundingIndex, price);

--- a/contracts/FuturesMarket.sol
+++ b/contracts/FuturesMarket.sol
@@ -991,17 +991,18 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
         if (positionSize != 0) {
             position.lastPrice = price;
             position.fundingIndex = fundingIndex;
-        }
 
-        // The user can decrease their margin if they have no position, or as long as:
-        //     * they have sufficient margin to do so
-        //     * the resulting margin would not be lower than the minimum margin
-        //     * the resulting leverage is lower than the maximum leverage
-        if (positionSize != 0 && marginDelta < 0) {
-            _revertIfError(
-                margin < _minInitialMargin() || _maxLeverage(baseAsset) < _abs(_currentLeverage(position, price, margin)),
-                Status.InsufficientMargin
-            );
+            // The user can always decrease their margin if they have no position, or as long as:
+            //     * they have sufficient margin to do so
+            //     * the resulting margin would not be lower than the minimum margin
+            //     * the resulting leverage is lower than the maximum leverage
+            if (marginDelta < 0) {
+                _revertIfError(
+                    margin < _minInitialMargin() ||
+                        _maxLeverage(baseAsset) < _abs(_currentLeverage(position, price, margin)),
+                    Status.InsufficientMargin
+                );
+            }
         }
 
         // Emit relevant events

--- a/contracts/FuturesMarketData.sol
+++ b/contracts/FuturesMarketData.sol
@@ -84,6 +84,7 @@ contract FuturesMarketData {
         int profitLoss;
         int accruedFunding;
         uint remainingMargin;
+        uint accessibleMargin;
         uint liquidationPrice;
         bool canLiquidatePosition;
     }
@@ -252,6 +253,11 @@ contract FuturesMarketData {
         return value;
     }
 
+    function _accessibleMargin(IFuturesMarket market, address account) internal view returns (uint) {
+        (uint value, ) = market.accessibleMargin(account);
+        return value;
+    }
+
     function _liquidationPrice(IFuturesMarket market, address account) internal view returns (uint) {
         (uint liquidationPrice, ) = market.liquidationPrice(account, true);
         return liquidationPrice;
@@ -265,6 +271,7 @@ contract FuturesMarketData {
                 _profitLoss(market, account),
                 _accruedFunding(market, account),
                 _remainingMargin(market, account),
+                _accessibleMargin(market, account),
                 _liquidationPrice(market, account),
                 market.canLiquidate(account)
             );

--- a/contracts/MixinFuturesMarketSettings.sol
+++ b/contracts/MixinFuturesMarketSettings.sol
@@ -7,9 +7,9 @@ import "./interfaces/IFlexibleStorage.sol";
 
 // https://docs.synthetix.io/contracts/source/contracts/MixinFuturesMarketSettings
 contract MixinFuturesMarketSettings is MixinResolver {
-    bytes32 internal constant SETTING_CONTRACT_NAME = "FuturesMarketSettings";
-
     /* ========== CONSTANTS ========== */
+
+    bytes32 internal constant SETTING_CONTRACT_NAME = "FuturesMarketSettings";
 
     /* ---------- Parameter Names ---------- */
 

--- a/contracts/interfaces/IFuturesMarket.sol
+++ b/contracts/interfaces/IFuturesMarket.sol
@@ -98,6 +98,8 @@ interface IFuturesMarket {
 
     function remainingMargin(address account) external view returns (uint marginRemaining, bool invalid);
 
+    function accessibleMargin(address account) external view returns (uint marginAccessible, bool invalid);
+
     function liquidationPrice(address account, bool includeFunding) external view returns (uint price, bool invalid);
 
     function canLiquidate(address account) external view returns (bool);

--- a/test/contracts/FuturesMarketData.js
+++ b/test/contracts/FuturesMarketData.js
@@ -203,6 +203,8 @@ contract('FuturesMarketData', accounts => {
 			assert.bnEqual(details2.accruedFunding, accruedFunding.funding);
 			const remaining = await futuresMarket.remainingMargin(trader1);
 			assert.bnEqual(details2.remainingMargin, remaining.marginRemaining);
+			const accessible = await futuresMarket.accessibleMargin(trader1);
+			assert.bnEqual(details2.accessibleMargin, accessible.marginAccessible);
 			const lp = await futuresMarket.liquidationPrice(trader1, true);
 			assert.bnEqual(details2.liquidationPrice, lp[0]);
 			assert.equal(details.canLiquidatePosition, await futuresMarket.canLiquidate(trader1));


### PR DESCRIPTION
Does the following:

* Adds a function `accessibleMargin` that reports the amount of margin a user can actually withdraw given their current position.
* Updates `withdrawAllMargin` to withdraw this quantity.
* Fixes a bug in `transferMargin`, where the minimum initial margin check and some other pieces were not properly respecting short positions.