### PR TITLE
SIP-174 Fix for settlements to not cached removed synths

### DIFF
--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -660,9 +660,9 @@ contract Exchanger is Owned, MixinSystemSettings, IExchanger {
             refund(from, currencyKey, refunded);
         }
 
-        // we check the synth is still in the system before updating the cache
-        // (this protects against settlements for removed synths causing any issues)
-        if (updateCache && address(issuer().synths(currencyKey)) != address(0)) {
+        // by checking a reclaim or refund we also check that the currency key is still a valid synth,
+        // as the deviation check will return 0 if the synth has been removed.
+        if (updateCache && (reclaimed > 0 || refunded > 0)) {
             bytes32[] memory key = new bytes32[](1);
             key[0] = currencyKey;
             debtCache().updateCachedSynthDebts(key);

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -660,7 +660,9 @@ contract Exchanger is Owned, MixinSystemSettings, IExchanger {
             refund(from, currencyKey, refunded);
         }
 
-        if (updateCache) {
+        // we check the synth is still in the system before updating the cache
+        // (this protects against settlements for removed synths causing any issues)
+        if (updateCache && address(issuer().synths(currencyKey)) != address(0)) {
             bytes32[] memory key = new bytes32[](1);
             key[0] = currencyKey;
             debtCache().updateCachedSynthDebts(key);

--- a/publish/releases.json
+++ b/publish/releases.json
@@ -335,7 +335,7 @@
 		{
 			"sip": 174,
 			"layer": "both",
-			"sources": ["Issuer", "SynthRedeemer"]
+			"sources": ["Exchanger", "Issuer", "SynthRedeemer"]
 		}
 	],
 	"releases": [

--- a/test/contracts/DebtCache.js
+++ b/test/contracts/DebtCache.js
@@ -827,32 +827,41 @@ contract('DebtCache', async accounts => {
 					from: owner,
 				});
 				await sAUDContract.issue(account1, toUnit(100));
+
 				await debtCache.takeDebtSnapshot();
 
+				const cachedDebt = await debtCache.cachedDebt();
+
 				await synthetix.exchange(sAUD, toUnit(50), sEUR, { from: account1 });
+				// so there's now 100 - 25 sUSD left (25 of it was exchanged)
+				// and now there's 100 + (25 / 2 ) of sEUR = 112.5
+
+				await systemSettings.setWaitingPeriodSecs(60, { from: owner });
+				// set a high price deviation threshold factor to be sure it doesn't trigger here
+				await systemSettings.setPriceDeviationThresholdFactor(toUnit('99'), { from: owner });
 
 				await exchangeRates.updateRates([sAUD, sEUR], ['2', '1'].map(toUnit), await currentTime(), {
 					from: oracle,
 				});
 
-				const tx = await exchanger.settle(account1, sAUD);
+				await fastForward(100);
+
+				const tx = await exchanger.settle(account1, sEUR);
 				const logs = await getDecodedLogs({
 					hash: tx.tx,
 					contracts: [debtCache],
 				});
 
-				// AU$150 worth $75 became worth $300
-				// But the EUR debt does not change due to settlement,
-				// and remains at $200 + $25 from the exchange
-
+				// The A$75 does not change as we settled sEUR
+				// But the EUR changes from 112.5 + 87.5 rebate = 200
 				const results = await debtCache.cachedSynthDebts([sAUD, sEUR]);
-				assert.bnEqual(results[0], toUnit(300));
-				assert.bnEqual(results[1], toUnit(225));
+				assert.bnEqual(results[0], toUnit(75));
+				assert.bnEqual(results[1], toUnit(200));
 
 				decodedEventEqual({
 					event: 'DebtCacheUpdated',
 					emittedFrom: debtCache.address,
-					args: [toUnit(825)],
+					args: [cachedDebt.sub(toUnit('25'))], // deduct the 25 units of sAUD
 					log: logs.find(({ name } = {}) => name === 'DebtCacheUpdated'),
 				});
 			});

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { artifacts, contract, web3 } = require('hardhat');
+const { smockit } = require('@eth-optimism/smock');
 
 const { assert, addSnapshotBeforeRestoreAfterEach } = require('./common');
 
@@ -758,138 +759,85 @@ contract('Exchanger (spec tests)', async accounts => {
 							await systemSettings.setWaitingPeriodSecs('60', { from: owner });
 						});
 						describe('various rebate & reclaim scenarios', () => {
-							describe('and the priceDeviationThresholdFactor is set to a factor of 2.5', () => {
+							describe('when the debt cache is replaced with a spy', () => {
+								let debtCacheSpy;
 								beforeEach(async () => {
-									// prevent circuit breaker from firing for doubling or halving rates by upping the threshold difference to 2.5
-									await systemSettings.setPriceDeviationThresholdFactor(toUnit('2.5'), {
+									// populate with a mocked DebtCache so we can inspect it
+									debtCacheSpy = await smockit(artifacts.require('DebtCache').abi);
+									await resolver.importAddresses([toBytes32('DebtCache')], [debtCacheSpy.address], {
 										from: owner,
 									});
+									await exchanger.rebuildCache();
 								});
-								describe('when the first user exchanges 100 sUSD into sUSD:sEUR at 2:1', () => {
-									let amountOfSrcExchanged;
-									let exchangeTime;
-									let exchangeTransaction;
+								describe('and the priceDeviationThresholdFactor is set to a factor of 2.5', () => {
 									beforeEach(async () => {
-										amountOfSrcExchanged = toUnit('100');
-										exchangeTime = await currentTime();
-										exchangeTransaction = await synthetix.exchange(
-											sUSD,
-											amountOfSrcExchanged,
-											sEUR,
-											{
-												from: account1,
-											}
-										);
-
-										const {
-											amountReceived,
-											exchangeFeeRate,
-										} = await exchanger.getAmountsForExchange(amountOfSrcExchanged, sUSD, sEUR);
-
-										const logs = await getDecodedLogs({
-											hash: exchangeTransaction.tx,
-											contracts: [
-												synthetix,
-												exchanger,
-												sUSDContract,
-												issuer,
-												flexibleStorage,
-												debtCache,
-											],
+										// prevent circuit breaker from firing for doubling or halving rates by upping the threshold difference to 2.5
+										await systemSettings.setPriceDeviationThresholdFactor(toUnit('2.5'), {
+											from: owner,
 										});
-
-										// ExchangeEntryAppended is emitted for exchange
-										decodedEventEqual({
-											log: logs.find(({ name }) => name === 'ExchangeEntryAppended'),
-											event: 'ExchangeEntryAppended',
-											emittedFrom: exchanger.address,
-											args: [
-												account1,
+									});
+									describe('when the first user exchanges 100 sUSD into sUSD:sEUR at 2:1', () => {
+										let amountOfSrcExchanged;
+										let exchangeTime;
+										let exchangeTransaction;
+										beforeEach(async () => {
+											amountOfSrcExchanged = toUnit('100');
+											exchangeTime = await currentTime();
+											exchangeTransaction = await synthetix.exchange(
 												sUSD,
 												amountOfSrcExchanged,
 												sEUR,
+												{
+													from: account1,
+												}
+											);
+
+											const {
 												amountReceived,
 												exchangeFeeRate,
-												new web3.utils.BN(1),
-												new web3.utils.BN(2),
-											],
-											bnCloseVariance,
-										});
-									});
-									it('then settlement reclaimAmount shows 0 reclaim and 0 refund', async () => {
-										const settlement = await exchanger.settlementOwing(account1, sEUR);
-										assert.equal(settlement.reclaimAmount, '0', 'Nothing can be reclaimAmount');
-										assert.equal(settlement.rebateAmount, '0', 'Nothing can be rebateAmount');
-										assert.equal(
-											settlement.numEntries,
-											'1',
-											'Must be one entry in the settlement queue'
-										);
-									});
-									describe('when settle() is invoked on sEUR', () => {
-										it('then it reverts as the waiting period has not ended', async () => {
-											await assert.revert(
-												synthetix.settle(sEUR, { from: account1 }),
-												'Cannot settle during waiting period'
-											);
-										});
-									});
-									it('when sEUR is attempted to be exchanged away by the user, it reverts', async () => {
-										await assert.revert(
-											synthetix.exchange(sEUR, toUnit('1'), sBTC, { from: account1 }),
-											'Cannot settle during waiting period'
-										);
-									});
+											} = await exchanger.getAmountsForExchange(amountOfSrcExchanged, sUSD, sEUR);
 
-									describe('when settle() is invoked on the src synth - sUSD', () => {
-										it('then it completes with no reclaim or rebate', async () => {
-											const txn = await synthetix.settle(sUSD, {
-												from: account1,
+											const logs = await getDecodedLogs({
+												hash: exchangeTransaction.tx,
+												contracts: [
+													synthetix,
+													exchanger,
+													sUSDContract,
+													issuer,
+													flexibleStorage,
+													debtCache,
+												],
 											});
+
+											// ExchangeEntryAppended is emitted for exchange
+											decodedEventEqual({
+												log: logs.find(({ name }) => name === 'ExchangeEntryAppended'),
+												event: 'ExchangeEntryAppended',
+												emittedFrom: exchanger.address,
+												args: [
+													account1,
+													sUSD,
+													amountOfSrcExchanged,
+													sEUR,
+													amountReceived,
+													exchangeFeeRate,
+													new web3.utils.BN(1),
+													new web3.utils.BN(2),
+												],
+												bnCloseVariance,
+											});
+										});
+										it('then settlement reclaimAmount shows 0 reclaim and 0 refund', async () => {
+											const settlement = await exchanger.settlementOwing(account1, sEUR);
+											assert.equal(settlement.reclaimAmount, '0', 'Nothing can be reclaimAmount');
+											assert.equal(settlement.rebateAmount, '0', 'Nothing can be rebateAmount');
 											assert.equal(
-												txn.logs.length,
-												0,
-												'Must not emit any events as no settlement required'
+												settlement.numEntries,
+												'1',
+												'Must be one entry in the settlement queue'
 											);
 										});
-									});
-									describe('when settle() is invoked on sEUR by another user', () => {
-										it('then it completes with no reclaim or rebate', async () => {
-											const txn = await synthetix.settle(sEUR, {
-												from: account2,
-											});
-											assert.equal(
-												txn.logs.length,
-												0,
-												'Must not emit any events as no settlement required'
-											);
-										});
-									});
-									describe('when the price doubles for sUSD:sEUR to 4:1', () => {
-										beforeEach(async () => {
-											await fastForward(5);
-											timestamp = await currentTime();
-
-											await exchangeRates.updateRates([sEUR], ['4'].map(toUnit), timestamp, {
-												from: oracle,
-											});
-										});
-										it('then settlement reclaimAmount shows a reclaim of half the entire balance of sEUR', async () => {
-											const expected = calculateExpectedSettlementAmount({
-												amount: amountOfSrcExchanged,
-												oldRate: divideDecimal(1, 2),
-												newRate: divideDecimal(1, 4),
-											});
-
-											const { reclaimAmount, rebateAmount } = await exchanger.settlementOwing(
-												account1,
-												sEUR
-											);
-
-											assert.bnEqual(rebateAmount, expected.rebateAmount);
-											assert.bnEqual(reclaimAmount, expected.reclaimAmount);
-										});
-										describe('when settle() is invoked', () => {
+										describe('when settle() is invoked on sEUR', () => {
 											it('then it reverts as the waiting period has not ended', async () => {
 												await assert.revert(
 													synthetix.settle(sEUR, { from: account1 }),
@@ -897,39 +845,28 @@ contract('Exchanger (spec tests)', async accounts => {
 												);
 											});
 										});
-										describe('when another minute passes', () => {
-											let expectedSettlement;
-											let srcBalanceBeforeExchange;
 
+										describe('when the waiting period elapses', () => {
 											beforeEach(async () => {
 												await fastForward(60);
-												srcBalanceBeforeExchange = await sEURContract.balanceOf(account1);
-
-												expectedSettlement = calculateExpectedSettlementAmount({
-													amount: amountOfSrcExchanged,
-													oldRate: divideDecimal(1, 2),
-													newRate: divideDecimal(1, 4),
-												});
 											});
-											describe('when settle() is invoked', () => {
-												let transaction;
+											describe('when settle() is invoked on sEUR', () => {
+												let txn;
 												beforeEach(async () => {
-													transaction = await synthetix.settle(sEUR, {
+													txn = await synthetix.settle(sEUR, {
 														from: account1,
 													});
 												});
-												it('then it settles with a reclaim', async () => {
-													await ensureTxnEmitsSettlementEvents({
-														hash: transaction.tx,
-														synth: sEURContract,
-														expected: expectedSettlement,
-													});
-												});
-												it('then it settles with a ExchangeEntrySettled event with reclaim', async () => {
+												it('then it completes with one settlement', async () => {
 													const logs = await getDecodedLogs({
-														hash: transaction.tx,
+														hash: txn.tx,
 														contracts: [synthetix, exchanger, sUSDContract],
 													});
+
+													assert.equal(
+														logs.filter(({ name }) => name === 'ExchangeEntrySettled').length,
+														1
+													);
 
 													decodedEventEqual({
 														log: logs.find(({ name }) => name === 'ExchangeEntrySettled'),
@@ -940,8 +877,8 @@ contract('Exchanger (spec tests)', async accounts => {
 															sUSD,
 															amountOfSrcExchanged,
 															sEUR,
-															expectedSettlement.reclaimAmount,
-															new web3.utils.BN(0),
+															'0',
+															'0',
 															new web3.utils.BN(1),
 															new web3.utils.BN(3),
 															exchangeTime + 1,
@@ -949,263 +886,73 @@ contract('Exchanger (spec tests)', async accounts => {
 														bnCloseVariance,
 													});
 												});
-											});
-											describe('when settle() is invoked and the exchange fee rate has changed', () => {
-												beforeEach(async () => {
-													systemSettings.setExchangeFeeRateForSynths([sBTC], [toUnit('0.1')], {
-														from: owner,
-													});
-												});
-												it('then it settles with a reclaim', async () => {
-													const { tx: hash } = await synthetix.settle(sEUR, {
-														from: account1,
-													});
-													await ensureTxnEmitsSettlementEvents({
-														hash,
-														synth: sEURContract,
-														expected: expectedSettlement,
-													});
-												});
-											});
-
-											// The user has ~49.5 sEUR and has a reclaim of ~24.75 - so 24.75 after settlement
-											describe(
-												'when an exchange out of sEUR for more than the balance after settlement,' +
-													'but less than the total initially',
-												() => {
-													let txn;
-													beforeEach(async () => {
-														txn = await synthetix.exchange(sEUR, toUnit('30'), sBTC, {
-															from: account1,
-														});
-													});
-													it('then it succeeds, exchanging the entire amount after settlement', async () => {
-														const srcBalanceAfterExchange = await sEURContract.balanceOf(account1);
-														assert.equal(srcBalanceAfterExchange, '0');
-
-														const decodedLogs = await ensureTxnEmitsSettlementEvents({
-															hash: txn.tx,
-															synth: sEURContract,
-															expected: expectedSettlement,
-														});
-
-														decodedEventEqual({
-															log: decodedLogs.find(({ name }) => name === 'SynthExchange'),
-															event: 'SynthExchange',
-															emittedFrom: await synthetix.proxy(),
-															args: [
-																account1,
-																sEUR,
-																srcBalanceBeforeExchange.sub(expectedSettlement.reclaimAmount),
-																sBTC,
-															],
-														});
-													});
-												}
-											);
-
-											describe(
-												'when an exchange out of sEUR for more than the balance after settlement,' +
-													'and more than the total initially and the exchangefee rate changed',
-												() => {
-													let txn;
-													beforeEach(async () => {
-														txn = await synthetix.exchange(sEUR, toUnit('50'), sBTC, {
-															from: account1,
-														});
-														systemSettings.setExchangeFeeRateForSynths([sBTC], [toUnit('0.1')], {
-															from: owner,
-														});
-													});
-													it('then it succeeds, exchanging the entire amount after settlement', async () => {
-														const srcBalanceAfterExchange = await sEURContract.balanceOf(account1);
-														assert.equal(srcBalanceAfterExchange, '0');
-
-														const decodedLogs = await ensureTxnEmitsSettlementEvents({
-															hash: txn.tx,
-															synth: sEURContract,
-															expected: expectedSettlement,
-														});
-
-														decodedEventEqual({
-															log: decodedLogs.find(({ name }) => name === 'SynthExchange'),
-															event: 'SynthExchange',
-															emittedFrom: await synthetix.proxy(),
-															args: [
-																account1,
-																sEUR,
-																srcBalanceBeforeExchange.sub(expectedSettlement.reclaimAmount),
-																sBTC,
-															],
-														});
-													});
-												}
-											);
-
-											describe('when an exchange out of sEUR for less than the balance after settlement', () => {
-												let newAmountToExchange;
-												let txn;
-												beforeEach(async () => {
-													newAmountToExchange = toUnit('10');
-													txn = await synthetix.exchange(sEUR, newAmountToExchange, sBTC, {
-														from: account1,
-													});
-												});
-												it('then it succeeds, exchanging the amount given', async () => {
-													const srcBalanceAfterExchange = await sEURContract.balanceOf(account1);
-
-													assert.bnClose(
-														srcBalanceAfterExchange,
-														srcBalanceBeforeExchange
-															.sub(expectedSettlement.reclaimAmount)
-															.sub(newAmountToExchange)
-													);
-
-													const decodedLogs = await ensureTxnEmitsSettlementEvents({
-														hash: txn.tx,
-														synth: sEURContract,
-														expected: expectedSettlement,
-													});
-
-													decodedEventEqual({
-														log: decodedLogs.find(({ name }) => name === 'SynthExchange'),
-														event: 'SynthExchange',
-														emittedFrom: await synthetix.proxy(),
-														args: [account1, sEUR, newAmountToExchange, sBTC], // amount to exchange must be the reclaim amount
-													});
+												it('and the debt cache sync is not called', async () => {
+													assert.equal(debtCacheSpy.smocked.updateCachedSynthDebts.calls.length, 0);
 												});
 											});
 										});
-									});
-									describe('when the price halves for sUSD:sEUR to 1:1', () => {
-										beforeEach(async () => {
-											await fastForward(5);
-
-											timestamp = await currentTime();
-
-											await exchangeRates.updateRates([sEUR], ['1'].map(toUnit), timestamp, {
-												from: oracle,
-											});
-										});
-										it('then settlement rebateAmount shows a rebate of half the entire balance of sEUR', async () => {
-											const expected = calculateExpectedSettlementAmount({
-												amount: amountOfSrcExchanged,
-												oldRate: divideDecimal(1, 2),
-												newRate: divideDecimal(1, 1),
-											});
-
-											const { reclaimAmount, rebateAmount } = await exchanger.settlementOwing(
-												account1,
-												sEUR
+										it('when sEUR is attempted to be exchanged away by the user, it reverts', async () => {
+											await assert.revert(
+												synthetix.exchange(sEUR, toUnit('1'), sBTC, { from: account1 }),
+												'Cannot settle during waiting period'
 											);
-
-											assert.bnEqual(rebateAmount, expected.rebateAmount);
-											assert.bnEqual(reclaimAmount, expected.reclaimAmount);
 										});
-										describe('when the user makes a 2nd exchange of 100 sUSD into sUSD:sEUR at 1:1', () => {
-											beforeEach(async () => {
-												// fast forward 60 seconds so 1st exchange is using first rate
-												await fastForward(60);
 
-												await synthetix.exchange(sUSD, amountOfSrcExchanged, sEUR, {
+										describe('when settle() is invoked on the src synth - sUSD', () => {
+											it('then it completes with no reclaim or rebate', async () => {
+												const txn = await synthetix.settle(sUSD, {
 													from: account1,
 												});
-											});
-											describe('and then the price increases for sUSD:sEUR to 2:1', () => {
-												beforeEach(async () => {
-													await fastForward(5);
-
-													timestamp = await currentTime();
-
-													await exchangeRates.updateRates([sEUR], ['2'].map(toUnit), timestamp, {
-														from: oracle,
-													});
-												});
-												describe('when settlement is invoked', () => {
-													describe('when another minute passes', () => {
-														let expectedSettlementReclaim;
-														let expectedSettlementRebate;
-														beforeEach(async () => {
-															await fastForward(60);
-
-															expectedSettlementRebate = calculateExpectedSettlementAmount({
-																amount: amountOfSrcExchanged,
-																oldRate: divideDecimal(1, 2),
-																newRate: divideDecimal(1, 1),
-															});
-
-															expectedSettlementReclaim = calculateExpectedSettlementAmount({
-																amount: amountOfSrcExchanged,
-																oldRate: divideDecimal(1, 1),
-																newRate: divideDecimal(1, 2),
-															});
-														});
-
-														describe('when settle() is invoked', () => {
-															let transaction;
-															beforeEach(async () => {
-																transaction = await synthetix.settle(sEUR, {
-																	from: account1,
-																});
-															});
-															it('then it settles with two ExchangeEntrySettled events one for reclaim and one for rebate', async () => {
-																const logs = await getDecodedLogs({
-																	hash: transaction.tx,
-																	contracts: [synthetix, exchanger, sUSDContract],
-																});
-
-																// check the rebate event first
-																decodedEventEqual({
-																	log: logs.filter(
-																		({ name }) => name === 'ExchangeEntrySettled'
-																	)[0],
-																	event: 'ExchangeEntrySettled',
-																	emittedFrom: exchanger.address,
-																	args: [
-																		account1,
-																		sUSD,
-																		amountOfSrcExchanged,
-																		sEUR,
-																		new web3.utils.BN(0),
-																		expectedSettlementRebate.rebateAmount,
-																		new web3.utils.BN(1),
-																		new web3.utils.BN(2),
-																		exchangeTime + 1,
-																	],
-																	bnCloseVariance,
-																});
-
-																// check the reclaim event
-																decodedEventEqual({
-																	log: logs.filter(
-																		({ name }) => name === 'ExchangeEntrySettled'
-																	)[1],
-																	event: 'ExchangeEntrySettled',
-																	emittedFrom: exchanger.address,
-																	args: [
-																		account1,
-																		sUSD,
-																		amountOfSrcExchanged,
-																		sEUR,
-																		expectedSettlementReclaim.reclaimAmount,
-																		new web3.utils.BN(0),
-																		new web3.utils.BN(1),
-																		new web3.utils.BN(2),
-																	],
-																	bnCloseVariance,
-																});
-															});
-														});
-													});
-												});
+												assert.equal(
+													txn.logs.length,
+													0,
+													'Must not emit any events as no settlement required'
+												);
 											});
 										});
-										describe('when settlement is invoked', () => {
-											it('then it reverts as the waiting period has not ended', async () => {
-												await assert.revert(
-													synthetix.settle(sEUR, { from: account1 }),
-													'Cannot settle during waiting period'
+										describe('when settle() is invoked on sEUR by another user', () => {
+											it('then it completes with no reclaim or rebate', async () => {
+												const txn = await synthetix.settle(sEUR, {
+													from: account2,
+												});
+												assert.equal(
+													txn.logs.length,
+													0,
+													'Must not emit any events as no settlement required'
 												);
+											});
+										});
+										describe('when the price doubles for sUSD:sEUR to 4:1', () => {
+											beforeEach(async () => {
+												await fastForward(5);
+												timestamp = await currentTime();
+
+												await exchangeRates.updateRates([sEUR], ['4'].map(toUnit), timestamp, {
+													from: oracle,
+												});
+											});
+											it('then settlement reclaimAmount shows a reclaim of half the entire balance of sEUR', async () => {
+												const expected = calculateExpectedSettlementAmount({
+													amount: amountOfSrcExchanged,
+													oldRate: divideDecimal(1, 2),
+													newRate: divideDecimal(1, 4),
+												});
+
+												const { reclaimAmount, rebateAmount } = await exchanger.settlementOwing(
+													account1,
+													sEUR
+												);
+
+												assert.bnEqual(rebateAmount, expected.rebateAmount);
+												assert.bnEqual(reclaimAmount, expected.reclaimAmount);
+											});
+											describe('when settle() is invoked', () => {
+												it('then it reverts as the waiting period has not ended', async () => {
+													await assert.revert(
+														synthetix.settle(sEUR, { from: account1 }),
+														'Cannot settle during waiting period'
+													);
+												});
 											});
 											describe('when another minute passes', () => {
 												let expectedSettlement;
@@ -1218,10 +965,9 @@ contract('Exchanger (spec tests)', async accounts => {
 													expectedSettlement = calculateExpectedSettlementAmount({
 														amount: amountOfSrcExchanged,
 														oldRate: divideDecimal(1, 2),
-														newRate: divideDecimal(1, 1),
+														newRate: divideDecimal(1, 4),
 													});
 												});
-
 												describe('when settle() is invoked', () => {
 													let transaction;
 													beforeEach(async () => {
@@ -1229,14 +975,14 @@ contract('Exchanger (spec tests)', async accounts => {
 															from: account1,
 														});
 													});
-													it('then it settles with a rebate', async () => {
+													it('then it settles with a reclaim', async () => {
 														await ensureTxnEmitsSettlementEvents({
 															hash: transaction.tx,
 															synth: sEURContract,
 															expected: expectedSettlement,
 														});
 													});
-													it('then it settles with a ExchangeEntrySettled event with rebate', async () => {
+													it('then it settles with a ExchangeEntrySettled event with reclaim', async () => {
 														const logs = await getDecodedLogs({
 															hash: transaction.tx,
 															contracts: [synthetix, exchanger, sUSDContract],
@@ -1251,28 +997,140 @@ contract('Exchanger (spec tests)', async accounts => {
 																sUSD,
 																amountOfSrcExchanged,
 																sEUR,
+																expectedSettlement.reclaimAmount,
 																new web3.utils.BN(0),
-																expectedSettlement.rebateAmount,
 																new web3.utils.BN(1),
-																new web3.utils.BN(2),
+																new web3.utils.BN(3),
 																exchangeTime + 1,
 															],
 															bnCloseVariance,
 														});
 													});
+													it('and the debt cache is called', async () => {
+														assert.equal(
+															debtCacheSpy.smocked.updateCachedSynthDebts.calls.length,
+															1
+														);
+														assert.equal(
+															debtCacheSpy.smocked.updateCachedSynthDebts.calls[0][0],
+															sEUR
+														);
+													});
+												});
+												describe('when settle() is invoked and the exchange fee rate has changed', () => {
+													beforeEach(async () => {
+														systemSettings.setExchangeFeeRateForSynths([sBTC], [toUnit('0.1')], {
+															from: owner,
+														});
+													});
+													it('then it settles with a reclaim', async () => {
+														const { tx: hash } = await synthetix.settle(sEUR, {
+															from: account1,
+														});
+														await ensureTxnEmitsSettlementEvents({
+															hash,
+															synth: sEURContract,
+															expected: expectedSettlement,
+														});
+													});
 												});
 
-												// The user has 49.5 sEUR and has a rebate of 49.5 - so 99 after settlement
-												describe('when an exchange out of sEUR for their expected balance before exchange', () => {
+												// The user has ~49.5 sEUR and has a reclaim of ~24.75 - so 24.75 after settlement
+												describe(
+													'when an exchange out of sEUR for more than the balance after settlement,' +
+														'but less than the total initially',
+													() => {
+														let txn;
+														beforeEach(async () => {
+															txn = await synthetix.exchange(sEUR, toUnit('30'), sBTC, {
+																from: account1,
+															});
+														});
+														it('then it succeeds, exchanging the entire amount after settlement', async () => {
+															const srcBalanceAfterExchange = await sEURContract.balanceOf(
+																account1
+															);
+															assert.equal(srcBalanceAfterExchange, '0');
+
+															const decodedLogs = await ensureTxnEmitsSettlementEvents({
+																hash: txn.tx,
+																synth: sEURContract,
+																expected: expectedSettlement,
+															});
+
+															decodedEventEqual({
+																log: decodedLogs.find(({ name }) => name === 'SynthExchange'),
+																event: 'SynthExchange',
+																emittedFrom: await synthetix.proxy(),
+																args: [
+																	account1,
+																	sEUR,
+																	srcBalanceBeforeExchange.sub(expectedSettlement.reclaimAmount),
+																	sBTC,
+																],
+															});
+														});
+													}
+												);
+
+												describe(
+													'when an exchange out of sEUR for more than the balance after settlement,' +
+														'and more than the total initially and the exchangefee rate changed',
+													() => {
+														let txn;
+														beforeEach(async () => {
+															txn = await synthetix.exchange(sEUR, toUnit('50'), sBTC, {
+																from: account1,
+															});
+															systemSettings.setExchangeFeeRateForSynths([sBTC], [toUnit('0.1')], {
+																from: owner,
+															});
+														});
+														it('then it succeeds, exchanging the entire amount after settlement', async () => {
+															const srcBalanceAfterExchange = await sEURContract.balanceOf(
+																account1
+															);
+															assert.equal(srcBalanceAfterExchange, '0');
+
+															const decodedLogs = await ensureTxnEmitsSettlementEvents({
+																hash: txn.tx,
+																synth: sEURContract,
+																expected: expectedSettlement,
+															});
+
+															decodedEventEqual({
+																log: decodedLogs.find(({ name }) => name === 'SynthExchange'),
+																event: 'SynthExchange',
+																emittedFrom: await synthetix.proxy(),
+																args: [
+																	account1,
+																	sEUR,
+																	srcBalanceBeforeExchange.sub(expectedSettlement.reclaimAmount),
+																	sBTC,
+																],
+															});
+														});
+													}
+												);
+
+												describe('when an exchange out of sEUR for less than the balance after settlement', () => {
+													let newAmountToExchange;
 													let txn;
 													beforeEach(async () => {
-														txn = await synthetix.exchange(sEUR, toUnit('49.5'), sBTC, {
+														newAmountToExchange = toUnit('10');
+														txn = await synthetix.exchange(sEUR, newAmountToExchange, sBTC, {
 															from: account1,
 														});
 													});
-													it('then it succeeds, exchanging the entire amount plus the rebate', async () => {
+													it('then it succeeds, exchanging the amount given', async () => {
 														const srcBalanceAfterExchange = await sEURContract.balanceOf(account1);
-														assert.equal(srcBalanceAfterExchange, '0');
+
+														assert.bnClose(
+															srcBalanceAfterExchange,
+															srcBalanceBeforeExchange
+																.sub(expectedSettlement.reclaimAmount)
+																.sub(newAmountToExchange)
+														);
 
 														const decodedLogs = await ensureTxnEmitsSettlementEvents({
 															hash: txn.tx,
@@ -1284,70 +1142,271 @@ contract('Exchanger (spec tests)', async accounts => {
 															log: decodedLogs.find(({ name }) => name === 'SynthExchange'),
 															event: 'SynthExchange',
 															emittedFrom: await synthetix.proxy(),
-															args: [
-																account1,
-																sEUR,
-																srcBalanceBeforeExchange.add(expectedSettlement.rebateAmount),
-																sBTC,
-															],
-														});
-													});
-												});
-
-												describe('when an exchange out of sEUR for some amount less than their balance before exchange', () => {
-													let txn;
-													beforeEach(async () => {
-														txn = await synthetix.exchange(sEUR, toUnit('10'), sBTC, {
-															from: account1,
-														});
-													});
-													it('then it succeeds, exchanging the amount plus the rebate', async () => {
-														const decodedLogs = await ensureTxnEmitsSettlementEvents({
-															hash: txn.tx,
-															synth: sEURContract,
-															expected: expectedSettlement,
-														});
-
-														decodedEventEqual({
-															log: decodedLogs.find(({ name }) => name === 'SynthExchange'),
-															event: 'SynthExchange',
-															emittedFrom: await synthetix.proxy(),
-															args: [
-																account1,
-																sEUR,
-																toUnit('10').add(expectedSettlement.rebateAmount),
-																sBTC,
-															],
+															args: [account1, sEUR, newAmountToExchange, sBTC], // amount to exchange must be the reclaim amount
 														});
 													});
 												});
 											});
 										});
-										describe('when the price returns to sUSD:sEUR to 2:1', () => {
+										describe('when the price halves for sUSD:sEUR to 1:1', () => {
 											beforeEach(async () => {
-												await fastForward(12);
+												await fastForward(5);
 
 												timestamp = await currentTime();
 
-												await exchangeRates.updateRates([sEUR], ['2'].map(toUnit), timestamp, {
+												await exchangeRates.updateRates([sEUR], ['1'].map(toUnit), timestamp, {
 													from: oracle,
 												});
 											});
-											it('then settlement reclaimAmount shows 0 reclaim and 0 refund', async () => {
-												const settlement = await exchanger.settlementOwing(account1, sEUR);
-												assert.equal(settlement.reclaimAmount, '0', 'Nothing can be reclaimAmount');
-												assert.equal(settlement.rebateAmount, '0', 'Nothing can be rebateAmount');
+											it('then settlement rebateAmount shows a rebate of half the entire balance of sEUR', async () => {
+												const expected = calculateExpectedSettlementAmount({
+													amount: amountOfSrcExchanged,
+													oldRate: divideDecimal(1, 2),
+													newRate: divideDecimal(1, 1),
+												});
+
+												const { reclaimAmount, rebateAmount } = await exchanger.settlementOwing(
+													account1,
+													sEUR
+												);
+
+												assert.bnEqual(rebateAmount, expected.rebateAmount);
+												assert.bnEqual(reclaimAmount, expected.reclaimAmount);
 											});
-											describe('when another minute elapses and the sETH price changes', () => {
+											describe('when the user makes a 2nd exchange of 100 sUSD into sUSD:sEUR at 1:1', () => {
 												beforeEach(async () => {
+													// fast forward 60 seconds so 1st exchange is using first rate
 													await fastForward(60);
+
+													await synthetix.exchange(sUSD, amountOfSrcExchanged, sEUR, {
+														from: account1,
+													});
+												});
+												describe('and then the price increases for sUSD:sEUR to 2:1', () => {
+													beforeEach(async () => {
+														await fastForward(5);
+
+														timestamp = await currentTime();
+
+														await exchangeRates.updateRates([sEUR], ['2'].map(toUnit), timestamp, {
+															from: oracle,
+														});
+													});
+													describe('when settlement is invoked', () => {
+														describe('when another minute passes', () => {
+															let expectedSettlementReclaim;
+															let expectedSettlementRebate;
+															beforeEach(async () => {
+																await fastForward(60);
+
+																expectedSettlementRebate = calculateExpectedSettlementAmount({
+																	amount: amountOfSrcExchanged,
+																	oldRate: divideDecimal(1, 2),
+																	newRate: divideDecimal(1, 1),
+																});
+
+																expectedSettlementReclaim = calculateExpectedSettlementAmount({
+																	amount: amountOfSrcExchanged,
+																	oldRate: divideDecimal(1, 1),
+																	newRate: divideDecimal(1, 2),
+																});
+															});
+
+															describe('when settle() is invoked', () => {
+																let transaction;
+																beforeEach(async () => {
+																	transaction = await synthetix.settle(sEUR, {
+																		from: account1,
+																	});
+																});
+																it('then it settles with two ExchangeEntrySettled events one for reclaim and one for rebate', async () => {
+																	const logs = await getDecodedLogs({
+																		hash: transaction.tx,
+																		contracts: [synthetix, exchanger, sUSDContract],
+																	});
+
+																	// check the rebate event first
+																	decodedEventEqual({
+																		log: logs.filter(
+																			({ name }) => name === 'ExchangeEntrySettled'
+																		)[0],
+																		event: 'ExchangeEntrySettled',
+																		emittedFrom: exchanger.address,
+																		args: [
+																			account1,
+																			sUSD,
+																			amountOfSrcExchanged,
+																			sEUR,
+																			new web3.utils.BN(0),
+																			expectedSettlementRebate.rebateAmount,
+																			new web3.utils.BN(1),
+																			new web3.utils.BN(2),
+																			exchangeTime + 1,
+																		],
+																		bnCloseVariance,
+																	});
+
+																	// check the reclaim event
+																	decodedEventEqual({
+																		log: logs.filter(
+																			({ name }) => name === 'ExchangeEntrySettled'
+																		)[1],
+																		event: 'ExchangeEntrySettled',
+																		emittedFrom: exchanger.address,
+																		args: [
+																			account1,
+																			sUSD,
+																			amountOfSrcExchanged,
+																			sEUR,
+																			expectedSettlementReclaim.reclaimAmount,
+																			new web3.utils.BN(0),
+																			new web3.utils.BN(1),
+																			new web3.utils.BN(2),
+																		],
+																		bnCloseVariance,
+																	});
+																});
+															});
+														});
+													});
+												});
+											});
+											describe('when settlement is invoked', () => {
+												it('then it reverts as the waiting period has not ended', async () => {
+													await assert.revert(
+														synthetix.settle(sEUR, { from: account1 }),
+														'Cannot settle during waiting period'
+													);
+												});
+												describe('when another minute passes', () => {
+													let expectedSettlement;
+													let srcBalanceBeforeExchange;
+
+													beforeEach(async () => {
+														await fastForward(60);
+														srcBalanceBeforeExchange = await sEURContract.balanceOf(account1);
+
+														expectedSettlement = calculateExpectedSettlementAmount({
+															amount: amountOfSrcExchanged,
+															oldRate: divideDecimal(1, 2),
+															newRate: divideDecimal(1, 1),
+														});
+													});
+
+													describe('when settle() is invoked', () => {
+														let transaction;
+														beforeEach(async () => {
+															transaction = await synthetix.settle(sEUR, {
+																from: account1,
+															});
+														});
+														it('then it settles with a rebate', async () => {
+															await ensureTxnEmitsSettlementEvents({
+																hash: transaction.tx,
+																synth: sEURContract,
+																expected: expectedSettlement,
+															});
+														});
+														it('then it settles with a ExchangeEntrySettled event with rebate', async () => {
+															const logs = await getDecodedLogs({
+																hash: transaction.tx,
+																contracts: [synthetix, exchanger, sUSDContract],
+															});
+
+															decodedEventEqual({
+																log: logs.find(({ name }) => name === 'ExchangeEntrySettled'),
+																event: 'ExchangeEntrySettled',
+																emittedFrom: exchanger.address,
+																args: [
+																	account1,
+																	sUSD,
+																	amountOfSrcExchanged,
+																	sEUR,
+																	new web3.utils.BN(0),
+																	expectedSettlement.rebateAmount,
+																	new web3.utils.BN(1),
+																	new web3.utils.BN(2),
+																	exchangeTime + 1,
+																],
+																bnCloseVariance,
+															});
+														});
+													});
+
+													// The user has 49.5 sEUR and has a rebate of 49.5 - so 99 after settlement
+													describe('when an exchange out of sEUR for their expected balance before exchange', () => {
+														let txn;
+														beforeEach(async () => {
+															txn = await synthetix.exchange(sEUR, toUnit('49.5'), sBTC, {
+																from: account1,
+															});
+														});
+														it('then it succeeds, exchanging the entire amount plus the rebate', async () => {
+															const srcBalanceAfterExchange = await sEURContract.balanceOf(
+																account1
+															);
+															assert.equal(srcBalanceAfterExchange, '0');
+
+															const decodedLogs = await ensureTxnEmitsSettlementEvents({
+																hash: txn.tx,
+																synth: sEURContract,
+																expected: expectedSettlement,
+															});
+
+															decodedEventEqual({
+																log: decodedLogs.find(({ name }) => name === 'SynthExchange'),
+																event: 'SynthExchange',
+																emittedFrom: await synthetix.proxy(),
+																args: [
+																	account1,
+																	sEUR,
+																	srcBalanceBeforeExchange.add(expectedSettlement.rebateAmount),
+																	sBTC,
+																],
+															});
+														});
+													});
+
+													describe('when an exchange out of sEUR for some amount less than their balance before exchange', () => {
+														let txn;
+														beforeEach(async () => {
+															txn = await synthetix.exchange(sEUR, toUnit('10'), sBTC, {
+																from: account1,
+															});
+														});
+														it('then it succeeds, exchanging the amount plus the rebate', async () => {
+															const decodedLogs = await ensureTxnEmitsSettlementEvents({
+																hash: txn.tx,
+																synth: sEURContract,
+																expected: expectedSettlement,
+															});
+
+															decodedEventEqual({
+																log: decodedLogs.find(({ name }) => name === 'SynthExchange'),
+																event: 'SynthExchange',
+																emittedFrom: await synthetix.proxy(),
+																args: [
+																	account1,
+																	sEUR,
+																	toUnit('10').add(expectedSettlement.rebateAmount),
+																	sBTC,
+																],
+															});
+														});
+													});
+												});
+											});
+											describe('when the price returns to sUSD:sEUR to 2:1', () => {
+												beforeEach(async () => {
+													await fastForward(12);
+
 													timestamp = await currentTime();
 
-													await exchangeRates.updateRates([sEUR], ['3'].map(toUnit), timestamp, {
+													await exchangeRates.updateRates([sEUR], ['2'].map(toUnit), timestamp, {
 														from: oracle,
 													});
 												});
-												it('then settlement reclaimAmount still shows 0 reclaim and 0 refund as the timeout period ended', async () => {
+												it('then settlement reclaimAmount shows 0 reclaim and 0 refund', async () => {
 													const settlement = await exchanger.settlementOwing(account1, sEUR);
 													assert.equal(
 														settlement.reclaimAmount,
@@ -1356,90 +1415,76 @@ contract('Exchanger (spec tests)', async accounts => {
 													);
 													assert.equal(settlement.rebateAmount, '0', 'Nothing can be rebateAmount');
 												});
-												describe('when settle() is invoked', () => {
-													it('then it settles with no reclaim or rebate', async () => {
-														const txn = await synthetix.settle(sEUR, {
-															from: account1,
+												describe('when another minute elapses and the sETH price changes', () => {
+													beforeEach(async () => {
+														await fastForward(60);
+														timestamp = await currentTime();
+
+														await exchangeRates.updateRates([sEUR], ['3'].map(toUnit), timestamp, {
+															from: oracle,
 														});
+													});
+													it('then settlement reclaimAmount still shows 0 reclaim and 0 refund as the timeout period ended', async () => {
+														const settlement = await exchanger.settlementOwing(account1, sEUR);
 														assert.equal(
-															txn.logs.length,
-															0,
-															'Must not emit any events as no settlement required'
+															settlement.reclaimAmount,
+															'0',
+															'Nothing can be reclaimAmount'
 														);
+														assert.equal(
+															settlement.rebateAmount,
+															'0',
+															'Nothing can be rebateAmount'
+														);
+													});
+													describe('when settle() is invoked', () => {
+														it('then it settles with no reclaim or rebate', async () => {
+															const txn = await synthetix.settle(sEUR, {
+																from: account1,
+															});
+															assert.equal(
+																txn.logs.length,
+																0,
+																'Must not emit any events as no settlement required'
+															);
+														});
 													});
 												});
 											});
 										});
 									});
-								});
-								describe('given the first user has 1000 sEUR', () => {
-									beforeEach(async () => {
-										await sEURContract.issue(account1, toUnit('1000'));
-									});
-									describe('when the first user exchanges 100 sEUR into sEUR:sBTC at 9000:2', () => {
-										let amountOfSrcExchanged;
+									describe('given the first user has 1000 sEUR', () => {
 										beforeEach(async () => {
-											amountOfSrcExchanged = toUnit('100');
-											await synthetix.exchange(sEUR, amountOfSrcExchanged, sBTC, {
-												from: account1,
-											});
+											await sEURContract.issue(account1, toUnit('1000'));
 										});
-										it('then settlement reclaimAmount shows 0 reclaim and 0 refund', async () => {
-											const settlement = await exchanger.settlementOwing(account1, sBTC);
-											assert.equal(settlement.reclaimAmount, '0', 'Nothing can be reclaimAmount');
-											assert.equal(settlement.rebateAmount, '0', 'Nothing can be rebateAmount');
-											assert.equal(
-												settlement.numEntries,
-												'1',
-												'Must be one entry in the settlement queue'
-											);
-										});
-										describe('when the price doubles for sUSD:sEUR to 4:1', () => {
+										describe('when the first user exchanges 100 sEUR into sEUR:sBTC at 9000:2', () => {
+											let amountOfSrcExchanged;
 											beforeEach(async () => {
-												await fastForward(5);
-												timestamp = await currentTime();
-
-												await exchangeRates.updateRates([sEUR], ['4'].map(toUnit), timestamp, {
-													from: oracle,
+												amountOfSrcExchanged = toUnit('100');
+												await synthetix.exchange(sEUR, amountOfSrcExchanged, sBTC, {
+													from: account1,
 												});
 											});
-											it('then settlement shows a rebate rebateAmount', async () => {
-												const { reclaimAmount, rebateAmount } = await exchanger.settlementOwing(
-													account1,
-													sBTC
+											it('then settlement reclaimAmount shows 0 reclaim and 0 refund', async () => {
+												const settlement = await exchanger.settlementOwing(account1, sBTC);
+												assert.equal(settlement.reclaimAmount, '0', 'Nothing can be reclaimAmount');
+												assert.equal(settlement.rebateAmount, '0', 'Nothing can be rebateAmount');
+												assert.equal(
+													settlement.numEntries,
+													'1',
+													'Must be one entry in the settlement queue'
 												);
-
-												const expected = calculateExpectedSettlementAmount({
-													amount: amountOfSrcExchanged,
-													oldRate: divideDecimal(2, 9000),
-													newRate: divideDecimal(4, 9000),
-												});
-
-												assert.bnClose(rebateAmount, expected.rebateAmount, bnCloseVariance);
-												assert.bnEqual(reclaimAmount, expected.reclaimAmount);
 											});
-											describe('when settlement is invoked', () => {
-												it('then it reverts as the waiting period has not ended', async () => {
-													await assert.revert(
-														synthetix.settle(sBTC, { from: account1 }),
-														'Cannot settle during waiting period'
-													);
-												});
-											});
-											describe('when the price gains for sBTC more than the loss of the sEUR change', () => {
+											describe('when the price doubles for sUSD:sEUR to 4:1', () => {
 												beforeEach(async () => {
 													await fastForward(5);
 													timestamp = await currentTime();
-													await exchangeRates.updateRates(
-														[sBTC],
-														['20000'].map(toUnit),
-														timestamp,
-														{
-															from: oracle,
-														}
-													);
+
+													await exchangeRates.updateRates([sEUR], ['4'].map(toUnit), timestamp, {
+														from: oracle,
+													});
 												});
-												it('then the reclaimAmount is whats left when subtracting the rebate', async () => {
+												it('then settlement shows a rebate rebateAmount', async () => {
 													const { reclaimAmount, rebateAmount } = await exchanger.settlementOwing(
 														account1,
 														sBTC
@@ -1448,26 +1493,38 @@ contract('Exchanger (spec tests)', async accounts => {
 													const expected = calculateExpectedSettlementAmount({
 														amount: amountOfSrcExchanged,
 														oldRate: divideDecimal(2, 9000),
-														newRate: divideDecimal(4, 20000),
+														newRate: divideDecimal(4, 9000),
 													});
 
-													assert.bnEqual(rebateAmount, expected.rebateAmount);
-													assert.bnClose(reclaimAmount, expected.reclaimAmount, bnCloseVariance);
+													assert.bnClose(rebateAmount, expected.rebateAmount, bnCloseVariance);
+													assert.bnEqual(reclaimAmount, expected.reclaimAmount);
 												});
-												describe('when the same user exchanges some sUSD into sBTC - the same destination', () => {
-													let amountOfSrcExchangedSecondary;
-													beforeEach(async () => {
-														amountOfSrcExchangedSecondary = toUnit('10');
-														await synthetix.exchange(sUSD, amountOfSrcExchangedSecondary, sBTC, {
-															from: account1,
-														});
+												describe('when settlement is invoked', () => {
+													it('then it reverts as the waiting period has not ended', async () => {
+														await assert.revert(
+															synthetix.settle(sBTC, { from: account1 }),
+															'Cannot settle during waiting period'
+														);
 													});
-													it('then the reclaimAmount is unchanged', async () => {
-														const {
-															reclaimAmount,
-															rebateAmount,
-															numEntries,
-														} = await exchanger.settlementOwing(account1, sBTC);
+												});
+												describe('when the price gains for sBTC more than the loss of the sEUR change', () => {
+													beforeEach(async () => {
+														await fastForward(5);
+														timestamp = await currentTime();
+														await exchangeRates.updateRates(
+															[sBTC],
+															['20000'].map(toUnit),
+															timestamp,
+															{
+																from: oracle,
+															}
+														);
+													});
+													it('then the reclaimAmount is whats left when subtracting the rebate', async () => {
+														const { reclaimAmount, rebateAmount } = await exchanger.settlementOwing(
+															account1,
+															sBTC
+														);
 
 														const expected = calculateExpectedSettlementAmount({
 															amount: amountOfSrcExchanged,
@@ -1477,102 +1534,133 @@ contract('Exchanger (spec tests)', async accounts => {
 
 														assert.bnEqual(rebateAmount, expected.rebateAmount);
 														assert.bnClose(reclaimAmount, expected.reclaimAmount, bnCloseVariance);
-														assert.equal(
-															numEntries,
-															'2',
-															'Must be two entries in the settlement queue'
-														);
 													});
-													describe('when the price of sBTC lowers, turning the profit to a loss', () => {
-														let expectedFromFirst;
-														let expectedFromSecond;
+													describe('when the same user exchanges some sUSD into sBTC - the same destination', () => {
+														let amountOfSrcExchangedSecondary;
 														beforeEach(async () => {
-															await fastForward(5);
-															timestamp = await currentTime();
-
-															await exchangeRates.updateRates(
-																[sBTC],
-																['10000'].map(toUnit),
-																timestamp,
-																{
-																	from: oracle,
-																}
-															);
-
-															expectedFromFirst = calculateExpectedSettlementAmount({
-																amount: amountOfSrcExchanged,
-																oldRate: divideDecimal(2, 9000),
-																newRate: divideDecimal(4, 10000),
-															});
-															expectedFromSecond = calculateExpectedSettlementAmount({
-																amount: amountOfSrcExchangedSecondary,
-																oldRate: divideDecimal(1, 20000),
-																newRate: divideDecimal(1, 10000),
+															amountOfSrcExchangedSecondary = toUnit('10');
+															await synthetix.exchange(sUSD, amountOfSrcExchangedSecondary, sBTC, {
+																from: account1,
 															});
 														});
-														it('then the rebateAmount calculation of settlementOwing on sBTC includes both exchanges', async () => {
+														it('then the reclaimAmount is unchanged', async () => {
 															const {
 																reclaimAmount,
 																rebateAmount,
+																numEntries,
 															} = await exchanger.settlementOwing(account1, sBTC);
 
-															assert.equal(reclaimAmount, '0');
+															const expected = calculateExpectedSettlementAmount({
+																amount: amountOfSrcExchanged,
+																oldRate: divideDecimal(2, 9000),
+																newRate: divideDecimal(4, 20000),
+															});
 
+															assert.bnEqual(rebateAmount, expected.rebateAmount);
 															assert.bnClose(
-																rebateAmount,
-																expectedFromFirst.rebateAmount.add(expectedFromSecond.rebateAmount),
+																reclaimAmount,
+																expected.reclaimAmount,
 																bnCloseVariance
 															);
+															assert.equal(
+																numEntries,
+																'2',
+																'Must be two entries in the settlement queue'
+															);
 														});
-														describe('when another minute passes', () => {
+														describe('when the price of sBTC lowers, turning the profit to a loss', () => {
+															let expectedFromFirst;
+															let expectedFromSecond;
 															beforeEach(async () => {
-																await fastForward(60);
-															});
-															describe('when settle() is invoked for sBTC', () => {
-																it('then it settles with a rebate @gasprofile', async () => {
-																	const txn = await synthetix.settle(sBTC, {
-																		from: account1,
-																	});
+																await fastForward(5);
+																timestamp = await currentTime();
 
-																	await ensureTxnEmitsSettlementEvents({
-																		hash: txn.tx,
-																		synth: sBTCContract,
-																		expected: {
-																			reclaimAmount: new web3.utils.BN(0),
-																			rebateAmount: expectedFromFirst.rebateAmount.add(
-																				expectedFromSecond.rebateAmount
-																			),
-																		},
-																	});
-																});
-															});
-														});
-														describe('when another minute passes and the exchange fee rate has increased', () => {
-															beforeEach(async () => {
-																await fastForward(60);
-																systemSettings.setExchangeFeeRateForSynths(
+																await exchangeRates.updateRates(
 																	[sBTC],
-																	[toUnit('0.1')],
+																	['10000'].map(toUnit),
+																	timestamp,
 																	{
-																		from: owner,
+																		from: oracle,
 																	}
 																);
-															});
-															describe('when settle() is invoked for sBTC', () => {
-																it('then it settles with a rebate using the exchange fee rate at time of trade', async () => {
-																	const { tx: hash } = await synthetix.settle(sBTC, {
-																		from: account1,
-																	});
 
-																	await ensureTxnEmitsSettlementEvents({
-																		hash,
-																		synth: sBTCContract,
-																		expected: {
-																			reclaimAmount: new web3.utils.BN(0),
-																			rebateAmount: expectedFromFirst.rebateAmount.add(
-																				expectedFromSecond.rebateAmount
-																			),
-																		},
+																expectedFromFirst = calculateExpectedSettlementAmount({
+																	amount: amountOfSrcExchanged,
+																	oldRate: divideDecimal(2, 9000),
+																	newRate: divideDecimal(4, 10000),
+																});
+																expectedFromSecond = calculateExpectedSettlementAmount({
+																	amount: amountOfSrcExchangedSecondary,
+																	oldRate: divideDecimal(1, 20000),
+																	newRate: divideDecimal(1, 10000),
+																});
+															});
+															it('then the rebateAmount calculation of settlementOwing on sBTC includes both exchanges', async () => {
+																const {
+																	reclaimAmount,
+																	rebateAmount,
+																} = await exchanger.settlementOwing(account1, sBTC);
+
+																assert.equal(reclaimAmount, '0');
+
+																assert.bnClose(
+																	rebateAmount,
+																	expectedFromFirst.rebateAmount.add(
+																		expectedFromSecond.rebateAmount
+																	),
+																	bnCloseVariance
+																);
+															});
+															describe('when another minute passes', () => {
+																beforeEach(async () => {
+																	await fastForward(60);
+																});
+																describe('when settle() is invoked for sBTC', () => {
+																	it('then it settles with a rebate @gasprofile', async () => {
+																		const txn = await synthetix.settle(sBTC, {
+																			from: account1,
+																		});
+
+																		await ensureTxnEmitsSettlementEvents({
+																			hash: txn.tx,
+																			synth: sBTCContract,
+																			expected: {
+																				reclaimAmount: new web3.utils.BN(0),
+																				rebateAmount: expectedFromFirst.rebateAmount.add(
+																					expectedFromSecond.rebateAmount
+																				),
+																			},
+																		});
+																	});
+																});
+															});
+															describe('when another minute passes and the exchange fee rate has increased', () => {
+																beforeEach(async () => {
+																	await fastForward(60);
+																	systemSettings.setExchangeFeeRateForSynths(
+																		[sBTC],
+																		[toUnit('0.1')],
+																		{
+																			from: owner,
+																		}
+																	);
+																});
+																describe('when settle() is invoked for sBTC', () => {
+																	it('then it settles with a rebate using the exchange fee rate at time of trade', async () => {
+																		const { tx: hash } = await synthetix.settle(sBTC, {
+																			from: account1,
+																		});
+
+																		await ensureTxnEmitsSettlementEvents({
+																			hash,
+																			synth: sBTCContract,
+																			expected: {
+																				reclaimAmount: new web3.utils.BN(0),
+																				rebateAmount: expectedFromFirst.rebateAmount.add(
+																					expectedFromSecond.rebateAmount
+																				),
+																			},
+																		});
 																	});
 																});
 															});
@@ -1581,42 +1669,44 @@ contract('Exchanger (spec tests)', async accounts => {
 												});
 											});
 										});
-									});
 
-									describe('and the max number of exchange entries is 5', () => {
-										beforeEach(async () => {
-											await exchangeState.setMaxEntriesInQueue('5', { from: owner });
-										});
-										describe('when a user tries to exchange 100 sEUR into sBTC 5 times', () => {
+										describe('and the max number of exchange entries is 5', () => {
 											beforeEach(async () => {
-												const txns = [];
-												for (let i = 0; i < 5; i++) {
-													txns.push(
-														await synthetix.exchange(sEUR, toUnit('100'), sBTC, { from: account1 })
-													);
-												}
+												await exchangeState.setMaxEntriesInQueue('5', { from: owner });
 											});
-											it('then all succeed', () => {});
-											it('when one more is tried, then if fails', async () => {
-												await assert.revert(
-													synthetix.exchange(sEUR, toUnit('100'), sBTC, { from: account1 }),
-													'Max queue length reached'
-												);
-											});
-											describe('when more than 60s elapses', () => {
+											describe('when a user tries to exchange 100 sEUR into sBTC 5 times', () => {
 												beforeEach(async () => {
-													await fastForward(70);
-												});
-												describe('and the user invokes settle() on the dest synth', () => {
-													beforeEach(async () => {
-														await synthetix.settle(sBTC, { from: account1 });
-													});
-													it('then when the user performs 5 more exchanges into the same synth, it succeeds', async () => {
-														for (let i = 0; i < 5; i++) {
+													const txns = [];
+													for (let i = 0; i < 5; i++) {
+														txns.push(
 															await synthetix.exchange(sEUR, toUnit('100'), sBTC, {
 																from: account1,
-															});
-														}
+															})
+														);
+													}
+												});
+												it('then all succeed', () => {});
+												it('when one more is tried, then if fails', async () => {
+													await assert.revert(
+														synthetix.exchange(sEUR, toUnit('100'), sBTC, { from: account1 }),
+														'Max queue length reached'
+													);
+												});
+												describe('when more than 60s elapses', () => {
+													beforeEach(async () => {
+														await fastForward(70);
+													});
+													describe('and the user invokes settle() on the dest synth', () => {
+														beforeEach(async () => {
+															await synthetix.settle(sBTC, { from: account1 });
+														});
+														it('then when the user performs 5 more exchanges into the same synth, it succeeds', async () => {
+															for (let i = 0; i < 5; i++) {
+																await synthetix.exchange(sEUR, toUnit('100'), sBTC, {
+																	from: account1,
+																});
+															}
+														});
 													});
 												});
 											});

--- a/test/contracts/Issuer.js
+++ b/test/contracts/Issuer.js
@@ -736,8 +736,27 @@ contract('Issuer (via Synthetix)', async accounts => {
 									it('then settling works as expected', async () => {
 										await synthetix.settle(currencyKey);
 
-										const { numEntries } = await exchanger.settlementOwing(owner, sETH);
+										const { numEntries } = await exchanger.settlementOwing(owner, currencyKey);
 										assert.equal(numEntries, '0');
+									});
+								});
+								describe('when the same user exchanges out of the synth', () => {
+									beforeEach(async () => {
+										await setExchangeWaitingPeriod({ owner, systemSettings, secs: 60 });
+										// pass through the waiting period so we can exchange again
+										await fastForward(90);
+										await synthetix.exchange(currencyKey, toUnit('1'), sUSD, { from: account2 });
+									});
+									describe('when the synth is removed', () => {
+										beforeEach(async () => {
+											await issuer.removeSynth(currencyKey, { from: owner });
+										});
+										it('then settling works as expected', async () => {
+											await synthetix.settle(sUSD);
+
+											const { numEntries } = await exchanger.settlementOwing(owner, sUSD);
+											assert.equal(numEntries, '0');
+										});
 									});
 								});
 							});

--- a/test/contracts/Issuer.js
+++ b/test/contracts/Issuer.js
@@ -757,6 +757,11 @@ contract('Issuer (via Synthetix)', async accounts => {
 											const { numEntries } = await exchanger.settlementOwing(owner, sUSD);
 											assert.equal(numEntries, '0');
 										});
+										it('then settling from the original currency works too', async () => {
+											await synthetix.settle(currencyKey);
+											const { numEntries } = await exchanger.settlementOwing(owner, currencyKey);
+											assert.equal(numEntries, '0');
+										});
 									});
 								});
 							});

--- a/test/contracts/Issuer.js
+++ b/test/contracts/Issuer.js
@@ -739,6 +739,17 @@ contract('Issuer (via Synthetix)', async accounts => {
 										const { numEntries } = await exchanger.settlementOwing(owner, currencyKey);
 										assert.equal(numEntries, '0');
 									});
+									describe('when the rate is also removed', () => {
+										beforeEach(async () => {
+											await exchangeRates.deleteRate(currencyKey, { from: oracle });
+										});
+										it('then settling works as expected', async () => {
+											await synthetix.settle(currencyKey);
+
+											const { numEntries } = await exchanger.settlementOwing(owner, currencyKey);
+											assert.equal(numEntries, '0');
+										});
+									});
 								});
 								describe('when the same user exchanges out of the synth', () => {
 									beforeEach(async () => {
@@ -761,6 +772,22 @@ contract('Issuer (via Synthetix)', async accounts => {
 											await synthetix.settle(currencyKey);
 											const { numEntries } = await exchanger.settlementOwing(owner, currencyKey);
 											assert.equal(numEntries, '0');
+										});
+										describe('when the rate is also removed', () => {
+											beforeEach(async () => {
+												await exchangeRates.deleteRate(currencyKey, { from: oracle });
+											});
+											it('then settling works as expected', async () => {
+												await synthetix.settle(currencyKey);
+
+												const { numEntries } = await exchanger.settlementOwing(owner, currencyKey);
+												assert.equal(numEntries, '0');
+											});
+											it('then settling from the original currency works too', async () => {
+												await synthetix.settle(currencyKey);
+												const { numEntries } = await exchanger.settlementOwing(owner, currencyKey);
+												assert.equal(numEntries, '0');
+											});
 										});
 									});
 								});


### PR DESCRIPTION
While `settle()` is smart enough to ignore any synth that is no longer in the system with a rate (see [this line](https://github.com/Synthetixio/synthetix/blob/master/contracts/Exchanger.sol#L225)) - and simply removes the entry in this case - there was an issue with `DebtCache` reverting. Thus, this change to 174 ensures that even after deprecation, if a user has unsettled exchanges into the synth being removed, settling them at a later date won't revert.

> Note: one requirement of this is that the aggregator for the synth is removed from `ExchangeRates` - which needs to be done during deprecation

Another way to solve this would be to guarantee all exchanges into the synth were settled prior to removing it, but this is an onerous task that would cost a lot of gas to process and even a single missed entry would mean that that account could no longer settle into that synth. 