### PR TITLE
Refactor exceedsDebtLimit check

### DIFF
--- a/contracts/CollateralManager.sol
+++ b/contracts/CollateralManager.sol
@@ -215,8 +215,7 @@ contract CollateralManager is ICollateralManager, Owned, Pausable, MixinResolver
             for (uint i = 0; i < rates.length; i++) {
                 uint longAmount = state.long(currencyKeys[i]).multiplyDecimal(rates[i]);
                 uint shortAmount = state.short(currencyKeys[i]).multiplyDecimal(rates[i]);
-                susdValue = susdValue.add(longAmount);
-                susdValue = susdValue.add(shortAmount);
+                susdValue = susdValue.add(longAmount).add(shortAmount);
                 if (invalid) {
                     anyRateIsInvalid = true;
                 }

--- a/contracts/CollateralManager.sol
+++ b/contracts/CollateralManager.sol
@@ -172,11 +172,11 @@ contract CollateralManager is ICollateralManager, Owned, Pausable, MixinResolver
     }
 
     function totalLong() public view returns (uint susdValue, bool anyRateIsInvalid) {
-        bytes32[] memory synths = _synths.elements;
+        bytes32[] memory synths = _currencyKeys.elements;
 
         if (synths.length > 0) {
             for (uint i = 0; i < synths.length; i++) {
-                bytes32 synth = _synth(synths[i]).currencyKey();
+                bytes32 synth = synths[i];
                 if (synth == sUSD) {
                     susdValue = susdValue.add(state.long(synth));
                 } else {
@@ -400,6 +400,7 @@ contract CollateralManager is ICollateralManager, Owned, Pausable, MixinResolver
             if (_synths.contains(synths[i])) {
                 // Remove it from the the address set lib.
                 _synths.remove(synths[i]);
+                _currencyKeys.remove(synthKeys[i]);
                 delete synthsByKey[synthKeys[i]];
 
                 emit SynthRemoved(synths[i]);

--- a/publish/src/commands/deploy/get-deploy-parameter-factory.js
+++ b/publish/src/commands/deploy/get-deploy-parameter-factory.js
@@ -21,7 +21,11 @@ module.exports = ({ params, yes, ignoreCustomParameters }) => async name => {
 			try {
 				await confirmAction(
 					yellow(
-						`⚠⚠⚠ WARNING: Found an entry for ${param.name} in params.json. Specified value is ${param.value} and default is ${defaultParam}.` +
+						`⚠⚠⚠ WARNING: Found an entry for ${
+							param.name
+						} in params.json. Specified value is ${JSON.stringify(
+							param.value
+						)} and default is ${JSON.stringify(defaultParam)}.` +
 							'\nDo you want to use the specified value (default otherwise)? (y/n) '
 					)
 				);

--- a/test/contracts/CollateralManager.js
+++ b/test/contracts/CollateralManager.js
@@ -358,6 +358,13 @@ contract('CollateralManager', async accounts => {
 			assert.bnEqual(debt, toUnit(100));
 		});
 
+		it('should get the total long and short balance in sUSD correctly', async () => {
+			const total = await manager.totalLongAndShort();
+			const debt = total.susdValue;
+
+			assert.bnEqual(debt, toUnit(500));
+		});
+
 		it('should report if a rate is invalid', async () => {
 			await fastForward(await exchangeRates.rateStalePeriod());
 


### PR DESCRIPTION
This PR fixes an issue where opening a loan may hit the gas limit on L2 since `CollateralManager.exceedsDebtLimit` calls `totalLong` and `totalShort` which iterate through both long and short synth arrays.

- Added the `totalLongAndShort` function so we can do just one `SLOAD` per fnc call rather than doing one for each synth in a loop.
- Reporting ~1M gas savings