### PR TITLE
Fixing releases to also mark SIPs as released

### DIFF
--- a/publish/src/commands/finalize-release.js
+++ b/publish/src/commands/finalize-release.js
@@ -26,12 +26,12 @@ const finalizeRelease = async ({ layer, release, versionTag }) => {
 		await versionsUpdate({ release, useOvm: true, versionTag });
 	}
 
-	const prerelease = semver.prerelease(versionTag) && semver.prerelease(versionTag) !== 'ovm';
+	const prerelease = semver.prerelease(versionTag) && semver.prerelease(versionTag)[0] !== 'ovm';
 
 	if (prerelease) {
 		console.log(
 			'Not updating the releases.json as this is a prerelease of',
-			semver.prerelease(versionTag)
+			semver.prerelease(versionTag)[0]
 		);
 		return;
 	}
@@ -40,6 +40,7 @@ const finalizeRelease = async ({ layer, release, versionTag }) => {
 	const major = semver.major(versionTag);
 	const minor = semver.minor(versionTag);
 
+	let sips = [];
 	// Mark as released the ones that have the specified version and layer
 	for (const release of releases.releases) {
 		const versionMatch = release.version.major === major && release.version.minor === minor;
@@ -47,6 +48,28 @@ const finalizeRelease = async ({ layer, release, versionTag }) => {
 
 		if (versionMatch && layerMatch) {
 			release.released = true;
+			sips = sips.concat(release.sips);
+		}
+	}
+
+	// now mark all sips as released on that layer
+	for (const sipNumber of sips) {
+		const sip = releases.sips.find(s => s.sip === sipNumber);
+		if (!sip) {
+			console.log(
+				'WARNING: Cannot find entry for SIP',
+				sipNumber,
+				'and thus cannot update its releasability'
+			);
+			continue;
+		}
+		// when it's the first release of the sip, or if the new release is both, then
+		// use the given layer
+		if (!sip.released || layer === 'both') {
+			sip.released = layer;
+			// else when releasing the other layer, then mark both released
+		} else if (sip.released !== layer) {
+			sip.released = 'both';
 		}
 	}
 


### PR DESCRIPTION
- Fixes issue whereby a finalized release (in the release pipeline) does not actually mark the SIPs as released for the given `layer`
- Also fixes bug whereby releasing with version `-ovm` was being incorrectly skipped.