### PR TITLE
Print deploy param object value

### DIFF
--- a/publish/src/commands/deploy/get-deploy-parameter-factory.js
+++ b/publish/src/commands/deploy/get-deploy-parameter-factory.js
@@ -21,7 +21,11 @@ module.exports = ({ params, yes, ignoreCustomParameters }) => async name => {
 			try {
 				await confirmAction(
 					yellow(
-						`⚠⚠⚠ WARNING: Found an entry for ${param.name} in params.json. Specified value is ${param.value} and default is ${defaultParam}.` +
+						`⚠⚠⚠ WARNING: Found an entry for ${
+							param.name
+						} in params.json. Specified value is ${JSON.stringify(
+							param.value
+						)} and default is ${JSON.stringify(defaultParam)}.` +
 							'\nDo you want to use the specified value (default otherwise)? (y/n) '
 					)
 				);


### PR DESCRIPTION
This PR introduces a minor addition to `get-deploy-parameter-factory.js` so it can output the value of an overridden parameter of type `Object`.