### PR TITLE
simulated liquidity feasibility

### DIFF
--- a/contracts/LiquidityOracle.sol
+++ b/contracts/LiquidityOracle.sol
@@ -1,0 +1,31 @@
+pragma solidity ^0.5.16;
+
+import "./Owned.sol";
+import "./MixinResolver.sol";
+import "./interfaces/ILiquidityOracle.sol";
+
+contract LiquidityOracle is Owned, MixinResolver, ILiquidityOracle {
+
+    // TODO: Move these to SystemSettings.
+    mapping(bytes32 => uint) public priceImpactFactor;
+    mapping(bytes32 => int) public maxOpenInterestDelta;
+
+    mapping(bytes32 => int) public openInterest;
+
+    bytes32 constant sETH = bytes32("sETH");
+    
+    constructor(
+        address _owner,
+        address _resolver
+    ) public Owned(_owner) MixinResolver(_resolver) {
+    }
+
+    function resetOpenInterest(bytes32 asset) public {
+        // New epoch.
+        maxOpenInterestDelta[asset] = 0;
+    }
+
+    function updateOpenInterest(bytes32 asset, uint amount) public {
+        maxOpenInterestDelta[asset] += amount;
+    }
+}

--- a/contracts/LiquidityOracle.sol
+++ b/contracts/LiquidityOracle.sol
@@ -14,18 +14,49 @@ contract LiquidityOracle is Owned, MixinResolver, ILiquidityOracle {
     using SafeDecimalMath for uint;
 
     // TODO: Move these to SystemSettings.
+
     mapping(bytes32 => uint) internal _priceImpactFactor;
     mapping(bytes32 => uint) internal _maxOpenInterestDelta;
+    mapping(bytes32 => int) internal _openInterest;
 
-    mapping(bytes32 => int) public openInterest;
-
-    bytes32 internal constant sETH = "sETH";
-
+    /* ========== CONSTRUCTOR ========== */
     constructor(address _owner, address _resolver) public Owned(_owner) MixinResolver(_resolver) {}
 
-    //
-    // TODO: permission these funcs.
-    //
+    /* ========== SETTERS ========== */
+
+    function setPriceImpactFactor(bytes32 asset, uint value) public onlyOwner {
+        _priceImpactFactor[asset] = value;
+    }
+
+    function setMaxOpenInterestDelta(bytes32 asset, uint value) public onlyOwner {
+        _maxOpenInterestDelta[asset] = value;
+    }
+
+    /* ========== MUTATIVE FUNCTIONS ========== */
+
+    function resetOpenInterest(bytes32 asset) public {
+        // New epoch.
+        _openInterest[asset] = 0;
+    }
+
+    function updateOpenInterest(bytes32 asset, int amount) public {
+        _openInterest[asset] += amount;
+    }
+
+    /* ========== GETTERS ========== */
+
+    // Returns the liquidity parameters for an `asset`.
+    function parameters(bytes32 asset)
+        public
+        view
+        returns (
+            int,
+            uint,
+            uint
+        )
+    {
+        return (openInterest(asset), priceImpactFactor(asset), maxOpenInterestDelta(asset));
+    }
 
     function priceImpactFactor(bytes32 asset) public view returns (uint v) {
         v = _priceImpactFactor[asset];
@@ -39,20 +70,7 @@ contract LiquidityOracle is Owned, MixinResolver, ILiquidityOracle {
         return v;
     }
 
-    function setPriceImpactFactor(bytes32 asset, uint value) public onlyOwner {
-        _priceImpactFactor[asset] = value;
-    }
-
-    function setMaxOpenInterestDelta(bytes32 asset, uint value) public onlyOwner {
-        _maxOpenInterestDelta[asset] = value;
-    }
-
-    function resetOpenInterest(bytes32 asset) public {
-        // New epoch.
-        openInterest[asset] = 0;
-    }
-
-    function updateOpenInterest(bytes32 asset, int amount) public {
-        openInterest[asset] += amount;
+    function openInterest(bytes32 asset) public view returns (int v) {
+        return _openInterest[asset];
     }
 }

--- a/contracts/LiquidityOracle.sol
+++ b/contracts/LiquidityOracle.sol
@@ -5,20 +5,15 @@ import "./MixinResolver.sol";
 import "./interfaces/ILiquidityOracle.sol";
 
 contract LiquidityOracle is Owned, MixinResolver, ILiquidityOracle {
-
     // TODO: Move these to SystemSettings.
     mapping(bytes32 => uint) public priceImpactFactor;
-    mapping(bytes32 => int) public maxOpenInterestDelta;
+    mapping(bytes32 => uint) public maxOpenInterestDelta;
 
     mapping(bytes32 => int) public openInterest;
 
-    bytes32 constant sETH = bytes32("sETH");
-    
-    constructor(
-        address _owner,
-        address _resolver
-    ) public Owned(_owner) MixinResolver(_resolver) {
-    }
+    bytes32 internal constant sETH = bytes32("sETH");
+
+    constructor(address _owner, address _resolver) public Owned(_owner) MixinResolver(_resolver) {}
 
     function resetOpenInterest(bytes32 asset) public {
         // New epoch.

--- a/contracts/LiquidityOracle.sol
+++ b/contracts/LiquidityOracle.sol
@@ -1,26 +1,58 @@
 pragma solidity ^0.5.16;
 
+// Inheritance
 import "./Owned.sol";
 import "./MixinResolver.sol";
+
+// Libraries
+import "./SafeDecimalMath.sol";
+
+// Internal references
 import "./interfaces/ILiquidityOracle.sol";
 
 contract LiquidityOracle is Owned, MixinResolver, ILiquidityOracle {
+    using SafeDecimalMath for uint;
+
     // TODO: Move these to SystemSettings.
-    mapping(bytes32 => uint) public priceImpactFactor;
-    mapping(bytes32 => uint) public maxOpenInterestDelta;
+    mapping(bytes32 => uint) internal _priceImpactFactor;
+    mapping(bytes32 => uint) internal _maxOpenInterestDelta;
 
     mapping(bytes32 => int) public openInterest;
 
-    bytes32 internal constant sETH = bytes32("sETH");
+    bytes32 internal constant sETH = "sETH";
 
     constructor(address _owner, address _resolver) public Owned(_owner) MixinResolver(_resolver) {}
 
-    function resetOpenInterest(bytes32 asset) public {
-        // New epoch.
-        maxOpenInterestDelta[asset] = 0;
+    //
+    // TODO: permission these funcs.
+    //
+
+    function priceImpactFactor(bytes32 asset) public view returns (uint v) {
+        v = _priceImpactFactor[asset];
+        require(v != 0, "unset: priceImpactFactor");
+        return v;
     }
 
-    function updateOpenInterest(bytes32 asset, uint amount) public {
-        maxOpenInterestDelta[asset] += amount;
+    function maxOpenInterestDelta(bytes32 asset) public view returns (uint v) {
+        v = _maxOpenInterestDelta[asset];
+        require(v != 0, "unset: maxOpenInterestDelta");
+        return v;
+    }
+
+    function setPriceImpactFactor(bytes32 asset, uint value) public onlyOwner {
+        _priceImpactFactor[asset] = value;
+    }
+
+    function setMaxOpenInterestDelta(bytes32 asset, uint value) public onlyOwner {
+        _maxOpenInterestDelta[asset] = value;
+    }
+
+    function resetOpenInterest(bytes32 asset) public {
+        // New epoch.
+        openInterest[asset] = 0;
+    }
+
+    function updateOpenInterest(bytes32 asset, int amount) public {
+        openInterest[asset] += amount;
     }
 }

--- a/contracts/Math.sol
+++ b/contracts/Math.sol
@@ -2,211 +2,33 @@ pragma solidity ^0.5.16;
 
 // Libraries
 import "./SafeDecimalMath.sol";
-import "openzeppelin-solidity-2.3.0/contracts/drafts/SignedSafeMath.sol";
-
-library SignedSafeDecimalMath {
-  using SignedSafeMath for int;
-
-  /* Number of decimal places in the representations. */
-  uint8 public constant decimals = 18;
-  uint8 public constant highPrecisionDecimals = 27;
-
-  /* The number representing 1.0. */
-  int public constant UNIT = int(10**uint(decimals));
-
-  /* The number representing 1.0 for higher fidelity numbers. */
-  int public constant PRECISE_UNIT = int(10**uint(highPrecisionDecimals));
-  int private constant UNIT_TO_HIGH_PRECISION_CONVERSION_FACTOR = int(10**uint(highPrecisionDecimals - decimals));
-
-  /**
-   * @return Provides an interface to UNIT.
-   */
-  function unit() external pure returns (int) {
-    return UNIT;
-  }
-
-  /**
-   * @return Provides an interface to PRECISE_UNIT.
-   */
-  function preciseUnit() external pure returns (int) {
-    return PRECISE_UNIT;
-  }
-
-  /**
-   * @return The result of multiplying x and y, interpreting the operands as fixed-point
-   * decimals.
-   *
-   * @dev A unit factor is divided out after the product of x and y is evaluated,
-   * so that product must be less than 2**256. As this is an integer division,
-   * the internal division always rounds down. This helps save on gas. Rounding
-   * is more expensive on gas.
-   */
-  function multiplyDecimal(int x, int y) internal pure returns (int) {
-    /* Divide by UNIT to remove the extra factor introduced by the product. */
-    return x.mul(y) / UNIT;
-  }
-
-  /**
-   * @return The result of safely multiplying x and y, interpreting the operands
-   * as fixed-point decimals of the specified precision unit.
-   *
-   * @dev The operands should be in the form of a the specified unit factor which will be
-   * divided out after the product of x and y is evaluated, so that product must be
-   * less than 2**256.
-   *
-   * Unlike multiplyDecimal, this function rounds the result to the nearest increment.
-   * Rounding is useful when you need to retain fidelity for small decimal numbers
-   * (eg. small fractions or percentages).
-   */
-  function _multiplyDecimalRound(
-    int x,
-    int y,
-    int precisionUnit
-  ) private pure returns (int) {
-    /* Divide by UNIT to remove the extra factor introduced by the product. */
-    int quotientTimesTen = x.mul(y) / (precisionUnit / 10);
-
-    if (quotientTimesTen % 10 >= 5) {
-      quotientTimesTen += 10;
-    }
-
-    return quotientTimesTen / 10;
-  }
-
-  /**
-   * @return The result of safely multiplying x and y, interpreting the operands
-   * as fixed-point decimals of a precise unit.
-   *
-   * @dev The operands should be in the precise unit factor which will be
-   * divided out after the product of x and y is evaluated, so that product must be
-   * less than 2**256.
-   *
-   * Unlike multiplyDecimal, this function rounds the result to the nearest increment.
-   * Rounding is useful when you need to retain fidelity for small decimal numbers
-   * (eg. small fractions or percentages).
-   */
-  function multiplyDecimalRoundPrecise(int x, int y) internal pure returns (int) {
-    return _multiplyDecimalRound(x, y, PRECISE_UNIT);
-  }
-
-  /**
-   * @return The result of safely multiplying x and y, interpreting the operands
-   * as fixed-point decimals of a standard unit.
-   *
-   * @dev The operands should be in the standard unit factor which will be
-   * divided out after the product of x and y is evaluated, so that product must be
-   * less than 2**256.
-   *
-   * Unlike multiplyDecimal, this function rounds the result to the nearest increment.
-   * Rounding is useful when you need to retain fidelity for small decimal numbers
-   * (eg. small fractions or percentages).
-   */
-  function multiplyDecimalRound(int x, int y) internal pure returns (int) {
-    return _multiplyDecimalRound(x, y, UNIT);
-  }
-
-  /**
-   * @return The result of safely dividing x and y. The return value is a high
-   * precision decimal.
-   *
-   * @dev y is divided after the product of x and the standard precision unit
-   * is evaluated, so the product of x and UNIT must be less than 2**256. As
-   * this is an integer division, the result is always rounded down.
-   * This helps save on gas. Rounding is more expensive on gas.
-   */
-  function divideDecimal(int x, int y) internal pure returns (int) {
-    /* Reintroduce the UNIT factor that will be divided out by y. */
-    return x.mul(UNIT).div(y);
-  }
-
-  /**
-   * @return The result of safely dividing x and y. The return value is as a rounded
-   * decimal in the precision unit specified in the parameter.
-   *
-   * @dev y is divided after the product of x and the specified precision unit
-   * is evaluated, so the product of x and the specified precision unit must
-   * be less than 2**256. The result is rounded to the nearest increment.
-   */
-  function _divideDecimalRound(
-    int x,
-    int y,
-    int precisionUnit
-  ) private pure returns (int) {
-    int resultTimesTen = x.mul(precisionUnit * 10).div(y);
-
-    if (resultTimesTen % 10 >= 5) {
-      resultTimesTen += 10;
-    }
-
-    return resultTimesTen / 10;
-  }
-
-  /**
-   * @return The result of safely dividing x and y. The return value is as a rounded
-   * standard precision decimal.
-   *
-   * @dev y is divided after the product of x and the standard precision unit
-   * is evaluated, so the product of x and the standard precision unit must
-   * be less than 2**256. The result is rounded to the nearest increment.
-   */
-  function divideDecimalRound(int x, int y) internal pure returns (int) {
-    return _divideDecimalRound(x, y, UNIT);
-  }
-
-  /**
-   * @return The result of safely dividing x and y. The return value is as a rounded
-   * high precision decimal.
-   *
-   * @dev y is divided after the product of x and the high precision unit
-   * is evaluated, so the product of x and the high precision unit must
-   * be less than 2**256. The result is rounded to the nearest increment.
-   */
-  function divideDecimalRoundPrecise(int x, int y) internal pure returns (int) {
-    return _divideDecimalRound(x, y, PRECISE_UNIT);
-  }
-
-  /**
-   * @dev Convert a standard decimal representation to a high precision one.
-   */
-  function decimalToPreciseDecimal(int i) internal pure returns (int) {
-    return i.mul(UNIT_TO_HIGH_PRECISION_CONVERSION_FACTOR);
-  }
-
-  /**
-   * @dev Convert a high precision decimal to a standard decimal representation.
-   */
-  function preciseDecimalToDecimal(int i) internal pure returns (int) {
-    int quotientTimesTen = i / (UNIT_TO_HIGH_PRECISION_CONVERSION_FACTOR / 10);
-
-    if (quotientTimesTen % 10 >= 5) {
-      quotientTimesTen += 10;
-    }
-
-    return quotientTimesTen / 10;
-  }
-}
-
+import "./SignedSafeMath.sol";
+import "./SignedSafeDecimalMath.sol";
 
 // https://docs.synthetix.io/contracts/source/libraries/math
 library Math {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
-  using SignedSafeMath for int;
-  using SignedSafeDecimalMath for int;
+    using SignedSafeMath for int;
+    using SignedSafeDecimalMath for int;
 
-  uint private constant SECONDS_PER_YEAR = 31536000;
-  /// @dev Internally this library uses 27 decimals of precision
-  uint private constant PRECISE_UNIT = 1e27;
-  uint private constant LN_2_PRECISE = 693147180559945309417232122;
-  uint private constant SQRT_TWOPI = 2506628274631000502415765285;
-  /// @dev Below this value, return 0
-  int private constant MIN_CDF_STD_DIST_INPUT = (int(PRECISE_UNIT) * -45) / 10; // -4.5
-  /// @dev Above this value, return 1
-  int private constant MAX_CDF_STD_DIST_INPUT = int(PRECISE_UNIT) * 10;
-  /// @dev Below this value, the result is always 0
-  int private constant MIN_EXP = -63 * int(PRECISE_UNIT);
-  /// @dev Above this value the a lot of precision is lost, and uint256s come close to not being able to handle the size
-  uint private constant MAX_EXP = 100 * PRECISE_UNIT;
+    uint private constant SECONDS_PER_YEAR = 31536000;
+    /// @dev Internally this library uses 27 decimals of precision
+    uint private constant PRECISE_UNIT = 1e27;
+    uint private constant LN_2_PRECISE = 693147180559945309417232122;
+    uint private constant SQRT_TWOPI = 2506628274631000502415765285;
+    /// @dev Below this value, return 0
+    int private constant MIN_CDF_STD_DIST_INPUT = (int(PRECISE_UNIT) * -45) / 10; // -4.5
+    /// @dev Above this value, return 1
+    int private constant MAX_CDF_STD_DIST_INPUT = int(PRECISE_UNIT) * 10;
+    /// @dev Below this value, the result is always 0
+    int private constant MIN_EXP = -63 * int(PRECISE_UNIT);
+    /// @dev Above this value the a lot of precision is lost, and uint256s come close to not being able to handle the size
+    uint private constant MAX_EXP = 100 * PRECISE_UNIT;
+    /// @dev Value to use to avoid any division by 0 or values near 0
+    uint private constant MIN_T_ANNUALISED = PRECISE_UNIT / SECONDS_PER_YEAR; // 1 second
+    uint private constant MIN_VOLATILITY = PRECISE_UNIT / 10000; // 0.001%
+    uint private constant VEGA_STANDARDISATION_MIN_DAYS = 7 days;
 
     /**
      * @dev Uses "exponentiation by squaring" algorithm where cost is 0(logN)
@@ -228,92 +50,143 @@ library Math {
         return result;
     }
 
-
     function max(uint a, uint b) public pure returns (uint) {
         return a > b ? a : b;
     }
-
 
     function max(int a, int b) public pure returns (int) {
         return a > b ? a : b;
     }
 
-  /*
-   * Math Operations
-   */
+    /*
+     * Math Operations
+     */
 
-  /**
-   * @dev Returns absolute value of an int as a uint.
-   */
-  function abs(int x) public pure returns (uint) {
-    return uint(x < 0 ? -x : x);
-  }
-
-  /**
-   * @dev Returns the floor of a PRECISE_UNIT (x - (x % 1e27))
-   */
-  function floor(uint x) internal pure returns (uint) {
-    return x - (x % PRECISE_UNIT);
-  }
-
-  /**
-   * @dev Returns the natural log of the value using Halley's method.
-   */
-  function ln(uint x) internal pure returns (int) {
-    int res;
-    int next;
-
-    for (uint i = 0; i < 8; i++) {
-      int e = int(exp(res));
-      next = res.add((int(x).sub(e).mul(2)).divideDecimalRoundPrecise(int(x).add(e)));
-      if (next == res) {
-        break;
-      }
-      res = next;
+    /**
+     * @dev Returns absolute value of an int as a uint.
+     */
+    function abs(int x) public pure returns (uint) {
+        return uint(x < 0 ? -x : x);
     }
 
-    return res;
-  }
-
-  /**
-   * @dev Returns the exponent of the value using taylor expansion with range reduction.
-   */
-  function exp(uint x) public pure  returns (uint) {
-    if (x == 0) {
-      return PRECISE_UNIT;
-    }
-    require(x <= MAX_EXP, "cannot handle exponents greater than 100");
-
-    uint k = floor(x.divideDecimalRoundPrecise(LN_2_PRECISE)) / PRECISE_UNIT;
-    uint p = 2**k;
-    uint r = x.sub(k.mul(LN_2_PRECISE));
-
-    uint _T = PRECISE_UNIT;
-
-    uint lastT;
-    for (uint8 i = 16; i > 0; i--) {
-      _T = _T.multiplyDecimalRoundPrecise(r / i).add(PRECISE_UNIT);
-      if (_T == lastT) {
-        break;
-      }
-      lastT = _T;
+    /**
+     * @dev Returns the floor of a PRECISE_UNIT (x - (x % 1e27))
+     */
+    function floor(uint x) internal pure returns (uint) {
+        return x - (x % PRECISE_UNIT);
     }
 
-    return p.mul(_T);
-  }
+    /**
+     * @dev Returns the natural log of the value using Halley's method.
+     */
+    function ln(uint x) internal pure returns (int) {
+        int res;
+        int next;
 
-  /**
-   * @dev Returns the exponent of the value using taylor expansion with range reduction, with support for negative
-   * numbers.
-   */
-  function exp(int x) public pure  returns (uint) {
-    if (0 <= x) {
-      return exp(uint(x));
-    } else if (x < MIN_EXP) {
-      // exp(-63) < 1e-27, so we just return 0
-      return 0;
-    } else {
-      return PRECISE_UNIT.divideDecimalRoundPrecise(exp(uint(-x)));
+        for (uint i = 0; i < 8; i++) {
+            int e = int(exp(res));
+            next = res.add((int(x).sub(e).mul(2)).divideDecimalRoundPrecise(int(x).add(e)));
+            if (next == res) {
+                break;
+            }
+            res = next;
+        }
+
+        return res;
     }
-  }
+
+    function log2(uint x) internal pure returns (uint y) {
+        assembly {
+            let arg := x
+            x := sub(x, 1)
+            x := or(x, div(x, 0x02))
+            x := or(x, div(x, 0x04))
+            x := or(x, div(x, 0x10))
+            x := or(x, div(x, 0x100))
+            x := or(x, div(x, 0x10000))
+            x := or(x, div(x, 0x100000000))
+            x := or(x, div(x, 0x10000000000000000))
+            x := or(x, div(x, 0x100000000000000000000000000000000))
+            x := add(x, 1)
+            let m := mload(0x40)
+            mstore(m, 0xf8f9cbfae6cc78fbefe7cdc3a1793dfcf4f0e8bbd8cec470b6a28a7a5a3e1efd)
+            mstore(add(m, 0x20), 0xf5ecf1b3e9debc68e1d9cfabc5997135bfb7a7a3938b7b606b5b4b3f2f1f0ffe)
+            mstore(add(m, 0x40), 0xf6e4ed9ff2d6b458eadcdf97bd91692de2d4da8fd2d0ac50c6ae9a8272523616)
+            mstore(add(m, 0x60), 0xc8c0b887b0a8a4489c948c7f847c6125746c645c544c444038302820181008ff)
+            mstore(add(m, 0x80), 0xf7cae577eec2a03cf3bad76fb589591debb2dd67e0aa9834bea6925f6a4a2e0e)
+            mstore(add(m, 0xa0), 0xe39ed557db96902cd38ed14fad815115c786af479b7e83247363534337271707)
+            mstore(add(m, 0xc0), 0xc976c13bb96e881cb166a933a55e490d9d56952b8d4e801485467d2362422606)
+            mstore(add(m, 0xe0), 0x753a6d1b65325d0c552a4d1345224105391a310b29122104190a110309020100)
+            mstore(0x40, add(m, 0x100))
+            let magic := 0x818283848586878898a8b8c8d8e8f929395969799a9b9d9e9faaeb6bedeeff
+            let shift := 0x100000000000000000000000000000000000000000000000000000000000000
+            let a := div(mul(x, magic), shift)
+            y := div(mload(add(m, sub(255, a))), shift)
+            y := add(y, mul(256, gt(arg, 0x8000000000000000000000000000000000000000000000000000000000000000)))
+        }
+    }
+
+    /**
+     * @dev Returns the exponent of the value using taylor expansion with range reduction.
+     */
+    function exp(uint x) public pure returns (uint) {
+        if (x == 0) {
+            return PRECISE_UNIT;
+        }
+        require(x <= MAX_EXP, "cannot handle exponents greater than 100");
+
+        uint k = floor(x.divideDecimalRoundPrecise(LN_2_PRECISE)) / PRECISE_UNIT;
+        uint p = 2**k;
+        uint r = x.sub(k.mul(LN_2_PRECISE));
+
+        uint _T = PRECISE_UNIT;
+
+        uint lastT;
+        for (uint8 i = 16; i > 0; i--) {
+            _T = _T.multiplyDecimalRoundPrecise(r / i).add(PRECISE_UNIT);
+            if (_T == lastT) {
+                break;
+            }
+            lastT = _T;
+        }
+
+        return p.mul(_T);
+    }
+
+    /**
+     * @dev Returns the exponent of the value using taylor expansion with range reduction, with support for negative
+     * numbers.
+     */
+    function exp(int x) public pure returns (uint) {
+        if (0 <= x) {
+            return exp(uint(x));
+        } else if (x < MIN_EXP) {
+            // exp(-63) < 1e-27, so we just return 0
+            return 0;
+        } else {
+            return PRECISE_UNIT.divideDecimalRoundPrecise(exp(uint(-x)));
+        }
+    }
+
+    /**
+     * @dev Returns the square root of the value using Newton's method. This ignores the unit, so numbers should be
+     * multiplied by their unit before being passed in.
+     */
+    function sqrt(uint x) public pure returns (uint y) {
+        uint z = (x.add(1)) / 2;
+        y = x;
+        while (z < y) {
+            y = z;
+            z = (x / z + z) / 2;
+        }
+    }
+
+    /**
+     * @dev Returns the square root of the value using Newton's method.
+     */
+    function sqrtPrecise(uint x) internal pure returns (uint) {
+        // Add in an extra unit factor for the square root to gobble;
+        // otherwise, sqrt(x * UNIT) = sqrt(x) * sqrt(UNIT)
+        return sqrt(x.mul(PRECISE_UNIT));
+    }
 }

--- a/contracts/Math.sol
+++ b/contracts/Math.sol
@@ -12,23 +12,13 @@ library Math {
     using SignedSafeMath for int;
     using SignedSafeDecimalMath for int;
 
-    uint private constant SECONDS_PER_YEAR = 31536000;
     /// @dev Internally this library uses 27 decimals of precision
     uint private constant PRECISE_UNIT = 1e27;
     uint private constant LN_2_PRECISE = 693147180559945309417232122;
-    uint private constant SQRT_TWOPI = 2506628274631000502415765285;
-    /// @dev Below this value, return 0
-    int private constant MIN_CDF_STD_DIST_INPUT = (int(PRECISE_UNIT) * -45) / 10; // -4.5
-    /// @dev Above this value, return 1
-    int private constant MAX_CDF_STD_DIST_INPUT = int(PRECISE_UNIT) * 10;
     /// @dev Below this value, the result is always 0
     int private constant MIN_EXP = -63 * int(PRECISE_UNIT);
     /// @dev Above this value the a lot of precision is lost, and uint256s come close to not being able to handle the size
     uint private constant MAX_EXP = 100 * PRECISE_UNIT;
-    /// @dev Value to use to avoid any division by 0 or values near 0
-    uint private constant MIN_T_ANNUALISED = PRECISE_UNIT / SECONDS_PER_YEAR; // 1 second
-    uint private constant MIN_VOLATILITY = PRECISE_UNIT / 10000; // 0.001%
-    uint private constant VEGA_STANDARDISATION_MIN_DAYS = 7 days;
 
     /**
      * @dev Uses "exponentiation by squaring" algorithm where cost is 0(logN)

--- a/contracts/Math.sol
+++ b/contracts/Math.sol
@@ -84,7 +84,7 @@ library Math {
         int next;
 
         for (uint i = 0; i < 8; i++) {
-            int e = int(exp(res));
+            int e = int(_exp(res));
             next = res.add((int(x).sub(e).mul(2)).divideDecimalRoundPrecise(int(x).add(e)));
             if (next == res) {
                 break;
@@ -95,41 +95,10 @@ library Math {
         return res;
     }
 
-    function log2(uint x) internal pure returns (uint y) {
-        assembly {
-            let arg := x
-            x := sub(x, 1)
-            x := or(x, div(x, 0x02))
-            x := or(x, div(x, 0x04))
-            x := or(x, div(x, 0x10))
-            x := or(x, div(x, 0x100))
-            x := or(x, div(x, 0x10000))
-            x := or(x, div(x, 0x100000000))
-            x := or(x, div(x, 0x10000000000000000))
-            x := or(x, div(x, 0x100000000000000000000000000000000))
-            x := add(x, 1)
-            let m := mload(0x40)
-            mstore(m, 0xf8f9cbfae6cc78fbefe7cdc3a1793dfcf4f0e8bbd8cec470b6a28a7a5a3e1efd)
-            mstore(add(m, 0x20), 0xf5ecf1b3e9debc68e1d9cfabc5997135bfb7a7a3938b7b606b5b4b3f2f1f0ffe)
-            mstore(add(m, 0x40), 0xf6e4ed9ff2d6b458eadcdf97bd91692de2d4da8fd2d0ac50c6ae9a8272523616)
-            mstore(add(m, 0x60), 0xc8c0b887b0a8a4489c948c7f847c6125746c645c544c444038302820181008ff)
-            mstore(add(m, 0x80), 0xf7cae577eec2a03cf3bad76fb589591debb2dd67e0aa9834bea6925f6a4a2e0e)
-            mstore(add(m, 0xa0), 0xe39ed557db96902cd38ed14fad815115c786af479b7e83247363534337271707)
-            mstore(add(m, 0xc0), 0xc976c13bb96e881cb166a933a55e490d9d56952b8d4e801485467d2362422606)
-            mstore(add(m, 0xe0), 0x753a6d1b65325d0c552a4d1345224105391a310b29122104190a110309020100)
-            mstore(0x40, add(m, 0x100))
-            let magic := 0x818283848586878898a8b8c8d8e8f929395969799a9b9d9e9faaeb6bedeeff
-            let shift := 0x100000000000000000000000000000000000000000000000000000000000000
-            let a := div(mul(x, magic), shift)
-            y := div(mload(add(m, sub(255, a))), shift)
-            y := add(y, mul(256, gt(arg, 0x8000000000000000000000000000000000000000000000000000000000000000)))
-        }
-    }
-
     /**
      * @dev Returns the exponent of the value using taylor expansion with range reduction.
      */
-    function exp(uint x) public pure returns (uint) {
+    function _exp(uint x) public pure returns (uint) {
         if (x == 0) {
             return PRECISE_UNIT;
         }
@@ -157,14 +126,14 @@ library Math {
      * @dev Returns the exponent of the value using taylor expansion with range reduction, with support for negative
      * numbers.
      */
-    function exp(int x) public pure returns (uint) {
+    function _exp(int x) public pure returns (uint) {
         if (0 <= x) {
-            return exp(uint(x));
+            return _exp(uint(x));
         } else if (x < MIN_EXP) {
             // exp(-63) < 1e-27, so we just return 0
             return 0;
         } else {
-            return PRECISE_UNIT.divideDecimalRoundPrecise(exp(uint(-x)));
+            return PRECISE_UNIT.divideDecimalRoundPrecise(_exp(uint(-x)));
         }
     }
 

--- a/contracts/Math.sol
+++ b/contracts/Math.sol
@@ -2,11 +2,211 @@ pragma solidity ^0.5.16;
 
 // Libraries
 import "./SafeDecimalMath.sol";
+import "openzeppelin-solidity-2.3.0/contracts/drafts/SignedSafeMath.sol";
+
+library SignedSafeDecimalMath {
+  using SignedSafeMath for int;
+
+  /* Number of decimal places in the representations. */
+  uint8 public constant decimals = 18;
+  uint8 public constant highPrecisionDecimals = 27;
+
+  /* The number representing 1.0. */
+  int public constant UNIT = int(10**uint(decimals));
+
+  /* The number representing 1.0 for higher fidelity numbers. */
+  int public constant PRECISE_UNIT = int(10**uint(highPrecisionDecimals));
+  int private constant UNIT_TO_HIGH_PRECISION_CONVERSION_FACTOR = int(10**uint(highPrecisionDecimals - decimals));
+
+  /**
+   * @return Provides an interface to UNIT.
+   */
+  function unit() external pure returns (int) {
+    return UNIT;
+  }
+
+  /**
+   * @return Provides an interface to PRECISE_UNIT.
+   */
+  function preciseUnit() external pure returns (int) {
+    return PRECISE_UNIT;
+  }
+
+  /**
+   * @return The result of multiplying x and y, interpreting the operands as fixed-point
+   * decimals.
+   *
+   * @dev A unit factor is divided out after the product of x and y is evaluated,
+   * so that product must be less than 2**256. As this is an integer division,
+   * the internal division always rounds down. This helps save on gas. Rounding
+   * is more expensive on gas.
+   */
+  function multiplyDecimal(int x, int y) internal pure returns (int) {
+    /* Divide by UNIT to remove the extra factor introduced by the product. */
+    return x.mul(y) / UNIT;
+  }
+
+  /**
+   * @return The result of safely multiplying x and y, interpreting the operands
+   * as fixed-point decimals of the specified precision unit.
+   *
+   * @dev The operands should be in the form of a the specified unit factor which will be
+   * divided out after the product of x and y is evaluated, so that product must be
+   * less than 2**256.
+   *
+   * Unlike multiplyDecimal, this function rounds the result to the nearest increment.
+   * Rounding is useful when you need to retain fidelity for small decimal numbers
+   * (eg. small fractions or percentages).
+   */
+  function _multiplyDecimalRound(
+    int x,
+    int y,
+    int precisionUnit
+  ) private pure returns (int) {
+    /* Divide by UNIT to remove the extra factor introduced by the product. */
+    int quotientTimesTen = x.mul(y) / (precisionUnit / 10);
+
+    if (quotientTimesTen % 10 >= 5) {
+      quotientTimesTen += 10;
+    }
+
+    return quotientTimesTen / 10;
+  }
+
+  /**
+   * @return The result of safely multiplying x and y, interpreting the operands
+   * as fixed-point decimals of a precise unit.
+   *
+   * @dev The operands should be in the precise unit factor which will be
+   * divided out after the product of x and y is evaluated, so that product must be
+   * less than 2**256.
+   *
+   * Unlike multiplyDecimal, this function rounds the result to the nearest increment.
+   * Rounding is useful when you need to retain fidelity for small decimal numbers
+   * (eg. small fractions or percentages).
+   */
+  function multiplyDecimalRoundPrecise(int x, int y) internal pure returns (int) {
+    return _multiplyDecimalRound(x, y, PRECISE_UNIT);
+  }
+
+  /**
+   * @return The result of safely multiplying x and y, interpreting the operands
+   * as fixed-point decimals of a standard unit.
+   *
+   * @dev The operands should be in the standard unit factor which will be
+   * divided out after the product of x and y is evaluated, so that product must be
+   * less than 2**256.
+   *
+   * Unlike multiplyDecimal, this function rounds the result to the nearest increment.
+   * Rounding is useful when you need to retain fidelity for small decimal numbers
+   * (eg. small fractions or percentages).
+   */
+  function multiplyDecimalRound(int x, int y) internal pure returns (int) {
+    return _multiplyDecimalRound(x, y, UNIT);
+  }
+
+  /**
+   * @return The result of safely dividing x and y. The return value is a high
+   * precision decimal.
+   *
+   * @dev y is divided after the product of x and the standard precision unit
+   * is evaluated, so the product of x and UNIT must be less than 2**256. As
+   * this is an integer division, the result is always rounded down.
+   * This helps save on gas. Rounding is more expensive on gas.
+   */
+  function divideDecimal(int x, int y) internal pure returns (int) {
+    /* Reintroduce the UNIT factor that will be divided out by y. */
+    return x.mul(UNIT).div(y);
+  }
+
+  /**
+   * @return The result of safely dividing x and y. The return value is as a rounded
+   * decimal in the precision unit specified in the parameter.
+   *
+   * @dev y is divided after the product of x and the specified precision unit
+   * is evaluated, so the product of x and the specified precision unit must
+   * be less than 2**256. The result is rounded to the nearest increment.
+   */
+  function _divideDecimalRound(
+    int x,
+    int y,
+    int precisionUnit
+  ) private pure returns (int) {
+    int resultTimesTen = x.mul(precisionUnit * 10).div(y);
+
+    if (resultTimesTen % 10 >= 5) {
+      resultTimesTen += 10;
+    }
+
+    return resultTimesTen / 10;
+  }
+
+  /**
+   * @return The result of safely dividing x and y. The return value is as a rounded
+   * standard precision decimal.
+   *
+   * @dev y is divided after the product of x and the standard precision unit
+   * is evaluated, so the product of x and the standard precision unit must
+   * be less than 2**256. The result is rounded to the nearest increment.
+   */
+  function divideDecimalRound(int x, int y) internal pure returns (int) {
+    return _divideDecimalRound(x, y, UNIT);
+  }
+
+  /**
+   * @return The result of safely dividing x and y. The return value is as a rounded
+   * high precision decimal.
+   *
+   * @dev y is divided after the product of x and the high precision unit
+   * is evaluated, so the product of x and the high precision unit must
+   * be less than 2**256. The result is rounded to the nearest increment.
+   */
+  function divideDecimalRoundPrecise(int x, int y) internal pure returns (int) {
+    return _divideDecimalRound(x, y, PRECISE_UNIT);
+  }
+
+  /**
+   * @dev Convert a standard decimal representation to a high precision one.
+   */
+  function decimalToPreciseDecimal(int i) internal pure returns (int) {
+    return i.mul(UNIT_TO_HIGH_PRECISION_CONVERSION_FACTOR);
+  }
+
+  /**
+   * @dev Convert a high precision decimal to a standard decimal representation.
+   */
+  function preciseDecimalToDecimal(int i) internal pure returns (int) {
+    int quotientTimesTen = i / (UNIT_TO_HIGH_PRECISION_CONVERSION_FACTOR / 10);
+
+    if (quotientTimesTen % 10 >= 5) {
+      quotientTimesTen += 10;
+    }
+
+    return quotientTimesTen / 10;
+  }
+}
+
 
 // https://docs.synthetix.io/contracts/source/libraries/math
 library Math {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
+  using SignedSafeMath for int;
+  using SignedSafeDecimalMath for int;
+
+  uint private constant SECONDS_PER_YEAR = 31536000;
+  /// @dev Internally this library uses 27 decimals of precision
+  uint private constant PRECISE_UNIT = 1e27;
+  uint private constant LN_2_PRECISE = 693147180559945309417232122;
+  uint private constant SQRT_TWOPI = 2506628274631000502415765285;
+  /// @dev Below this value, return 0
+  int private constant MIN_CDF_STD_DIST_INPUT = (int(PRECISE_UNIT) * -45) / 10; // -4.5
+  /// @dev Above this value, return 1
+  int private constant MAX_CDF_STD_DIST_INPUT = int(PRECISE_UNIT) * 10;
+  /// @dev Below this value, the result is always 0
+  int private constant MIN_EXP = -63 * int(PRECISE_UNIT);
+  /// @dev Above this value the a lot of precision is lost, and uint256s come close to not being able to handle the size
+  uint private constant MAX_EXP = 100 * PRECISE_UNIT;
 
     /**
      * @dev Uses "exponentiation by squaring" algorithm where cost is 0(logN)
@@ -27,4 +227,93 @@ library Math {
         }
         return result;
     }
+
+
+    function max(uint a, uint b) public pure returns (uint) {
+        return a > b ? a : b;
+    }
+
+
+    function max(int a, int b) public pure returns (int) {
+        return a > b ? a : b;
+    }
+
+  /*
+   * Math Operations
+   */
+
+  /**
+   * @dev Returns absolute value of an int as a uint.
+   */
+  function abs(int x) public pure returns (uint) {
+    return uint(x < 0 ? -x : x);
+  }
+
+  /**
+   * @dev Returns the floor of a PRECISE_UNIT (x - (x % 1e27))
+   */
+  function floor(uint x) internal pure returns (uint) {
+    return x - (x % PRECISE_UNIT);
+  }
+
+  /**
+   * @dev Returns the natural log of the value using Halley's method.
+   */
+  function ln(uint x) internal pure returns (int) {
+    int res;
+    int next;
+
+    for (uint i = 0; i < 8; i++) {
+      int e = int(exp(res));
+      next = res.add((int(x).sub(e).mul(2)).divideDecimalRoundPrecise(int(x).add(e)));
+      if (next == res) {
+        break;
+      }
+      res = next;
+    }
+
+    return res;
+  }
+
+  /**
+   * @dev Returns the exponent of the value using taylor expansion with range reduction.
+   */
+  function exp(uint x) public pure  returns (uint) {
+    if (x == 0) {
+      return PRECISE_UNIT;
+    }
+    require(x <= MAX_EXP, "cannot handle exponents greater than 100");
+
+    uint k = floor(x.divideDecimalRoundPrecise(LN_2_PRECISE)) / PRECISE_UNIT;
+    uint p = 2**k;
+    uint r = x.sub(k.mul(LN_2_PRECISE));
+
+    uint _T = PRECISE_UNIT;
+
+    uint lastT;
+    for (uint8 i = 16; i > 0; i--) {
+      _T = _T.multiplyDecimalRoundPrecise(r / i).add(PRECISE_UNIT);
+      if (_T == lastT) {
+        break;
+      }
+      lastT = _T;
+    }
+
+    return p.mul(_T);
+  }
+
+  /**
+   * @dev Returns the exponent of the value using taylor expansion with range reduction, with support for negative
+   * numbers.
+   */
+  function exp(int x) public pure  returns (uint) {
+    if (0 <= x) {
+      return exp(uint(x));
+    } else if (x < MIN_EXP) {
+      // exp(-63) < 1e-27, so we just return 0
+      return 0;
+    } else {
+      return PRECISE_UNIT.divideDecimalRoundPrecise(exp(uint(-x)));
+    }
+  }
 }

--- a/contracts/SignedSafeDecimalMath.sol
+++ b/contracts/SignedSafeDecimalMath.sol
@@ -1,0 +1,185 @@
+pragma solidity ^0.5.16;
+
+import "./SignedSafeMath.sol";
+
+library SignedSafeDecimalMath {
+    using SignedSafeMath for int;
+
+    /* Number of decimal places in the representations. */
+    uint8 public constant decimals = 18;
+    uint8 public constant highPrecisionDecimals = 27;
+
+    /* The number representing 1.0. */
+    int public constant UNIT = int(10**uint(decimals));
+
+    /* The number representing 1.0 for higher fidelity numbers. */
+    int public constant PRECISE_UNIT = int(10**uint(highPrecisionDecimals));
+    int private constant UNIT_TO_HIGH_PRECISION_CONVERSION_FACTOR = int(10**uint(highPrecisionDecimals - decimals));
+
+    /**
+     * @return Provides an interface to UNIT.
+     */
+    function unit() external pure returns (int) {
+        return UNIT;
+    }
+
+    /**
+     * @return Provides an interface to PRECISE_UNIT.
+     */
+    function preciseUnit() external pure returns (int) {
+        return PRECISE_UNIT;
+    }
+
+    /**
+     * @return The result of multiplying x and y, interpreting the operands as fixed-point
+     * decimals.
+     *
+     * @dev A unit factor is divided out after the product of x and y is evaluated,
+     * so that product must be less than 2**256. As this is an integer division,
+     * the internal division always rounds down. This helps save on gas. Rounding
+     * is more expensive on gas.
+     */
+    function multiplyDecimal(int x, int y) internal pure returns (int) {
+        /* Divide by UNIT to remove the extra factor introduced by the product. */
+        return x.mul(y) / UNIT;
+    }
+
+    /**
+     * @return The result of safely multiplying x and y, interpreting the operands
+     * as fixed-point decimals of the specified precision unit.
+     *
+     * @dev The operands should be in the form of a the specified unit factor which will be
+     * divided out after the product of x and y is evaluated, so that product must be
+     * less than 2**256.
+     *
+     * Unlike multiplyDecimal, this function rounds the result to the nearest increment.
+     * Rounding is useful when you need to retain fidelity for small decimal numbers
+     * (eg. small fractions or percentages).
+     */
+    function _multiplyDecimalRound(
+        int x,
+        int y,
+        int precisionUnit
+    ) private pure returns (int) {
+        /* Divide by UNIT to remove the extra factor introduced by the product. */
+        int quotientTimesTen = x.mul(y) / (precisionUnit / 10);
+
+        if (quotientTimesTen % 10 >= 5) {
+            quotientTimesTen += 10;
+        }
+
+        return quotientTimesTen / 10;
+    }
+
+    /**
+     * @return The result of safely multiplying x and y, interpreting the operands
+     * as fixed-point decimals of a precise unit.
+     *
+     * @dev The operands should be in the precise unit factor which will be
+     * divided out after the product of x and y is evaluated, so that product must be
+     * less than 2**256.
+     *
+     * Unlike multiplyDecimal, this function rounds the result to the nearest increment.
+     * Rounding is useful when you need to retain fidelity for small decimal numbers
+     * (eg. small fractions or percentages).
+     */
+    function multiplyDecimalRoundPrecise(int x, int y) internal pure returns (int) {
+        return _multiplyDecimalRound(x, y, PRECISE_UNIT);
+    }
+
+    /**
+     * @return The result of safely multiplying x and y, interpreting the operands
+     * as fixed-point decimals of a standard unit.
+     *
+     * @dev The operands should be in the standard unit factor which will be
+     * divided out after the product of x and y is evaluated, so that product must be
+     * less than 2**256.
+     *
+     * Unlike multiplyDecimal, this function rounds the result to the nearest increment.
+     * Rounding is useful when you need to retain fidelity for small decimal numbers
+     * (eg. small fractions or percentages).
+     */
+    function multiplyDecimalRound(int x, int y) internal pure returns (int) {
+        return _multiplyDecimalRound(x, y, UNIT);
+    }
+
+    /**
+     * @return The result of safely dividing x and y. The return value is a high
+     * precision decimal.
+     *
+     * @dev y is divided after the product of x and the standard precision unit
+     * is evaluated, so the product of x and UNIT must be less than 2**256. As
+     * this is an integer division, the result is always rounded down.
+     * This helps save on gas. Rounding is more expensive on gas.
+     */
+    function divideDecimal(int x, int y) internal pure returns (int) {
+        /* Reintroduce the UNIT factor that will be divided out by y. */
+        return x.mul(UNIT).div(y);
+    }
+
+    /**
+     * @return The result of safely dividing x and y. The return value is as a rounded
+     * decimal in the precision unit specified in the parameter.
+     *
+     * @dev y is divided after the product of x and the specified precision unit
+     * is evaluated, so the product of x and the specified precision unit must
+     * be less than 2**256. The result is rounded to the nearest increment.
+     */
+    function _divideDecimalRound(
+        int x,
+        int y,
+        int precisionUnit
+    ) private pure returns (int) {
+        int resultTimesTen = x.mul(precisionUnit * 10).div(y);
+
+        if (resultTimesTen % 10 >= 5) {
+            resultTimesTen += 10;
+        }
+
+        return resultTimesTen / 10;
+    }
+
+    /**
+     * @return The result of safely dividing x and y. The return value is as a rounded
+     * standard precision decimal.
+     *
+     * @dev y is divided after the product of x and the standard precision unit
+     * is evaluated, so the product of x and the standard precision unit must
+     * be less than 2**256. The result is rounded to the nearest increment.
+     */
+    function divideDecimalRound(int x, int y) internal pure returns (int) {
+        return _divideDecimalRound(x, y, UNIT);
+    }
+
+    /**
+     * @return The result of safely dividing x and y. The return value is as a rounded
+     * high precision decimal.
+     *
+     * @dev y is divided after the product of x and the high precision unit
+     * is evaluated, so the product of x and the high precision unit must
+     * be less than 2**256. The result is rounded to the nearest increment.
+     */
+    function divideDecimalRoundPrecise(int x, int y) internal pure returns (int) {
+        return _divideDecimalRound(x, y, PRECISE_UNIT);
+    }
+
+    /**
+     * @dev Convert a standard decimal representation to a high precision one.
+     */
+    function decimalToPreciseDecimal(int i) internal pure returns (int) {
+        return i.mul(UNIT_TO_HIGH_PRECISION_CONVERSION_FACTOR);
+    }
+
+    /**
+     * @dev Convert a high precision decimal to a standard decimal representation.
+     */
+    function preciseDecimalToDecimal(int i) internal pure returns (int) {
+        int quotientTimesTen = i / (UNIT_TO_HIGH_PRECISION_CONVERSION_FACTOR / 10);
+
+        if (quotientTimesTen % 10 >= 5) {
+            quotientTimesTen += 10;
+        }
+
+        return quotientTimesTen / 10;
+    }
+}

--- a/contracts/SignedSafeMath.sol
+++ b/contracts/SignedSafeMath.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.5.0;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations.
+ *
+ * NOTE: `SignedSafeMath` is no longer needed starting with Solidity 0.8. The compiler
+ * now has built in overflow checking.
+ */
+library SignedSafeMath {
+    /**
+     * @dev Returns the multiplication of two signed integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `*` operator.
+     *
+     * Requirements:
+     *
+     * - Multiplication cannot overflow.
+     */
+    function mul(int256 a, int256 b) internal pure returns (int256) {
+        return a * b;
+    }
+
+    /**
+     * @dev Returns the integer division of two signed integers. Reverts on
+     * division by zero. The result is rounded towards zero.
+     *
+     * Counterpart to Solidity's `/` operator.
+     *
+     * Requirements:
+     *
+     * - The divisor cannot be zero.
+     */
+    function div(int256 a, int256 b) internal pure returns (int256) {
+        return a / b;
+    }
+
+    /**
+     * @dev Returns the subtraction of two signed integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `-` operator.
+     *
+     * Requirements:
+     *
+     * - Subtraction cannot overflow.
+     */
+    function sub(int256 a, int256 b) internal pure returns (int256) {
+        return a - b;
+    }
+
+    /**
+     * @dev Returns the addition of two signed integers, reverting on
+     * overflow.
+     *
+     * Counterpart to Solidity's `+` operator.
+     *
+     * Requirements:
+     *
+     * - Addition cannot overflow.
+     */
+    function add(int256 a, int256 b) internal pure returns (int256) {
+        return a + b;
+    }
+}

--- a/contracts/SimulatedLiquidityMath.sol
+++ b/contracts/SimulatedLiquidityMath.sol
@@ -1,0 +1,74 @@
+pragma solidity ^0.5.16;
+
+// Libraries
+import "./Math.sol";
+import "./SafeDecimalMath.sol";
+import "./SignedSafeDecimalMath.sol";
+
+library SimulatedLiquidityMath {
+    using SafeMath for uint;
+    using SafeDecimalMath for uint;
+    using SignedSafeDecimalMath for int;
+
+    function _calculatePricePremiumIntegral(
+        int n,
+        uint delta,
+        uint lambda
+    ) public view returns (int) {
+        int num = int(delta) - n;
+        int denom = int(delta) + n;
+
+        if (denom <= 0) {
+            return -int(SafeDecimalMath.unit()) / 5; // -0.2
+        } else if (num <= 0) {
+            return int(SafeDecimalMath.unit()) / 5; // 0.2
+        }
+
+        // Math.ln accepts integers encoded with 27dp.
+        // This scales from the default UNIT of 18dp.
+        uint LN_SCALE_FACTOR = 10**9;
+        uint UNIT = SafeDecimalMath.unit();
+
+        return
+            int(lambda).multiplyDecimal(int(delta) - n).multiplyDecimal(
+                Math.ln(uint(num).divideDecimal(uint(denom)) * LN_SCALE_FACTOR) / int(LN_SCALE_FACTOR)
+            ) +
+            int(2 * UNIT).multiplyDecimal(int(delta)).multiplyDecimal(int(lambda)).multiplyDecimal(
+                Math.ln((delta + uint(n)) * LN_SCALE_FACTOR) / int(LN_SCALE_FACTOR)
+            );
+    }
+
+    function calculateQuotePrice(
+        int s,
+        int n,
+        uint _O,
+        uint lambda,
+        uint delta
+    ) internal view returns (int) {
+        if (s == 0) {
+            return int(_O);
+        }
+
+        return
+            int(_O) +
+            int(_O).divideDecimal(s).multiplyDecimal(
+                _calculatePricePremiumIntegral(n + s, delta, lambda) - _calculatePricePremiumIntegral(n, delta, lambda)
+            );
+    }
+
+    // Gets the quote for a trade to buy `buyAmount` of an asset at a given oracle price,
+    // given the simulated liquidity parameters of the asset.
+    function getSimulatedQuote(
+        int openInterest,
+        uint priceImpactFactor,
+        uint maxOpenInterest,
+        uint oraclePrice,
+        int buyAmount
+    ) public view returns (int quotePrice, int quoteAmount) {
+        // premium_ = premium(open_interest + amount, delta, lambda_)
+        // mark_price = rate * (1 + premium_)
+        quotePrice = calculateQuotePrice(buyAmount, openInterest, oraclePrice, priceImpactFactor, maxOpenInterest);
+        quoteAmount = buyAmount.multiplyDecimal(quotePrice);
+        return (quotePrice, quoteAmount);
+    }
+}

--- a/contracts/interfaces/ILiquidityOracle.sol
+++ b/contracts/interfaces/ILiquidityOracle.sol
@@ -7,6 +7,15 @@ interface ILiquidityOracle {
 
     function openInterest(bytes32 asset) external view returns (int);
 
+    function parameters(bytes32 asset)
+        external
+        view
+        returns (
+            int openInterest,
+            uint priceImpact,
+            uint maxOpenInterest
+        );
+
     function resetOpenInterest(bytes32 asset) external;
 
     function updateOpenInterest(bytes32 asset, int amount) external;

--- a/contracts/interfaces/ILiquidityOracle.sol
+++ b/contracts/interfaces/ILiquidityOracle.sol
@@ -1,9 +1,13 @@
 pragma solidity ^0.5.16;
 
 interface ILiquidityOracle {
+    function priceImpactFactor(bytes32 asset) external view returns (uint);
+
+    function maxOpenInterestDelta(bytes32 asset) external view returns (uint);
+
+    function openInterest(bytes32 asset) external view returns (int);
+
     function resetOpenInterest(bytes32 asset) external;
+
     function updateOpenInterest(bytes32 asset, uint amount) external;
-    function openInterest(bytes32 asset) external returns (uint);
-    function priceImpactFactor(bytes32 asset) external returns (uint);
-    function maxOpenInterestDelta(bytes32 asset) external returns (int);
 }

--- a/contracts/interfaces/ILiquidityOracle.sol
+++ b/contracts/interfaces/ILiquidityOracle.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.5.16;
+
+interface ILiquidityOracle {
+    function resetOpenInterest(bytes32 asset) external;
+    function updateOpenInterest(bytes32 asset, uint amount) external;
+    function openInterest(bytes32 asset) external returns (uint);
+    function priceImpactFactor(bytes32 asset) external returns (uint);
+    function maxOpenInterestDelta(bytes32 asset) external returns (int);
+}

--- a/contracts/interfaces/ILiquidityOracle.sol
+++ b/contracts/interfaces/ILiquidityOracle.sol
@@ -9,5 +9,5 @@ interface ILiquidityOracle {
 
     function resetOpenInterest(bytes32 asset) external;
 
-    function updateOpenInterest(bytes32 asset, uint amount) external;
+    function updateOpenInterest(bytes32 asset, int amount) external;
 }

--- a/contracts/test-helpers/PublicSimulatedLiquidityMath.sol
+++ b/contracts/test-helpers/PublicSimulatedLiquidityMath.sol
@@ -1,0 +1,18 @@
+/* PublicSimulatedLiquidityMath.sol: expose the internal functions in SimulatedLiquidityMath library
+ * for testing purposes.
+ */
+pragma solidity ^0.5.16;
+
+import "../SimulatedLiquidityMath.sol";
+
+contract PublicSimulatedLiquidityMath {
+    function getSimulatedQuote(
+        int openInterest,
+        uint lambda,
+        uint delta,
+        uint oraclePrice,
+        int buyAmount
+    ) public view returns (int quotePrice, int quoteAmount) {
+        return SimulatedLiquidityMath.getSimulatedQuote(openInterest, lambda, delta, oraclePrice, buyAmount);
+    }
+}

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -70,6 +70,7 @@ contract('Exchanger (spec tests)', async accounts => {
 		debtCache,
 		issuer,
 		flexibleStorage,
+		/* eslint-disable no-unused-vars */
 		liquidityOracle;
 
 	const itReadsTheWaitingPeriod = () => {
@@ -3937,17 +3938,18 @@ contract('Exchanger (spec tests)', async accounts => {
 
 		itSetsExchangeFeeRateForSynths();
 
-		describe.only('simulated slippage', async () => {
+		describe('simulated slippage', async () => {
 			it('getSimulatedPrice', async () => {
 				const { quotePrice, quoteAmount } = await exchanger.getSimulatedPrice(
 					sETH,
 					toUnit('2000'),
 					toUnit('20000')
 				);
-				console.log([quotePrice, quoteAmount].map(x => x.toString()));
+				// console.log([quotePrice, quoteAmount].map(x => x.toString()));
 
 				// exchange ETH amount=20,000.000 rate=2000 premium=0.00537 mark_price=2,010.731 quote_price=2,005.349 take_amount=40,106,984.985
-				// exchange ETH amount = -20, 000.000 rate = 2000 premium = -0.00000 mark_price = 2, 000.000 quote_price = 2, 005.349 take_amount = -40, 106, 984.985
+				assert.bnClose(quotePrice, toUnit('2005.349'), toUnit('1'));
+				assert.bnClose(quoteAmount, toUnit('40106984.985'), toUnit('10'));
 			});
 		});
 	});

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -3937,20 +3937,5 @@ contract('Exchanger (spec tests)', async accounts => {
 		itPricesSpikeDeviation();
 
 		itSetsExchangeFeeRateForSynths();
-
-		describe('simulated slippage', async () => {
-			it('getSimulatedPrice', async () => {
-				const { quotePrice, quoteAmount } = await exchanger.getSimulatedPrice(
-					sETH,
-					toUnit('2000'),
-					toUnit('20000')
-				);
-				// console.log([quotePrice, quoteAmount].map(x => x.toString()));
-
-				// exchange ETH amount=20,000.000 rate=2000 premium=0.00537 mark_price=2,010.731 quote_price=2,005.349 take_amount=40,106,984.985
-				assert.bnClose(quotePrice, toUnit('2005.349'), toUnit('1'));
-				assert.bnClose(quoteAmount, toUnit('40106984.985'), toUnit('10'));
-			});
-		});
 	});
 });

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -69,7 +69,8 @@ contract('Exchanger (spec tests)', async accounts => {
 		resolver,
 		debtCache,
 		issuer,
-		flexibleStorage;
+		flexibleStorage,
+		liquidityOracle;
 
 	const itReadsTheWaitingPeriod = () => {
 		describe('waitingPeriodSecs', () => {
@@ -3857,6 +3858,7 @@ contract('Exchanger (spec tests)', async accounts => {
 				DebtCache: debtCache,
 				Issuer: issuer,
 				FlexibleStorage: flexibleStorage,
+				LiquidityOracle: liquidityOracle,
 			} = await setupAllContracts({
 				accounts,
 				synths: ['sUSD', 'sETH', 'sEUR', 'sAUD', 'sBTC', 'iBTC', 'sTRX'],
@@ -3874,6 +3876,7 @@ contract('Exchanger (spec tests)', async accounts => {
 					'DelegateApprovals',
 					'FlexibleStorage',
 					'CollateralManager',
+					'LiquidityOracle',
 				],
 			}));
 
@@ -3933,5 +3936,19 @@ contract('Exchanger (spec tests)', async accounts => {
 		itPricesSpikeDeviation();
 
 		itSetsExchangeFeeRateForSynths();
+
+		describe.only('simulated slippage', async () => {
+			it('getSimulatedPrice', async () => {
+				const { quotePrice, quoteAmount } = await exchanger.getSimulatedPrice(
+					sETH,
+					toUnit('2000'),
+					toUnit('20000')
+				);
+				console.log([quotePrice, quoteAmount].map(x => x.toString()));
+
+				// exchange ETH amount=20,000.000 rate=2000 premium=0.00537 mark_price=2,010.731 quote_price=2,005.349 take_amount=40,106,984.985
+				// exchange ETH amount = -20, 000.000 rate = 2000 premium = -0.00000 mark_price = 2, 000.000 quote_price = 2, 005.349 take_amount = -40, 106, 984.985
+			});
+		});
 	});
 });

--- a/test/contracts/SimulatedLiquidityMath.js
+++ b/test/contracts/SimulatedLiquidityMath.js
@@ -1,0 +1,66 @@
+'use strict';
+
+const { artifacts, contract } = require('hardhat');
+
+const { assert } = require('./common');
+
+const Math$ = artifacts.require('contracts/Math.sol:Math');
+const SafeMath = artifacts.require('SafeMath');
+const SafeDecimalMath = artifacts.require('SafeDecimalMath');
+const SignedSafeMath = artifacts.require('SignedSafeMath');
+const SignedSafeDecimalMath = artifacts.require('SignedSafeDecimalMath');
+const SimulatedLiquidityMath = artifacts.require('SimulatedLiquidityMath');
+const PublicSimulatedLiquidityMath = artifacts.require('PublicSimulatedLiquidityMath');
+
+const { toUnit } = require('../utils')();
+
+contract('SimulatedLiquidityMath', async () => {
+	let instance;
+
+	before(async () => {
+		Math$.link(await SafeDecimalMath.new());
+		Math$.link(await SignedSafeMath.new());
+		Math$.link(await SignedSafeDecimalMath.new());
+
+		SafeDecimalMath.link(SafeMath.new());
+
+		SignedSafeDecimalMath.link();
+
+		SimulatedLiquidityMath.link(await Math$.new());
+		SimulatedLiquidityMath.link(await SafeDecimalMath.new());
+		SimulatedLiquidityMath.link(await SignedSafeDecimalMath.new());
+		PublicSimulatedLiquidityMath.link(await SimulatedLiquidityMath.new());
+	});
+
+	beforeEach(async () => {
+		// Save ourselves from having to await deployed() in every single test.
+		// We do this in a beforeEach instead of before to ensure we isolate
+		// contract interfaces to prevent test bleed.
+		instance = await PublicSimulatedLiquidityMath.new();
+	});
+
+	// -----------------------
+	// UNITS
+	// -----------------------
+
+	it('getSimulatedPrice', async () => {
+		const openInterest = toUnit('0');
+		const priceImpactFactor = toUnit('0.02');
+		const maxOpenInterest = toUnit('150000');
+		const oraclePrice = toUnit('2000');
+		const buyAmount = toUnit('20000');
+
+		const { quotePrice, quoteAmount } = await instance.getSimulatedPrice(
+			openInterest,
+			priceImpactFactor,
+			maxOpenInterest,
+			oraclePrice,
+			buyAmount
+		);
+		// console.log([quotePrice, quoteAmount].map(x => x.toString()));
+
+		// exchange ETH amount=20,000.000 rate=2000 premium=0.00537 mark_price=2,010.731 quote_price=2,005.349 take_amount=40,106,984.985
+		assert.bnClose(quotePrice, toUnit('2005.349'), toUnit('1'));
+		assert.bnClose(quoteAmount, toUnit('40106984.985'), toUnit('10'));
+	});
+});

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -145,6 +145,7 @@ const setupContract = async ({
 		AddressResolver: [owner],
 		SystemStatus: [owner],
 		FlexibleStorage: [tryGetAddressOf('AddressResolver')],
+		LiquidityOracle: [owner, tryGetAddressOf('AddressResolver')],
 		ExchangeRates: [
 			owner,
 			oracle,
@@ -592,8 +593,12 @@ const setupAllContracts = async ({
 			deps: ['AddressResolver', 'FlexibleStorage'],
 		},
 		{
+			contract: 'LiquidityOracle',
+			deps: ['AddressResolver'],
+		},
+		{
 			contract: 'ExchangeRates',
-			deps: ['AddressResolver', 'SystemSettings'],
+			deps: ['AddressResolver', 'SystemSettings', 'LiquidityOracle'],
 			mocks: ['Exchanger'],
 		},
 		{ contract: 'SynthetixState' },
@@ -682,6 +687,7 @@ const setupAllContracts = async ({
 				'ExchangeState',
 				'FlexibleStorage',
 				'DebtCache',
+				'LiquidityOracle',
 			],
 		},
 		{
@@ -1026,6 +1032,12 @@ const setupAllContracts = async ({
 				from: owner,
 			}),
 			returnObj['SystemSettings'].setEtherWrapperBurnFeeRate(ETHER_WRAPPER_BURN_FEE_RATE, {
+				from: owner,
+			}),
+			returnObj['LiquidityOracle'].setMaxOpenInterestDelta(toBytes32('sETH'), toUnit('150000'), {
+				from: owner,
+			}),
+			returnObj['LiquidityOracle'].setPriceImpactFactor(toBytes32('sETH'), toUnit('0.02'), {
 				from: owner,
 			}),
 		]);


### PR DESCRIPTION
Working Solidity implementation of the simulated liquidity pricing mechanism (https://github.com/Synthetixio/SIPs/pull/706) for exchanges.

Based off of the design built in the model here - https://colab.research.google.com/drive/1Nm9TsA3r3Ldfzr0NUgzR0JjO_nNtM5wb?usp=sharing#scrollTo=lKuZRWnpOxj2

Introduces a `LiquidityOracle` which tracks open interest during an epoch, modifies `Exchanger` and `ExchangeRates` accordingly.

Math stolen from lyra's contracts here - https://github.com/lyra-finance/lyra-protocol/blob/master/contracts/BlackScholes.sol#L62

To do:

 - [ ] Design to what side of the trade that price impact should be applied during exchanges.
 - [ ] Add ACL and permissioning to LiquidityOracle.