### PR TITLE
Fixes for imports to prevent issues with IERC20

### DIFF
--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -11,6 +11,7 @@ import "./SafeDecimalMath.sol";
 
 // Internal references
 import "./interfaces/ISystemStatus.sol";
+import "./interfaces/IERC20.sol";
 import "./interfaces/IExchangeState.sol";
 import "./interfaces/IExchangeRates.sol";
 import "./interfaces/ISynthetix.sol";
@@ -20,10 +21,6 @@ import "./interfaces/IIssuer.sol";
 import "./interfaces/ITradingRewards.sol";
 import "./interfaces/IVirtualSynth.sol";
 import "./Proxyable.sol";
-
-// Note: use OZ's IERC20 here as using ours will complain about conflicting names
-// during the build (VirtualSynth has IERC20 from the OZ ERC20 implementation)
-import "openzeppelin-solidity-2.3.0/contracts/token/ERC20/IERC20.sol";
 
 // Used to have strongly-typed access to internal mutative functions in Synthetix
 interface ISynthetixInternal {

--- a/contracts/ExchangerWithVirtualSynth.sol
+++ b/contracts/ExchangerWithVirtualSynth.sol
@@ -4,9 +4,19 @@ pragma solidity ^0.5.16;
 import "./Exchanger.sol";
 
 // Internal references
-import "./interfaces/IVirtualSynth.sol";
 import "./MinimalProxyFactory.sol";
-import "./VirtualSynth.sol";
+import "./interfaces/IAddressResolver.sol";
+import "./interfaces/IERC20.sol";
+
+interface IVirtualSynthInternal {
+    function initialize(
+        IERC20 _synth,
+        IAddressResolver _resolver,
+        address _recipient,
+        uint _amount,
+        bytes32 _currencyKey
+    ) external;
+}
 
 // https://docs.synthetix.io/contracts/source/contracts/exchangerwithvirtualsynth
 contract ExchangerWithVirtualSynth is MinimalProxyFactory, Exchanger {
@@ -38,7 +48,8 @@ contract ExchangerWithVirtualSynth is MinimalProxyFactory, Exchanger {
         // prevent inverse synths from being allowed due to purgeability
         require(currencyKey[0] != 0x69, "Cannot virtualize this synth");
 
-        VirtualSynth vSynth = VirtualSynth(_cloneAsMinimalProxy(_virtualSynthMastercopy(), "Could not create new vSynth"));
+        IVirtualSynthInternal vSynth =
+            IVirtualSynthInternal(_cloneAsMinimalProxy(_virtualSynthMastercopy(), "Could not create new vSynth"));
         vSynth.initialize(synth, resolver, recipient, amount, currencyKey);
         emit VirtualSynthCreated(address(synth), recipient, address(vSynth), currencyKey, amount);
 

--- a/contracts/TradingRewards.sol
+++ b/contracts/TradingRewards.sol
@@ -6,7 +6,6 @@ import "./MixinResolver.sol";
 import "./Owned.sol";
 
 // External dependencies.
-import "openzeppelin-solidity-2.3.0/contracts/token/ERC20/ERC20Detailed.sol";
 import "openzeppelin-solidity-2.3.0/contracts/token/ERC20/SafeERC20.sol";
 import "openzeppelin-solidity-2.3.0/contracts/utils/ReentrancyGuard.sol";
 

--- a/contracts/VirtualSynth.sol
+++ b/contracts/VirtualSynth.sol
@@ -11,9 +11,6 @@ import "./interfaces/ISynth.sol";
 import "./interfaces/IAddressResolver.sol";
 import "./interfaces/IVirtualSynth.sol";
 import "./interfaces/IExchanger.sol";
-// Note: use OZ's IERC20 here as using ours will complain about conflicting names
-// during the build
-import "openzeppelin-solidity-2.3.0/contracts/token/ERC20/IERC20.sol";
 
 // https://docs.synthetix.io/contracts/source/contracts/virtualsynth
 // Note: this contract should be treated as an abstract contract and should not be directly deployed.

--- a/contracts/test-helpers/FakeTradingRewards.sol
+++ b/contracts/test-helpers/FakeTradingRewards.sol
@@ -2,8 +2,6 @@ pragma solidity ^0.5.16;
 
 import "../TradingRewards.sol";
 
-import "openzeppelin-solidity-2.3.0/contracts/token/ERC20/ERC20Detailed.sol";
-
 import "../interfaces/IExchanger.sol";
 
 contract FakeTradingRewards is TradingRewards {


### PR DESCRIPTION
This is a cleanup of the contract imports so that multiple definitions of `IERC20` - both internally and via Open Zeppelin, don't start conflicting with each other at compile time (msg: `DeclarationError: Identifier already declared.`). This started appearing in the #1493 PR as the migration needed to import both `Issuer` and `Exchanger` which led to `ERC20` being imported, along with IERC20 from Open Zeppelin, and then clashed with other imports of the internal `IERC20`.

The solution was a) to remove all references to `VirtualSynth` from `Exchanger` in the first place, relying instead on the interface, as the minimal proxy solution allows for this; then b) remove `IERC20` imported into  VirtualSynth, relying on the OZ one.