### PR TITLE
fix loop stopping condition in feepool

### DIFF
--- a/contracts/FeePool.sol
+++ b/contracts/FeePool.sol
@@ -386,8 +386,8 @@ contract FeePool is Owned, Proxyable, LimitedSetup, MixinSystemSettings, IFeePoo
         uint feesPaid;
         // Start at the oldest period and record the amount, moving to newer periods
         // until we've exhausted the amount.
-        // The condition checks for overflow because we're going to 0 with an unsigned int.
-        for (uint i = FEE_PERIOD_LENGTH - 1; i < FEE_PERIOD_LENGTH; i--) {
+        for (uint offset = FEE_PERIOD_LENGTH; offset > 0; offset--) {
+            uint i = offset - 1;
             uint feesAlreadyClaimed = _recentFeePeriodsStorage(i).feesClaimed;
             uint delta = _recentFeePeriodsStorage(i).feesToDistribute.sub(feesAlreadyClaimed);
 
@@ -425,8 +425,8 @@ contract FeePool is Owned, Proxyable, LimitedSetup, MixinSystemSettings, IFeePoo
 
         // Start at the oldest period and record the amount, moving to newer periods
         // until we've exhausted the amount.
-        // The condition checks for overflow because we're going to 0 with an unsigned int.
-        for (uint i = FEE_PERIOD_LENGTH - 1; i < FEE_PERIOD_LENGTH; i--) {
+        for (uint offset = FEE_PERIOD_LENGTH; offset > 0; offset--) {
+            uint i = offset - 1;
             uint toDistribute =
                 _recentFeePeriodsStorage(i).rewardsToDistribute.sub(_recentFeePeriodsStorage(i).rewardsClaimed);
 

--- a/contracts/FeePoolState.sol
+++ b/contracts/FeePoolState.sol
@@ -114,8 +114,8 @@ contract FeePoolState is Owned, LimitedSetup {
      * @notice Pushes down the entire array of debt ratios per fee period
      */
     function issuanceDataIndexOrder(address account) private {
-        for (uint i = FEE_PERIOD_LENGTH - 2; i < FEE_PERIOD_LENGTH; i--) {
-            uint next = i + 1;
+        for (uint next = FEE_PERIOD_LENGTH - 1; next > 0; next--) {
+            uint i = next - 1;
             accountIssuanceLedger[account][next].debtPercentage = accountIssuanceLedger[account][i].debtPercentage;
             accountIssuanceLedger[account][next].debtEntryIndex = accountIssuanceLedger[account][i].debtEntryIndex;
         }


### PR DESCRIPTION
Follow up from https://github.com/Synthetixio/synthetix/pull/1576/ 

Several reverse loops had incorrect stopping condition that works now, but is incorrect, and will result in panic errors with newer compiler versions.