### PR TITLE
Fix param spam during deployment

### DIFF
--- a/publish/src/commands/deploy/get-deploy-parameter-factory.js
+++ b/publish/src/commands/deploy/get-deploy-parameter-factory.js
@@ -4,9 +4,7 @@ const { yellow } = require('chalk');
 
 const { defaults } = require('../../../..');
 
-const { confirmAction } = require('../../util');
-
-module.exports = ({ params, yes, ignoreCustomParameters }) => async name => {
+module.exports = ({ params, ignoreCustomParameters }) => async name => {
 	const defaultParam = defaults[name];
 	if (ignoreCustomParameters) {
 		return defaultParam;
@@ -17,27 +15,7 @@ module.exports = ({ params, yes, ignoreCustomParameters }) => async name => {
 	const param = (params || []).find(p => p.name === name);
 
 	if (param) {
-		if (!yes) {
-			try {
-				await confirmAction(
-					yellow(
-						`⚠⚠⚠ WARNING: Found an entry for ${
-							param.name
-						} in params.json. Specified value is ${JSON.stringify(
-							param.value
-						)} and default is ${JSON.stringify(defaultParam)}.` +
-							'\nDo you want to use the specified value (default otherwise)? (y/n) '
-					)
-				);
-
-				effectiveValue = param.value;
-			} catch (err) {
-				console.error(err);
-			}
-		} else {
-			// yes = true
-			effectiveValue = param.value;
-		}
+		effectiveValue = param.value;
 	}
 
 	if (effectiveValue !== defaultParam) {

--- a/publish/src/commands/deploy/index.js
+++ b/publish/src/commands/deploy/index.js
@@ -95,7 +95,7 @@ const deploy = async ({
 		freshDeploy,
 	});
 
-	const getDeployParameter = getDeployParameterFactory({ params, yes, ignoreCustomParameters });
+	const getDeployParameter = getDeployParameterFactory({ params, ignoreCustomParameters });
 
 	const addressOf = c => (c ? c.address : '');
 	const sourceOf = c => (c ? c.source : '');


### PR DESCRIPTION
Removed the need to take action and confirm the values declared in `params.json` during the deployment process. It will just print a warning message now instead.