### PR TITLE
Ensuring SCCP-139 feeds are persisted to future ExchangeRates contracts

### DIFF
--- a/publish/deployed/mainnet/feeds.json
+++ b/publish/deployed/mainnet/feeds.json
@@ -54,5 +54,45 @@
 	"KRW": {
 		"asset": "KRW",
 		"feed": "0x01435677FB11763550905594A16B645847C1d0F3"
+	},
+	"XTZ": {
+		"asset": "XTZ",
+		"standaloneFor": "sXTZ",
+		"feed": "0x5239a625dEb44bF3EeAc2CD5366ba24b8e9DB63F"
+	},
+	"RUNE": {
+		"asset": "RUNE",
+		"standaloneFor": "sRUNE",
+		"feed": "0x48731cF7e84dc94C5f84577882c14Be11a5B7456"
+	},
+	"YFI": {
+		"asset": "YFI",
+		"standaloneFor": "sYFI",
+		"feed": "0xA027702dbb89fbd58938e4324ac03B58d812b0E1"
+	},
+	"CRV": {
+		"asset": "CRV",
+		"standaloneFor": "sCRV",
+		"feed": "0xCd627aA160A6fA45Eb793D19Ef54f5062F20f33f"
+	},
+	"UNI": {
+		"asset": "UNI",
+		"standaloneFor": "sUNI",
+		"feed": "0x553303d460EE0afB37EdFf9bE42922D8FF63220e"
+	},
+	"XRP": {
+		"asset": "XRP",
+		"standaloneFor": "sXRP",
+		"feed": "0xCed2660c6Dd1Ffd856A5A82C67f3482d88C50b12"
+	},
+	"BNB": {
+		"asset": "BNB",
+		"standaloneFor": "sBNB",
+		"feed": "0x14e613AC84a31f709eadbdF89C6CC390fDc9540A"
+	},
+	"XAU": {
+		"asset": "XAU",
+		"standaloneFor": "sXAU",
+		"feed": "0x214eD9Da11D2fbe465a6fc601a91E62EbEc1a0D6"
 	}
 }

--- a/publish/src/commands/deploy/configure-standalone-price-feeds.js
+++ b/publish/src/commands/deploy/configure-standalone-price-feeds.js
@@ -12,17 +12,23 @@ module.exports = async ({ deployer, runStep, standaloneFeeds }) => {
 	// Setup remaining price feeds (that aren't synths)
 	const { ExchangeRates } = deployer.deployedContracts;
 
-	for (const { asset, feed } of standaloneFeeds) {
+	for (const { asset, standaloneFor, feed } of standaloneFeeds) {
+		// When standalone present, use this as the key not the asset
+		// This is for SCCP-139 and the Thales markets which rely on
+		// synth keys existing in future ExchangeRates contracts
+		// even though the synths have been deprecated.
+		// The 8 feeds from SCCP-139 can be removed after Dec 31, 2021.
+		const key = standaloneFor || asset;
 		if (isAddress(feed) && ExchangeRates) {
 			await runStep({
 				contract: `ExchangeRates`,
 				target: ExchangeRates,
 				read: 'aggregators',
-				readArg: toBytes32(asset),
+				readArg: toBytes32(key),
 				expected: input => input === feed,
 				write: 'addAggregator',
-				writeArg: [toBytes32(asset), feed],
-				comment: `Ensure the ExchangeRates contract has the feed for ${asset}`,
+				writeArg: [toBytes32(key), feed],
+				comment: `Ensure the ExchangeRates contract has the feed for ${key}`,
 			});
 		}
 	}


### PR DESCRIPTION
Basically this ensures that during future deploys of `ExchangeRates`, the feeds required for SCPP-139 will be saved to the contract storage