### PR TITLE
Futures liquidation fee update

### DIFF
--- a/contracts/FuturesMarket.sol
+++ b/contracts/FuturesMarket.sol
@@ -676,7 +676,7 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
      * @return lMargin liquidation margin to maintain in sUSD fixed point decimal units
      */
     function liquidationMargin(address account) external view returns (uint lMargin) {
-        require(positions[account].size > 0, "0 size position");
+        require(positions[account].size != 0, "0 size position");
         (uint price, ) = _assetPrice();
         return _liquidationMargin(positions[account].size, price);
     }

--- a/contracts/FuturesMarket.sol
+++ b/contracts/FuturesMarket.sol
@@ -516,7 +516,7 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
 
         uint uMargin = uint(newMargin);
         int positionSize = position.size;
-        // minimum margin beyond which position can be liqudiated
+        // minimum margin beyond which position can be liquidated
         uint lMargin = _liquidationMargin(positionSize, price);
         if (positionSize != 0 && uMargin <= lMargin) {
             return (uMargin, Status.CanLiquidate);
@@ -639,7 +639,7 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
         uint proportionalFee = _abs(positionSize).multiplyDecimalRound(price).mul(_liquidationFeeBPs()).div(10000);
         uint minFee = _minLiquidationFee();
         // max(proportionalFee, minFee) - to prevent not incentivising liquidations enough
-        return proportionalFee > minFee ? proportionalFee : minFee;
+        return proportionalFee > minFee ? proportionalFee : minFee; // not using _max() helper because it's for signed ints
     }
 
     /**
@@ -705,6 +705,9 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
         if (!invalid && _canLiquidate(positions[account], fundingSequence.length, price)) {
             return _liquidationFee(positions[account].size, price);
         } else {
+            // theoretically we can calculate a value, but this value is always incorrect because
+            // it's for a price at which liquidation cannot happen - so is misleading, because
+            // it won't be paid, and what will be paid is a different fee (for a different price)
             return 0;
         }
     }

--- a/contracts/FuturesMarket.sol
+++ b/contracts/FuturesMarket.sol
@@ -634,9 +634,8 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
      * @return lFee liquidation fee to be paid to liquidator in sUSD fixed point decimal units
      */
     function _liquidationFee(int positionSize, uint price) internal view returns (uint lFee) {
-        // size * price * fee-BPs / 10000
-        // the first multiplication is decimal because price is fixed point decimal, but BPs and 10000 are plain int
-        uint proportionalFee = _abs(positionSize).multiplyDecimalRound(price).mul(_liquidationFeeBPs()).div(10000);
+        // size * price * fee-ratio
+        uint proportionalFee = _abs(positionSize).multiplyDecimalRound(price).multiplyDecimalRound(_liquidationFeeRatio());
         uint minFee = _minLiquidationFee();
         // max(proportionalFee, minFee) - to prevent not incentivising liquidations enough
         return proportionalFee > minFee ? proportionalFee : minFee; // not using _max() helper because it's for signed ints
@@ -652,9 +651,8 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
      * @return lBuffer liquidation buffer to be paid to liquidator in sUSD fixed point decimal units
      */
     function _liquidationBuffer(int positionSize, uint price) internal view returns (uint lBuffer) {
-        // size * price * buffer-BPs / 10000
-        // the first multiplication is decimal because price is fixed point decimal, but BPs and 10000 are plain int
-        return _abs(positionSize).multiplyDecimalRound(price).mul(_liquidationBufferBPs()).div(10000);
+        // size * price * buffer-ratio
+        return _abs(positionSize).multiplyDecimalRound(price).multiplyDecimalRound(_liquidationBufferRatio());
     }
 
     /**

--- a/contracts/FuturesMarket.sol
+++ b/contracts/FuturesMarket.sol
@@ -634,10 +634,9 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
      * @return lFee liquidation fee to be paid to liquidator in sUSD fixed point decimal units
      */
     function _liquidationFee(int positionSize, uint price) internal view returns (uint lFee) {
-        uint absPositionSize = positionSize < 0 ? uint(-positionSize) : uint(positionSize);
         // size * price * fee-BPs / 10000
         // the first multiplication is decimal because price is fixed point decimal, but BPs and 10000 are plain int
-        uint proportionalFee = absPositionSize.multiplyDecimalRound(price).mul(_liquidationFeeBPs()).div(10000);
+        uint proportionalFee = _abs(positionSize).multiplyDecimalRound(price).mul(_liquidationFeeBPs()).div(10000);
         uint minFee = _minLiquidationFee();
         // max(proportionalFee, minFee) - to prevent not incentivising liquidations enough
         return proportionalFee > minFee ? proportionalFee : minFee;
@@ -653,10 +652,9 @@ contract FuturesMarket is Owned, Proxyable, MixinFuturesMarketSettings, IFutures
      * @return lBuffer liquidation buffer to be paid to liquidator in sUSD fixed point decimal units
      */
     function _liquidationBuffer(int positionSize, uint price) internal view returns (uint lBuffer) {
-        uint absPositionSize = positionSize < 0 ? uint(-positionSize) : uint(positionSize);
         // size * price * buffer-BPs / 10000
         // the first multiplication is decimal because price is fixed point decimal, but BPs and 10000 are plain int
-        return absPositionSize.multiplyDecimalRound(price).mul(_liquidationBufferBPs()).div(10000);
+        return _abs(positionSize).multiplyDecimalRound(price).mul(_liquidationBufferBPs()).div(10000);
     }
 
     /**

--- a/contracts/FuturesMarketData.sol
+++ b/contracts/FuturesMarketData.sol
@@ -14,6 +14,8 @@ contract FuturesMarketData {
 
     struct FuturesGlobals {
         uint minInitialMargin;
+        uint liquidationFeeBPs;
+        uint liquidationBufferBPs;
         uint minLiquidationFee;
     }
 
@@ -117,7 +119,13 @@ contract FuturesMarketData {
 
     function globals() external view returns (FuturesGlobals memory) {
         IFuturesMarketSettings settings = _futuresMarketSettings();
-        return FuturesGlobals(settings.minInitialMargin(), settings.minLiquidationFee());
+        return
+            FuturesGlobals({
+                minInitialMargin: settings.minInitialMargin(),
+                liquidationFeeBPs: settings.liquidationFeeBPs(),
+                liquidationBufferBPs: settings.liquidationBufferBPs(),
+                minLiquidationFee: settings.minLiquidationFee()
+            });
     }
 
     function parameters(bytes32 baseAsset) external view returns (IFuturesMarketSettings.Parameters memory) {

--- a/contracts/FuturesMarketData.sol
+++ b/contracts/FuturesMarketData.sol
@@ -14,7 +14,7 @@ contract FuturesMarketData {
 
     struct FuturesGlobals {
         uint minInitialMargin;
-        uint liquidationFee;
+        uint minLiquidationFee;
     }
 
     struct MarketSummary {
@@ -117,7 +117,7 @@ contract FuturesMarketData {
 
     function globals() external view returns (FuturesGlobals memory) {
         IFuturesMarketSettings settings = _futuresMarketSettings();
-        return FuturesGlobals(settings.minInitialMargin(), settings.liquidationFee());
+        return FuturesGlobals(settings.minInitialMargin(), settings.minLiquidationFee());
     }
 
     function parameters(bytes32 baseAsset) external view returns (IFuturesMarketSettings.Parameters memory) {

--- a/contracts/FuturesMarketData.sol
+++ b/contracts/FuturesMarketData.sol
@@ -14,8 +14,8 @@ contract FuturesMarketData {
 
     struct FuturesGlobals {
         uint minInitialMargin;
-        uint liquidationFeeBPs;
-        uint liquidationBufferBPs;
+        uint liquidationFeeRatio;
+        uint liquidationBufferRatio;
         uint minLiquidationFee;
     }
 
@@ -122,8 +122,8 @@ contract FuturesMarketData {
         return
             FuturesGlobals({
                 minInitialMargin: settings.minInitialMargin(),
-                liquidationFeeBPs: settings.liquidationFeeBPs(),
-                liquidationBufferBPs: settings.liquidationBufferBPs(),
+                liquidationFeeRatio: settings.liquidationFeeRatio(),
+                liquidationBufferRatio: settings.liquidationBufferRatio(),
                 minLiquidationFee: settings.minLiquidationFee()
             });
     }

--- a/contracts/FuturesMarketSettings.sol
+++ b/contracts/FuturesMarketSettings.sol
@@ -224,7 +224,7 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
     function setMinLiquidationFee(uint _sUSD) external onlyOwner {
         require(_sUSD <= _minInitialMargin(), "min margin < liquidation fee");
         _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_LIQUIDATION_FEE, _sUSD);
-        emit LiquidationFeeUpdated(_sUSD);
+        emit MinLiquidationFeeUpdated(_sUSD);
     }
 
     function setLiquidationFeeBPs(uint _bps) external onlyOwner {
@@ -246,7 +246,7 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
     /* ========== EVENTS ========== */
 
     event ParameterUpdated(bytes32 indexed asset, bytes32 indexed parameter, uint value);
-    event LiquidationFeeUpdated(uint sUSD);
+    event MinLiquidationFeeUpdated(uint sUSD);
     event LiquidationFeeBPsUpdated(uint bps);
     event LiquidationBufferBPsUpdated(uint bps);
     event MinInitialMarginUpdated(uint minMargin);

--- a/contracts/FuturesMarketSettings.sol
+++ b/contracts/FuturesMarketSettings.sol
@@ -113,13 +113,13 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
      * The amount of sUSD paid to a liquidator when they successfully liquidate a position.
      * This quantity must be no greater than `minInitialMargin`.
      */
-    function liquidationFee() external view returns (uint) {
-        return _liquidationFee();
+    function minLiquidationFee() external view returns (uint) {
+        return _minLiquidationFee();
     }
 
     /*
      * The minimum margin required to open a position.
-     * This quantity must be no less than `liquidationFee`.
+     * This quantity must be no less than `minLiquidationFee`.
      */
     function minInitialMargin() external view returns (uint) {
         return _minInitialMargin();
@@ -206,14 +206,14 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
         setMaxFundingRateDelta(_baseAsset, _maxFundingRateDelta);
     }
 
-    function setLiquidationFee(uint _sUSD) external onlyOwner {
+    function setMinLiquidationFee(uint _sUSD) external onlyOwner {
         require(_sUSD <= _minInitialMargin(), "min margin < liquidation fee");
-        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_FEE, _sUSD);
+        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_LIQUIDATION_FEE, _sUSD);
         emit LiquidationFeeUpdated(_sUSD);
     }
 
     function setMinInitialMargin(uint _minMargin) external onlyOwner {
-        require(_liquidationFee() <= _minMargin, "min margin < liquidation fee");
+        require(_minLiquidationFee() <= _minMargin, "min margin < liquidation fee");
         _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_INITIAL_MARGIN, _minMargin);
         emit MinInitialMarginUpdated(_minMargin);
     }

--- a/contracts/FuturesMarketSettings.sol
+++ b/contracts/FuturesMarketSettings.sol
@@ -121,15 +121,15 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
      * Liquidation fee basis points paid to liquidator.
      * Use together with minLiquidationFee() to calculate the actual fee paid.
      */
-    function liquidationFeeBPs() external view returns (uint) {
-        return _liquidationFeeBPs();
+    function liquidationFeeRatio() external view returns (uint) {
+        return _liquidationFeeRatio();
     }
 
     /*
      * Liquidation price buffer in basis points to prevent negative margin on liquidation.
      */
-    function liquidationBufferBPs() external view returns (uint) {
-        return _liquidationBufferBPs();
+    function liquidationBufferRatio() external view returns (uint) {
+        return _liquidationBufferRatio();
     }
 
     /*
@@ -227,14 +227,14 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
         emit MinLiquidationFeeUpdated(_sUSD);
     }
 
-    function setLiquidationFeeBPs(uint _bps) external onlyOwner {
-        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_FEE_BPS, _bps);
-        emit LiquidationFeeBPsUpdated(_bps);
+    function setLiquidationFeeRatio(uint _ratio) external onlyOwner {
+        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_FEE_RATIO, _ratio);
+        emit LiquidationFeeRatioUpdated(_ratio);
     }
 
-    function setLiquidationBufferBPs(uint _bps) external onlyOwner {
-        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_BUFFER_BPS, _bps);
-        emit LiquidationBufferBPsUpdated(_bps);
+    function setLiquidationBufferRatio(uint _ratio) external onlyOwner {
+        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_BUFFER_RATIO, _ratio);
+        emit LiquidationBufferRatioUpdated(_ratio);
     }
 
     function setMinInitialMargin(uint _minMargin) external onlyOwner {
@@ -247,7 +247,7 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
 
     event ParameterUpdated(bytes32 indexed asset, bytes32 indexed parameter, uint value);
     event MinLiquidationFeeUpdated(uint sUSD);
-    event LiquidationFeeBPsUpdated(uint bps);
-    event LiquidationBufferBPsUpdated(uint bps);
+    event LiquidationFeeRatioUpdated(uint bps);
+    event LiquidationBufferRatioUpdated(uint bps);
     event MinInitialMarginUpdated(uint minMargin);
 }

--- a/contracts/FuturesMarketSettings.sol
+++ b/contracts/FuturesMarketSettings.sol
@@ -110,11 +110,26 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
     }
 
     /*
-     * The amount of sUSD paid to a liquidator when they successfully liquidate a position.
+     * The minimum amount of sUSD paid to a liquidator when they successfully liquidate a position.
      * This quantity must be no greater than `minInitialMargin`.
      */
     function minLiquidationFee() external view returns (uint) {
         return _minLiquidationFee();
+    }
+
+    /*
+     * Liquidation fee basis points paid to liquidator.
+     * Use together with minLiquidationFee() to calculate the actual fee paid.
+     */
+    function liquidationFeeBPs() external view returns (uint) {
+        return _liquidationFeeBPs();
+    }
+
+    /*
+     * Liquidation price buffer in basis points to prevent negative margin on liquidation.
+     */
+    function liquidationBufferBPs() external view returns (uint) {
+        return _liquidationBufferBPs();
     }
 
     /*
@@ -212,6 +227,16 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
         emit LiquidationFeeUpdated(_sUSD);
     }
 
+    function setLiquidationFeeBPs(uint _bps) external onlyOwner {
+        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_FEE_BPS, _bps);
+        emit LiquidationFeeBPsUpdated(_bps);
+    }
+
+    function setLiquidationBufferBPs(uint _bps) external onlyOwner {
+        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_BUFFER_BPS, _bps);
+        emit LiquidationBufferBPsUpdated(_bps);
+    }
+
     function setMinInitialMargin(uint _minMargin) external onlyOwner {
         require(_minLiquidationFee() <= _minMargin, "min margin < liquidation fee");
         _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_INITIAL_MARGIN, _minMargin);
@@ -222,5 +247,7 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
 
     event ParameterUpdated(bytes32 indexed asset, bytes32 indexed parameter, uint value);
     event LiquidationFeeUpdated(uint sUSD);
+    event LiquidationFeeBPsUpdated(uint bps);
+    event LiquidationBufferBPsUpdated(uint bps);
     event MinInitialMarginUpdated(uint minMargin);
 }

--- a/contracts/MixinFuturesMarketSettings.sol
+++ b/contracts/MixinFuturesMarketSettings.sol
@@ -27,9 +27,9 @@ contract MixinFuturesMarketSettings is MixinResolver {
     // minimum liquidation fee payable to liquidator
     bytes32 internal constant SETTING_MIN_LIQUIDATION_FEE = "futuresMinLiquidationFee";
     // liquidation fee basis points payed to liquidator
-    bytes32 internal constant SETTING_LIQUIDATION_FEE_BPS = "futuresLiquidationFeeBPs";
+    bytes32 internal constant SETTING_LIQUIDATION_FEE_RATIO = "futuresLiquidationFeeRatio";
     // liquidation buffer to prevent negative margin upon liquidation
-    bytes32 internal constant SETTING_LIQUIDATION_BUFFER_BPS = "futuresLiquidationBufferBPs";
+    bytes32 internal constant SETTING_LIQUIDATION_BUFFER_RATIO = "futuresLiquidationBufferRatio";
     bytes32 internal constant SETTING_MIN_INITIAL_MARGIN = "futuresMinInitialMargin";
 
     /* ---------- Address Resolver Configuration ---------- */
@@ -117,12 +117,12 @@ contract MixinFuturesMarketSettings is MixinResolver {
         return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_LIQUIDATION_FEE);
     }
 
-    function _liquidationFeeBPs() internal view returns (uint) {
-        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_FEE_BPS);
+    function _liquidationFeeRatio() internal view returns (uint) {
+        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_FEE_RATIO);
     }
 
-    function _liquidationBufferBPs() internal view returns (uint) {
-        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_BUFFER_BPS);
+    function _liquidationBufferRatio() internal view returns (uint) {
+        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_BUFFER_RATIO);
     }
 
     function _minInitialMargin() internal view returns (uint) {

--- a/contracts/MixinFuturesMarketSettings.sol
+++ b/contracts/MixinFuturesMarketSettings.sol
@@ -24,7 +24,7 @@ contract MixinFuturesMarketSettings is MixinResolver {
     bytes32 internal constant PARAMETER_MAX_FUNDING_RATE_DELTA = "maxFundingRateDelta";
 
     // Global settings
-    bytes32 internal constant SETTING_LIQUIDATION_FEE = "futuresLiquidationFee";
+    bytes32 internal constant SETTING_MIN_LIQUIDATION_FEE = "futuresMinLiquidationFee";
     bytes32 internal constant SETTING_MIN_INITIAL_MARGIN = "futuresMinInitialMargin";
 
     /* ---------- Address Resolver Configuration ---------- */
@@ -108,8 +108,8 @@ contract MixinFuturesMarketSettings is MixinResolver {
         maxFundingRateDelta = _maxFundingRateDelta(_baseAsset);
     }
 
-    function _liquidationFee() internal view returns (uint) {
-        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_FEE);
+    function _minLiquidationFee() internal view returns (uint) {
+        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_LIQUIDATION_FEE);
     }
 
     function _minInitialMargin() internal view returns (uint) {

--- a/contracts/MixinFuturesMarketSettings.sol
+++ b/contracts/MixinFuturesMarketSettings.sol
@@ -24,7 +24,12 @@ contract MixinFuturesMarketSettings is MixinResolver {
     bytes32 internal constant PARAMETER_MAX_FUNDING_RATE_DELTA = "maxFundingRateDelta";
 
     // Global settings
+    // minimum liquidation fee payable to liquidator
     bytes32 internal constant SETTING_MIN_LIQUIDATION_FEE = "futuresMinLiquidationFee";
+    // liquidation fee basis points payed to liquidator
+    bytes32 internal constant SETTING_LIQUIDATION_FEE_BPS = "futuresLiquidationFeeBPs";
+    // liquidation buffer to prevent negative margin upon liquidation
+    bytes32 internal constant SETTING_LIQUIDATION_BUFFER_BPS = "futuresLiquidationBufferBPs";
     bytes32 internal constant SETTING_MIN_INITIAL_MARGIN = "futuresMinInitialMargin";
 
     /* ---------- Address Resolver Configuration ---------- */
@@ -110,6 +115,14 @@ contract MixinFuturesMarketSettings is MixinResolver {
 
     function _minLiquidationFee() internal view returns (uint) {
         return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_LIQUIDATION_FEE);
+    }
+
+    function _liquidationFeeBPs() internal view returns (uint) {
+        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_FEE_BPS);
+    }
+
+    function _liquidationBufferBPs() internal view returns (uint) {
+        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_BUFFER_BPS);
     }
 
     function _minInitialMargin() internal view returns (uint) {

--- a/contracts/interfaces/IFuturesMarket.sol
+++ b/contracts/interfaces/IFuturesMarket.sol
@@ -102,6 +102,8 @@ interface IFuturesMarket {
 
     function liquidationPrice(address account, bool includeFunding) external view returns (uint price, bool invalid);
 
+    function liquidationMargin(address account) external view returns (uint lMargin);
+
     function liquidationFee(address account) external view returns (uint);
 
     function canLiquidate(address account) external view returns (bool);

--- a/contracts/interfaces/IFuturesMarket.sol
+++ b/contracts/interfaces/IFuturesMarket.sol
@@ -102,6 +102,8 @@ interface IFuturesMarket {
 
     function liquidationPrice(address account, bool includeFunding) external view returns (uint price, bool invalid);
 
+    function liquidationFee(address account) external view returns (uint);
+
     function canLiquidate(address account) external view returns (bool);
 
     function currentLeverage(address account) external view returns (int leverage, bool invalid);

--- a/contracts/interfaces/IFuturesMarketSettings.sol
+++ b/contracts/interfaces/IFuturesMarketSettings.sol
@@ -44,5 +44,9 @@ interface IFuturesMarketSettings {
 
     function minLiquidationFee() external view returns (uint);
 
+    function liquidationFeeBPs() external view returns (uint);
+
+    function liquidationBufferBPs() external view returns (uint);
+
     function minInitialMargin() external view returns (uint);
 }

--- a/contracts/interfaces/IFuturesMarketSettings.sol
+++ b/contracts/interfaces/IFuturesMarketSettings.sol
@@ -42,7 +42,7 @@ interface IFuturesMarketSettings {
             uint _maxFundingRateDelta
         );
 
-    function liquidationFee() external view returns (uint);
+    function minLiquidationFee() external view returns (uint);
 
     function minInitialMargin() external view returns (uint);
 }

--- a/contracts/interfaces/IFuturesMarketSettings.sol
+++ b/contracts/interfaces/IFuturesMarketSettings.sol
@@ -44,9 +44,9 @@ interface IFuturesMarketSettings {
 
     function minLiquidationFee() external view returns (uint);
 
-    function liquidationFeeBPs() external view returns (uint);
+    function liquidationFeeRatio() external view returns (uint);
 
-    function liquidationBufferBPs() external view returns (uint);
+    function liquidationBufferRatio() external view returns (uint);
 
     function minInitialMargin() external view returns (uint);
 }

--- a/index.js
+++ b/index.js
@@ -204,8 +204,8 @@ const defaults = {
 	ETHER_WRAPPER_BURN_FEE_RATE: w3utils.toWei('0.0005'), // 5 bps
 
 	FUTURES_MIN_LIQUIDATION_FEE: w3utils.toWei('20'), // 20 sUSD liquidation fee
-	FUTURES_LIQUIDATION_FEE_BPS: w3utils.toWei('35'), // 35 basis points liquidation incentive
-	FUTURES_LIQUIDATION_BUFFER_BPS: w3utils.toWei('25'), // 25 basis points liquidation buffer
+	FUTURES_LIQUIDATION_FEE_BPS: w3utils.toBN('35'), // 35 basis points liquidation incentive
+	FUTURES_LIQUIDATION_BUFFER_BPS: w3utils.toBN('25'), // 25 basis points liquidation buffer
 	FUTURES_MIN_INITIAL_MARGIN: w3utils.toWei('100'), // minimum initial margin for all markets
 };
 

--- a/index.js
+++ b/index.js
@@ -204,6 +204,8 @@ const defaults = {
 	ETHER_WRAPPER_BURN_FEE_RATE: w3utils.toWei('0.0005'), // 5 bps
 
 	FUTURES_MIN_LIQUIDATION_FEE: w3utils.toWei('20'), // 20 sUSD liquidation fee
+	FUTURES_LIQUIDATION_FEE_BPS: w3utils.toWei('35'), // 35 basis points liquidation incentive
+	FUTURES_LIQUIDATION_BUFFER_BPS: w3utils.toWei('25'), // 25 basis points liquidation buffer
 	FUTURES_MIN_INITIAL_MARGIN: w3utils.toWei('100'), // minimum initial margin for all markets
 };
 

--- a/index.js
+++ b/index.js
@@ -203,7 +203,7 @@ const defaults = {
 	ETHER_WRAPPER_MINT_FEE_RATE: w3utils.toWei('0.02'), // 200 bps
 	ETHER_WRAPPER_BURN_FEE_RATE: w3utils.toWei('0.0005'), // 5 bps
 
-	FUTURES_LIQUIDATION_FEE: w3utils.toWei('20'), // 20 sUSD liquidation fee
+	FUTURES_MIN_LIQUIDATION_FEE: w3utils.toWei('20'), // 20 sUSD liquidation fee
 	FUTURES_MIN_INITIAL_MARGIN: w3utils.toWei('100'), // minimum initial margin for all markets
 };
 

--- a/index.js
+++ b/index.js
@@ -204,8 +204,8 @@ const defaults = {
 	ETHER_WRAPPER_BURN_FEE_RATE: w3utils.toWei('0.0005'), // 5 bps
 
 	FUTURES_MIN_LIQUIDATION_FEE: w3utils.toWei('20'), // 20 sUSD liquidation fee
-	FUTURES_LIQUIDATION_FEE_BPS: w3utils.toBN('35'), // 35 basis points liquidation incentive
-	FUTURES_LIQUIDATION_BUFFER_BPS: w3utils.toBN('25'), // 25 basis points liquidation buffer
+	FUTURES_LIQUIDATION_FEE_RATIO: w3utils.toWei('0.0035'), // 35 basis points liquidation incentive
+	FUTURES_LIQUIDATION_BUFFER_RATIO: w3utils.toWei('0.0025'), // 25 basis points liquidation buffer
 	FUTURES_MIN_INITIAL_MARGIN: w3utils.toWei('100'), // minimum initial margin for all markets
 };
 

--- a/publish/deployed/kovan-ovm-futures/deployment.json
+++ b/publish/deployed/kovan-ovm-futures/deployment.json
@@ -24404,7 +24404,7 @@
 										},
 										{
 											"internalType": "uint256",
-											"name": "maxMarketValueUSD",
+											"name": "maxMarketValue",
 											"type": "uint256"
 										}
 									],
@@ -24421,7 +24421,7 @@
 										},
 										{
 											"internalType": "uint256",
-											"name": "skewScaleUSD",
+											"name": "minSkewScale",
 											"type": "uint256"
 										},
 										{
@@ -24549,7 +24549,7 @@
 										},
 										{
 											"internalType": "uint256",
-											"name": "maxMarketValueUSD",
+											"name": "maxMarketValue",
 											"type": "uint256"
 										}
 									],
@@ -24566,7 +24566,7 @@
 										},
 										{
 											"internalType": "uint256",
-											"name": "skewScaleUSD",
+											"name": "minSkewScale",
 											"type": "uint256"
 										},
 										{
@@ -24840,7 +24840,7 @@
 								},
 								{
 									"internalType": "uint256",
-									"name": "maxMarketValueUSD",
+									"name": "maxMarketValue",
 									"type": "uint256"
 								},
 								{
@@ -24850,7 +24850,7 @@
 								},
 								{
 									"internalType": "uint256",
-									"name": "skewScaleUSD",
+									"name": "minSkewScale",
 									"type": "uint256"
 								},
 								{
@@ -25385,7 +25385,7 @@
 							"type": "bytes32"
 						}
 					],
-					"name": "maxMarketValueUSD",
+					"name": "maxMarketValue",
 					"outputs": [
 						{
 							"internalType": "uint256",
@@ -25421,7 +25421,7 @@
 							"type": "bytes32"
 						}
 					],
-					"name": "skewScaleUSD",
+					"name": "minSkewScale",
 					"outputs": [
 						{
 							"internalType": "uint256",
@@ -25511,7 +25511,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_maxMarketValueUSD",
+							"name": "_maxMarketValue",
 							"type": "uint256"
 						},
 						{
@@ -25521,7 +25521,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_skewScaleUSD",
+							"name": "_minSkewScale",
 							"type": "uint256"
 						},
 						{
@@ -25698,11 +25698,11 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_maxMarketValueUSD",
+							"name": "_maxMarketValue",
 							"type": "uint256"
 						}
 					],
-					"name": "setMaxMarketValueUSD",
+					"name": "setMaxMarketValue",
 					"outputs": [],
 					"payable": false,
 					"stateMutability": "nonpayable",
@@ -25733,11 +25733,11 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_skewScaleUSD",
+							"name": "_minSkewScale",
 							"type": "uint256"
 						}
 					],
-					"name": "setSkewScaleUSD",
+					"name": "setMinSkewScale",
 					"outputs": [],
 					"payable": false,
 					"stateMutability": "nonpayable",
@@ -25773,7 +25773,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_maxMarketValueUSD",
+							"name": "_maxMarketValue",
 							"type": "uint256"
 						},
 						{
@@ -25783,7 +25783,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_skewScaleUSD",
+							"name": "_minSkewScale",
 							"type": "uint256"
 						},
 						{
@@ -26724,7 +26724,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "maxMarketValueUSD",
+							"name": "maxMarketValue",
 							"type": "uint256"
 						},
 						{
@@ -26734,7 +26734,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "skewScaleUSD",
+							"name": "minSkewScale",
 							"type": "uint256"
 						},
 						{

--- a/publish/deployed/kovan-ovm-futures/deployment.json
+++ b/publish/deployed/kovan-ovm-futures/deployment.json
@@ -24421,7 +24421,7 @@
 										},
 										{
 											"internalType": "uint256",
-											"name": "minSkewScaleUSD",
+											"name": "skewScaleUSD",
 											"type": "uint256"
 										},
 										{
@@ -24566,7 +24566,7 @@
 										},
 										{
 											"internalType": "uint256",
-											"name": "minSkewScaleUSD",
+											"name": "skewScaleUSD",
 											"type": "uint256"
 										},
 										{
@@ -24850,7 +24850,7 @@
 								},
 								{
 									"internalType": "uint256",
-									"name": "minSkewScaleUSD",
+									"name": "skewScaleUSD",
 									"type": "uint256"
 								},
 								{
@@ -25421,7 +25421,7 @@
 							"type": "bytes32"
 						}
 					],
-					"name": "minSkewScaleUSD",
+					"name": "skewScaleUSD",
 					"outputs": [
 						{
 							"internalType": "uint256",
@@ -25521,7 +25521,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_minSkewScaleUSD",
+							"name": "_skewScaleUSD",
 							"type": "uint256"
 						},
 						{
@@ -25733,11 +25733,11 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_minSkewScaleUSD",
+							"name": "_skewScaleUSD",
 							"type": "uint256"
 						}
 					],
-					"name": "setMinSkewScaleUSD",
+					"name": "setSkewScaleUSD",
 					"outputs": [],
 					"payable": false,
 					"stateMutability": "nonpayable",
@@ -25783,7 +25783,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_minSkewScaleUSD",
+							"name": "_skewScaleUSD",
 							"type": "uint256"
 						},
 						{
@@ -26734,7 +26734,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "minSkewScaleUSD",
+							"name": "skewScaleUSD",
 							"type": "uint256"
 						},
 						{

--- a/publish/deployed/kovan-ovm-futures/deployment.json
+++ b/publish/deployed/kovan-ovm-futures/deployment.json
@@ -24342,7 +24342,7 @@
 								},
 								{
 									"internalType": "uint256",
-									"name": "liquidationFee",
+									"name": "minLiquidationFee",
 									"type": "uint256"
 								}
 							],
@@ -25280,7 +25280,7 @@
 				{
 					"constant": true,
 					"inputs": [],
-					"name": "liquidationFee",
+					"name": "minLiquidationFee",
 					"outputs": [
 						{
 							"internalType": "uint256",
@@ -25602,7 +25602,7 @@
 							"type": "uint256"
 						}
 					],
-					"name": "setLiquidationFee",
+					"name": "setMinLiquidationFee",
 					"outputs": [],
 					"payable": false,
 					"stateMutability": "nonpayable",

--- a/publish/deployed/kovan-ovm-futures/deployment.json
+++ b/publish/deployed/kovan-ovm-futures/deployment.json
@@ -25159,7 +25159,7 @@
 							"type": "uint256"
 						}
 					],
-					"name": "LiquidationFeeUpdated",
+					"name": "MinLiquidationFeeUpdated",
 					"type": "event"
 				},
 				{

--- a/publish/deployed/kovan-ovm-futures/deployment.json
+++ b/publish/deployed/kovan-ovm-futures/deployment.json
@@ -24404,7 +24404,7 @@
 										},
 										{
 											"internalType": "uint256",
-											"name": "maxMarketValue",
+											"name": "maxMarketValueUSD",
 											"type": "uint256"
 										}
 									],
@@ -24549,7 +24549,7 @@
 										},
 										{
 											"internalType": "uint256",
-											"name": "maxMarketValue",
+											"name": "maxMarketValueUSD",
 											"type": "uint256"
 										}
 									],
@@ -24840,7 +24840,7 @@
 								},
 								{
 									"internalType": "uint256",
-									"name": "maxMarketValue",
+									"name": "maxMarketValueUSD",
 									"type": "uint256"
 								},
 								{
@@ -25385,7 +25385,7 @@
 							"type": "bytes32"
 						}
 					],
-					"name": "maxMarketValue",
+					"name": "maxMarketValueUSD",
 					"outputs": [
 						{
 							"internalType": "uint256",
@@ -25511,7 +25511,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_maxMarketValue",
+							"name": "_maxMarketValueUSD",
 							"type": "uint256"
 						},
 						{
@@ -25698,11 +25698,11 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_maxMarketValue",
+							"name": "_maxMarketValueUSD",
 							"type": "uint256"
 						}
 					],
-					"name": "setMaxMarketValue",
+					"name": "setMaxMarketValueUSD",
 					"outputs": [],
 					"payable": false,
 					"stateMutability": "nonpayable",
@@ -25773,7 +25773,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_maxMarketValue",
+							"name": "_maxMarketValueUSD",
 							"type": "uint256"
 						},
 						{
@@ -26724,7 +26724,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "maxMarketValue",
+							"name": "maxMarketValueUSD",
 							"type": "uint256"
 						},
 						{

--- a/publish/deployed/kovan-ovm-futures/deployment.json
+++ b/publish/deployed/kovan-ovm-futures/deployment.json
@@ -24421,7 +24421,7 @@
 										},
 										{
 											"internalType": "uint256",
-											"name": "minSkewScale",
+											"name": "minSkewScaleUSD",
 											"type": "uint256"
 										},
 										{
@@ -24566,7 +24566,7 @@
 										},
 										{
 											"internalType": "uint256",
-											"name": "minSkewScale",
+											"name": "minSkewScaleUSD",
 											"type": "uint256"
 										},
 										{
@@ -24850,7 +24850,7 @@
 								},
 								{
 									"internalType": "uint256",
-									"name": "minSkewScale",
+									"name": "minSkewScaleUSD",
 									"type": "uint256"
 								},
 								{
@@ -25421,7 +25421,7 @@
 							"type": "bytes32"
 						}
 					],
-					"name": "minSkewScale",
+					"name": "minSkewScaleUSD",
 					"outputs": [
 						{
 							"internalType": "uint256",
@@ -25521,7 +25521,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_minSkewScale",
+							"name": "_minSkewScaleUSD",
 							"type": "uint256"
 						},
 						{
@@ -25733,11 +25733,11 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_minSkewScale",
+							"name": "_minSkewScaleUSD",
 							"type": "uint256"
 						}
 					],
-					"name": "setMinSkewScale",
+					"name": "setMinSkewScaleUSD",
 					"outputs": [],
 					"payable": false,
 					"stateMutability": "nonpayable",
@@ -25783,7 +25783,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "_minSkewScale",
+							"name": "_minSkewScaleUSD",
 							"type": "uint256"
 						},
 						{
@@ -26734,7 +26734,7 @@
 						},
 						{
 							"internalType": "uint256",
-							"name": "minSkewScale",
+							"name": "minSkewScaleUSD",
 							"type": "uint256"
 						},
 						{

--- a/publish/deployed/kovan-ovm-futures/deployment.json
+++ b/publish/deployed/kovan-ovm-futures/deployment.json
@@ -24342,7 +24342,7 @@
 								},
 								{
 									"internalType": "uint256",
-									"name": "minLiquidationFee",
+									"name": "liquidationFee",
 									"type": "uint256"
 								}
 							],
@@ -25159,7 +25159,7 @@
 							"type": "uint256"
 						}
 					],
-					"name": "MinLiquidationFeeUpdated",
+					"name": "LiquidationFeeUpdated",
 					"type": "event"
 				},
 				{
@@ -25280,7 +25280,7 @@
 				{
 					"constant": true,
 					"inputs": [],
-					"name": "minLiquidationFee",
+					"name": "liquidationFee",
 					"outputs": [
 						{
 							"internalType": "uint256",
@@ -25602,7 +25602,7 @@
 							"type": "uint256"
 						}
 					],
-					"name": "setMinLiquidationFee",
+					"name": "setLiquidationFee",
 					"outputs": [],
 					"payable": false,
 					"stateMutability": "nonpayable",

--- a/publish/src/commands/deploy/configure-futures.js
+++ b/publish/src/commands/deploy/configure-futures.js
@@ -44,20 +44,20 @@ module.exports = async ({
 	await runStep({
 		contract: 'FuturesMarketSettings',
 		target: futuresMarketSettings,
-		read: 'liquidationFeeBPs',
+		read: 'liquidationFeeRatio',
 		expected: input => input !== '0', // only change if zero
-		write: 'setLiquidationFeeBPs',
-		writeArg: await getDeployParameter('FUTURES_LIQUIDATION_FEE_BPS'),
+		write: 'setLiquidationFeeRatio',
+		writeArg: await getDeployParameter('FUTURES_LIQUIDATION_FEE_RATIO'),
 		comment: 'Set the reward for liquidating a futures position (SIP-80)',
 	});
 
 	await runStep({
 		contract: 'FuturesMarketSettings',
 		target: futuresMarketSettings,
-		read: 'liquidationBufferBPs',
+		read: 'liquidationBufferRatio',
 		expected: input => input !== '0', // only change if zero
-		write: 'setLiquidationBufferBPs',
-		writeArg: await getDeployParameter('FUTURES_LIQUIDATION_BUFFER_BPS'),
+		write: 'setLiquidationBufferRatio',
+		writeArg: await getDeployParameter('FUTURES_LIQUIDATION_BUFFER_RATIO'),
 		comment: 'Set the reward for liquidating a futures position (SIP-80)',
 	});
 

--- a/publish/src/commands/deploy/configure-futures.js
+++ b/publish/src/commands/deploy/configure-futures.js
@@ -44,10 +44,10 @@ module.exports = async ({
 	await runStep({
 		contract: 'FuturesMarketSettings',
 		target: futuresMarketSettings,
-		read: 'liquidationFee',
+		read: 'minLiquidationFee',
 		expected: input => input !== '0', // only change if zero
-		write: 'setLiquidationFee',
-		writeArg: await getDeployParameter('FUTURES_LIQUIDATION_FEE'),
+		write: 'setMinLiquidationFee',
+		writeArg: await getDeployParameter('FUTURES_MIN_LIQUIDATION_FEE'),
 		comment: 'Set the reward for liquidating a futures position (SIP-80)',
 	});
 

--- a/publish/src/commands/deploy/configure-futures.js
+++ b/publish/src/commands/deploy/configure-futures.js
@@ -44,11 +44,31 @@ module.exports = async ({
 	await runStep({
 		contract: 'FuturesMarketSettings',
 		target: futuresMarketSettings,
+		read: 'liquidationFeeBPs',
+		expected: input => input !== '0', // only change if zero
+		write: 'setLiquidationFeeBPs',
+		writeArg: await getDeployParameter('FUTURES_LIQUIDATION_FEE_BPS'),
+		comment: 'Set the reward for liquidating a futures position (SIP-80)',
+	});
+
+	await runStep({
+		contract: 'FuturesMarketSettings',
+		target: futuresMarketSettings,
+		read: 'liquidationBufferBPs',
+		expected: input => input !== '0', // only change if zero
+		write: 'setLiquidationBufferBPs',
+		writeArg: await getDeployParameter('FUTURES_LIQUIDATION_BUFFER_BPS'),
+		comment: 'Set the reward for liquidating a futures position (SIP-80)',
+	});
+
+	await runStep({
+		contract: 'FuturesMarketSettings',
+		target: futuresMarketSettings,
 		read: 'minLiquidationFee',
 		expected: input => input !== '0', // only change if zero
 		write: 'setMinLiquidationFee',
 		writeArg: await getDeployParameter('FUTURES_MIN_LIQUIDATION_FEE'),
-		comment: 'Set the reward for liquidating a futures position (SIP-80)',
+		comment: 'Set the minimum reward for liquidating a futures position (SIP-80)',
 	});
 
 	const futuresAssets = futuresMarkets.map(x => x.asset);

--- a/test/contracts/FuturesMarket.js
+++ b/test/contracts/FuturesMarket.js
@@ -64,7 +64,7 @@ contract('FuturesMarket', accounts => {
 	const skewScaleUSD = toUnit('100000');
 	const maxFundingRateDelta = toUnit('0.0125');
 	const initialPrice = toUnit('100');
-	const liquidationFee = toUnit('20');
+	const minLiquidationFee = toUnit('20');
 	const minInitialMargin = toUnit('100');
 
 	const initialFundingIndex = toBN(4);
@@ -3096,7 +3096,7 @@ contract('FuturesMarket', accounts => {
 					toUnit('0.001')
 				);
 
-				await futuresMarketSettings.setLiquidationFee(toUnit('100'), { from: owner });
+				await futuresMarketSettings.setMinLiquidationFee(toUnit('100'), { from: owner });
 
 				assert.bnClose(
 					(await futuresMarket.liquidationPrice(trader, true)).price,
@@ -3109,7 +3109,7 @@ contract('FuturesMarket', accounts => {
 					toUnit('0.001')
 				);
 
-				await futuresMarketSettings.setLiquidationFee(toUnit('0'), { from: owner });
+				await futuresMarketSettings.setMinLiquidationFee(toUnit('0'), { from: owner });
 
 				assert.bnClose(
 					(await futuresMarket.liquidationPrice(trader, true)).price,
@@ -3379,7 +3379,7 @@ contract('FuturesMarket', accounts => {
 				assert.bnEqual(position.lastPrice, toUnit(0));
 				assert.bnEqual(position.fundingIndex, toBN(0));
 
-				assert.bnEqual(await sUSD.balanceOf(noBalance), liquidationFee);
+				assert.bnEqual(await sUSD.balanceOf(noBalance), minLiquidationFee);
 
 				const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
 
@@ -3387,7 +3387,7 @@ contract('FuturesMarket', accounts => {
 				decodedEventEqual({
 					event: 'Issued',
 					emittedFrom: sUSD.address,
-					args: [noBalance, liquidationFee],
+					args: [noBalance, minLiquidationFee],
 					log: decodedLogs[1],
 				});
 				decodedEventEqual({
@@ -3408,7 +3408,7 @@ contract('FuturesMarket', accounts => {
 				decodedEventEqual({
 					event: 'PositionLiquidated',
 					emittedFrom: proxyFuturesMarket.address,
-					args: [positionId, trader, noBalance, positionSize, price, liquidationFee],
+					args: [positionId, trader, noBalance, positionSize, price, minLiquidationFee],
 					log: decodedLogs[3],
 					bnCloseVariance: toUnit('0.001'),
 				});
@@ -3430,7 +3430,7 @@ contract('FuturesMarket', accounts => {
 				assert.bnEqual(position.lastPrice, toUnit(0));
 				assert.bnEqual(position.fundingIndex, toBN(0));
 
-				assert.bnEqual(await sUSD.balanceOf(noBalance), liquidationFee);
+				assert.bnEqual(await sUSD.balanceOf(noBalance), minLiquidationFee);
 
 				const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
 
@@ -3438,7 +3438,7 @@ contract('FuturesMarket', accounts => {
 				decodedEventEqual({
 					event: 'Issued',
 					emittedFrom: sUSD.address,
-					args: [noBalance, liquidationFee],
+					args: [noBalance, minLiquidationFee],
 					log: decodedLogs[1],
 				});
 				decodedEventEqual({
@@ -3459,7 +3459,7 @@ contract('FuturesMarket', accounts => {
 				decodedEventEqual({
 					event: 'PositionLiquidated',
 					emittedFrom: proxyFuturesMarket.address,
-					args: [positionId, trader3, noBalance, positionSize, price, liquidationFee],
+					args: [positionId, trader3, noBalance, positionSize, price, minLiquidationFee],
 					log: decodedLogs[3],
 					bnCloseVariance: toUnit('0.001'),
 				});
@@ -3475,7 +3475,7 @@ contract('FuturesMarket', accounts => {
 				assert.isFalse(await futuresMarket.canLiquidate(trader));
 
 				// raise the liquidation fee
-				await futuresMarketSettings.setLiquidationFee(toUnit('100'), { from: owner });
+				await futuresMarketSettings.setMinLiquidationFee(toUnit('100'), { from: owner });
 
 				assert.isTrue(await futuresMarket.canLiquidate(trader));
 				price = (await futuresMarket.liquidationPrice(trader, true)).price;

--- a/test/contracts/FuturesMarket.js
+++ b/test/contracts/FuturesMarket.js
@@ -3140,16 +3140,17 @@ contract('FuturesMarket', accounts => {
 				await fastForward(24 * 60 * 60);
 
 				// trader 1 pays 30 * -0.05 = -1.5 base units of funding, and a $22.5 trading fee
-				// liquidation price = (20 - (1500 - 22.5) + 30 * 250) / (30 - 1.5) = 212.018...
+				// liquidation price = pLast + (mLiq - m) / s + fPerUnit
+				// liquidation price = 250 + (20 - (1500 - 22.5)) / 30 + 0.05 * 250 = 213.917
 				let lPrice = await futuresMarket.liquidationPrice(trader, true);
-				assert.bnClose(lPrice[0], toUnit(212.018), toUnit(0.001));
+				assert.bnClose(lPrice[0], toUnit(213.917), toUnit(0.001));
 				lPrice = await futuresMarket.liquidationPrice(trader, false);
 				assert.bnClose(lPrice[0], preLPrice1, toUnit(0.001));
 
 				// trader2 receives -10 * -0.05 = 0.5 base units of funding, and a $2.5 trading fee
-				// liquidation price = (20 - (500 - 2.5) - 10 * 250) / (-10 + 0.5) = 312.894...
+				// liquidation price = 250 + (20 - (500 - 2.5)) / 10 + 0.05 * 250 = 310.25
 				lPrice = await futuresMarket.liquidationPrice(trader2, true);
-				assert.bnClose(lPrice[0], toUnit(313.421), toUnit(0.001));
+				assert.bnClose(lPrice[0], toUnit(310.25), toUnit(0.001));
 				lPrice = await futuresMarket.liquidationPrice(trader2, false);
 				assert.bnClose(lPrice[0], preLPrice2, toUnit(0.001));
 			});
@@ -3171,15 +3172,15 @@ contract('FuturesMarket', accounts => {
 
 				// funding rate = -10/50 * 0.1 = -0.02
 				// trader 1 pays 30 * 7 * -0.02 = -4.2 units of funding, pays $22.5 exchange fee
-				// Remaining margin = (20 - (1500 - 22.5) + 30 * 250) / (30 - 4.2) = 234.205...
+				// Remaining margin = 250 + (20 - (1500 - 22.5))/30 - (- 7 * 0.02) * 250) = 236.41666
 				let lPrice = await futuresMarket.liquidationPrice(trader, true);
-				assert.bnClose(lPrice[0], toUnit(234.205), toUnit(0.01));
+				assert.bnClose(lPrice[0], toUnit(236.41666), toUnit(0.01));
 				assert.isTrue(lPrice[1]);
 
 				// trader 2 receives -20 * 7 * -0.02 = 2.8 units of funding, pays $5 exchange fee
-				// Remaining margin = (20 - (1000 - 5) - 20 * 250) / (-20 + 2.8) = 346.802...
+				// Remaining margin = 250 + (20 - (100 - 5)) / (-20) - (- 7 * 0.02) * 250) = 333.75
 				lPrice = await futuresMarket.liquidationPrice(trader2, true);
-				assert.bnClose(lPrice[0], toUnit(347.383), toUnit(0.01));
+				assert.bnClose(lPrice[0], toUnit(333.75), toUnit(0.01));
 				assert.isTrue(lPrice[1]);
 			});
 

--- a/test/contracts/FuturesMarketData.js
+++ b/test/contracts/FuturesMarketData.js
@@ -1,7 +1,7 @@
 const { artifacts, contract, web3 } = require('hardhat');
 const { toWei } = web3.utils;
 const { toBytes32 } = require('../../');
-const { currentTime, toUnit } = require('../utils')();
+const { currentTime, toUnit, toBN } = require('../utils')();
 const { setupContract, setupAllContracts } = require('./setup');
 const { assert } = require('./common');
 
@@ -152,6 +152,13 @@ contract('FuturesMarketData', accounts => {
 			assert.bnEqual(globals.minInitialMargin, toUnit('100'));
 			assert.bnEqual(await futuresMarketSettings.minLiquidationFee(), globals.minLiquidationFee);
 			assert.bnEqual(globals.minLiquidationFee, toUnit('20'));
+			assert.bnEqual(await futuresMarketSettings.liquidationFeeBPs(), globals.liquidationFeeBPs);
+			assert.bnEqual(globals.liquidationFeeBPs, toBN('35'));
+			assert.bnEqual(
+				await futuresMarketSettings.liquidationBufferBPs(),
+				globals.liquidationBufferBPs
+			);
+			assert.bnEqual(globals.liquidationBufferBPs, toBN('25'));
 		});
 	});
 

--- a/test/contracts/FuturesMarketData.js
+++ b/test/contracts/FuturesMarketData.js
@@ -150,8 +150,8 @@ contract('FuturesMarketData', accounts => {
 
 			assert.bnEqual(await futuresMarketSettings.minInitialMargin(), globals.minInitialMargin);
 			assert.bnEqual(globals.minInitialMargin, toUnit('100'));
-			assert.bnEqual(await futuresMarketSettings.liquidationFee(), globals.liquidationFee);
-			assert.bnEqual(globals.liquidationFee, toUnit('20'));
+			assert.bnEqual(await futuresMarketSettings.minLiquidationFee(), globals.minLiquidationFee);
+			assert.bnEqual(globals.minLiquidationFee, toUnit('20'));
 		});
 	});
 

--- a/test/contracts/FuturesMarketData.js
+++ b/test/contracts/FuturesMarketData.js
@@ -1,7 +1,7 @@
 const { artifacts, contract, web3 } = require('hardhat');
 const { toWei } = web3.utils;
 const { toBytes32 } = require('../../');
-const { currentTime, toUnit, toBN } = require('../utils')();
+const { currentTime, toUnit } = require('../utils')();
 const { setupContract, setupAllContracts } = require('./setup');
 const { assert } = require('./common');
 
@@ -152,13 +152,16 @@ contract('FuturesMarketData', accounts => {
 			assert.bnEqual(globals.minInitialMargin, toUnit('100'));
 			assert.bnEqual(await futuresMarketSettings.minLiquidationFee(), globals.minLiquidationFee);
 			assert.bnEqual(globals.minLiquidationFee, toUnit('20'));
-			assert.bnEqual(await futuresMarketSettings.liquidationFeeBPs(), globals.liquidationFeeBPs);
-			assert.bnEqual(globals.liquidationFeeBPs, toBN('35'));
 			assert.bnEqual(
-				await futuresMarketSettings.liquidationBufferBPs(),
-				globals.liquidationBufferBPs
+				await futuresMarketSettings.liquidationFeeRatio(),
+				globals.liquidationFeeRatio
 			);
-			assert.bnEqual(globals.liquidationBufferBPs, toBN('25'));
+			assert.bnEqual(globals.liquidationFeeRatio, toUnit('0.0035'));
+			assert.bnEqual(
+				await futuresMarketSettings.liquidationBufferRatio(),
+				globals.liquidationBufferRatio
+			);
+			assert.bnEqual(globals.liquidationBufferRatio, toUnit('0.0025'));
 		});
 	});
 

--- a/test/contracts/FuturesMarketSettings.js
+++ b/test/contracts/FuturesMarketSettings.js
@@ -89,6 +89,8 @@ contract('FuturesMarketSettings', accounts => {
 				'setMaxFundingRateDelta',
 				'setParameters',
 				'setMinLiquidationFee',
+				'setLiquidationFeeBPs',
+				'setLiquidationBufferBPs',
 				'setMinInitialMargin',
 			],
 		});

--- a/test/contracts/FuturesMarketSettings.js
+++ b/test/contracts/FuturesMarketSettings.js
@@ -89,8 +89,8 @@ contract('FuturesMarketSettings', accounts => {
 				'setMaxFundingRateDelta',
 				'setParameters',
 				'setMinLiquidationFee',
-				'setLiquidationFeeBPs',
-				'setLiquidationBufferBPs',
+				'setLiquidationFeeRatio',
+				'setLiquidationBufferRatio',
 				'setMinInitialMargin',
 			],
 		});
@@ -296,69 +296,71 @@ contract('FuturesMarketSettings', accounts => {
 		});
 	});
 
-	describe('setLiquidationFeeBPs()', () => {
-		let liquidationFeeBPs;
+	describe('setLiquidationFeeRatio()', () => {
+		let liquidationFeeRatio;
 		beforeEach(async () => {
-			liquidationFeeBPs = await futuresMarketSettings.liquidationFeeBPs();
+			liquidationFeeRatio = await futuresMarketSettings.liquidationFeeRatio();
 		});
-		it('should be able to change liquidationFeeBPs', async () => {
-			const originalValue = await futuresMarketSettings.liquidationFeeBPs();
-			await futuresMarketSettings.setLiquidationFeeBPs(originalValue.mul(toBN(2)), { from: owner });
-			const newValue = await futuresMarketSettings.liquidationFeeBPs.call();
-			assert.bnEqual(newValue, originalValue.mul(toBN(2)));
+		it('should be able to change liquidationFeeRatio', async () => {
+			const originalValue = await futuresMarketSettings.liquidationFeeRatio();
+			await futuresMarketSettings.setLiquidationFeeRatio(originalValue.mul(toUnit(0.0002)), {
+				from: owner,
+			});
+			const newValue = await futuresMarketSettings.liquidationFeeRatio.call();
+			assert.bnEqual(newValue, originalValue.mul(toUnit(0.0002)));
 		});
 
-		it('only owner is permitted to change liquidationFeeBPs', async () => {
+		it('only owner is permitted to change liquidationFeeRatio', async () => {
 			await onlyGivenAddressCanInvoke({
-				fnc: futuresMarketSettings.setLiquidationFeeBPs,
-				args: [liquidationFeeBPs.toString()],
+				fnc: futuresMarketSettings.setLiquidationFeeRatio,
+				args: [liquidationFeeRatio.toString()],
 				address: owner,
 				accounts,
 				reason: 'Only the contract owner may perform this action',
 			});
 		});
 
-		it('should emit event on successful liquidationFeeBPs change', async () => {
-			const newValue = toBN(100);
-			const txn = await futuresMarketSettings.setLiquidationFeeBPs(newValue, {
+		it('should emit event on successful liquidationFeeRatio change', async () => {
+			const newValue = toUnit(0.01);
+			const txn = await futuresMarketSettings.setLiquidationFeeRatio(newValue, {
 				from: owner,
 			});
-			assert.eventEqual(txn, 'LiquidationFeeBPsUpdated', {
+			assert.eventEqual(txn, 'LiquidationFeeRatioUpdated', {
 				bps: newValue,
 			});
 		});
 	});
 
-	describe('setLiquidationBufferBPs()', () => {
-		let liquidationBufferBPs;
+	describe('setLiquidationBufferRatio()', () => {
+		let liquidationBufferRatio;
 		beforeEach(async () => {
-			liquidationBufferBPs = await futuresMarketSettings.liquidationBufferBPs();
+			liquidationBufferRatio = await futuresMarketSettings.liquidationBufferRatio();
 		});
-		it('should be able to change liquidationBufferBPs', async () => {
-			const originalValue = await futuresMarketSettings.liquidationBufferBPs();
-			await futuresMarketSettings.setLiquidationBufferBPs(originalValue.mul(toBN(2)), {
+		it('should be able to change liquidationBufferRatio', async () => {
+			const originalValue = await futuresMarketSettings.liquidationBufferRatio();
+			await futuresMarketSettings.setLiquidationBufferRatio(originalValue.mul(toUnit(0.0002)), {
 				from: owner,
 			});
-			const newValue = await futuresMarketSettings.liquidationBufferBPs.call();
-			assert.bnEqual(newValue, originalValue.mul(toBN(2)));
+			const newValue = await futuresMarketSettings.liquidationBufferRatio.call();
+			assert.bnEqual(newValue, originalValue.mul(toUnit(0.0002)));
 		});
 
-		it('only owner is permitted to change liquidationBufferBPs', async () => {
+		it('only owner is permitted to change liquidationBufferRatio', async () => {
 			await onlyGivenAddressCanInvoke({
-				fnc: futuresMarketSettings.setLiquidationBufferBPs,
-				args: [liquidationBufferBPs.toString()],
+				fnc: futuresMarketSettings.setLiquidationBufferRatio,
+				args: [liquidationBufferRatio.toString()],
 				address: owner,
 				accounts,
 				reason: 'Only the contract owner may perform this action',
 			});
 		});
 
-		it('should emit event on successful liquidationBufferBPs change', async () => {
+		it('should emit event on successful liquidationBufferRatio change', async () => {
 			const newValue = toBN(100);
-			const txn = await futuresMarketSettings.setLiquidationBufferBPs(newValue, {
+			const txn = await futuresMarketSettings.setLiquidationBufferRatio(newValue, {
 				from: owner,
 			});
-			assert.eventEqual(txn, 'LiquidationBufferBPsUpdated', {
+			assert.eventEqual(txn, 'LiquidationBufferRatioUpdated', {
 				bps: newValue,
 			});
 		});

--- a/test/contracts/FuturesMarketSettings.js
+++ b/test/contracts/FuturesMarketSettings.js
@@ -88,7 +88,7 @@ contract('FuturesMarketSettings', accounts => {
 				'setSkewScaleUSD',
 				'setMaxFundingRateDelta',
 				'setParameters',
-				'setLiquidationFee',
+				'setMinLiquidationFee',
 				'setMinInitialMargin',
 			],
 		});
@@ -236,28 +236,28 @@ contract('FuturesMarketSettings', accounts => {
 		});
 	});
 
-	describe('setLiquidationFee()', () => {
+	describe('setMinLiquidationFee()', () => {
 		let minInitialMargin;
 		beforeEach(async () => {
 			minInitialMargin = await futuresMarketSettings.minInitialMargin.call();
 		});
 		it('should be able to change the futures liquidation fee', async () => {
 			// fee <= minInitialMargin
-			const liquidationFee = minInitialMargin;
+			const minLiquidationFee = minInitialMargin;
 
-			const originalLiquidationFee = await futuresMarketSettings.liquidationFee.call();
-			await futuresMarketSettings.setLiquidationFee(liquidationFee, { from: owner });
-			const newLiquidationFee = await futuresMarketSettings.liquidationFee.call();
-			assert.bnEqual(newLiquidationFee, liquidationFee);
+			const originalLiquidationFee = await futuresMarketSettings.minLiquidationFee.call();
+			await futuresMarketSettings.setMinLiquidationFee(minLiquidationFee, { from: owner });
+			const newLiquidationFee = await futuresMarketSettings.minLiquidationFee.call();
+			assert.bnEqual(newLiquidationFee, minLiquidationFee);
 			assert.bnNotEqual(newLiquidationFee, originalLiquidationFee);
 		});
 
 		it('only owner is permitted to change the futures liquidation fee', async () => {
-			const liquidationFee = toUnit('100');
+			const minLiquidationFee = toUnit('100');
 
 			await onlyGivenAddressCanInvoke({
-				fnc: futuresMarketSettings.setLiquidationFee,
-				args: [liquidationFee.toString()],
+				fnc: futuresMarketSettings.setMinLiquidationFee,
+				args: [minLiquidationFee.toString()],
 				address: owner,
 				accounts,
 				reason: 'Only the contract owner may perform this action',
@@ -266,13 +266,13 @@ contract('FuturesMarketSettings', accounts => {
 
 		it('should revert if the fee is greater than the min initial margin', async () => {
 			await assert.revert(
-				futuresMarketSettings.setLiquidationFee(minInitialMargin.add(new BN(1)), {
+				futuresMarketSettings.setMinLiquidationFee(minInitialMargin.add(new BN(1)), {
 					from: owner,
 				}),
 				'min margin < liquidation fee'
 			);
 
-			const currentLiquidationFee = await futuresMarketSettings.liquidationFee.call();
+			const currentLiquidationFee = await futuresMarketSettings.minLiquidationFee.call();
 			await assert.revert(
 				futuresMarketSettings.setMinInitialMargin(currentLiquidationFee.sub(new BN(1)), {
 					from: owner,
@@ -283,13 +283,13 @@ contract('FuturesMarketSettings', accounts => {
 
 		it('should emit event on successful liquidation fee change', async () => {
 			// fee <= minInitialMargin
-			const liquidationFee = minInitialMargin.sub(new BN(1));
+			const minLiquidationFee = minInitialMargin.sub(new BN(1));
 
-			const txn = await futuresMarketSettings.setLiquidationFee(liquidationFee, {
+			const txn = await futuresMarketSettings.setMinLiquidationFee(minLiquidationFee, {
 				from: owner,
 			});
 			assert.eventEqual(txn, 'LiquidationFeeUpdated', {
-				sUSD: liquidationFee,
+				sUSD: minLiquidationFee,
 			});
 		});
 	});

--- a/test/contracts/FuturesMarketSettings.js
+++ b/test/contracts/FuturesMarketSettings.js
@@ -1,7 +1,7 @@
 const { artifacts, contract } = require('hardhat');
 
 const { toBytes32 } = require('../..');
-const { toUnit } = require('../utils')();
+const { toUnit, toBN } = require('../utils')();
 
 const { mockGenericContractFnc, setupAllContracts } = require('./setup');
 const { assert } = require('./common');
@@ -290,8 +290,76 @@ contract('FuturesMarketSettings', accounts => {
 			const txn = await futuresMarketSettings.setMinLiquidationFee(minLiquidationFee, {
 				from: owner,
 			});
-			assert.eventEqual(txn, 'LiquidationFeeUpdated', {
+			assert.eventEqual(txn, 'MinLiquidationFeeUpdated', {
 				sUSD: minLiquidationFee,
+			});
+		});
+	});
+
+	describe('setLiquidationFeeBPs()', () => {
+		let liquidationFeeBPs;
+		beforeEach(async () => {
+			liquidationFeeBPs = await futuresMarketSettings.liquidationFeeBPs();
+		});
+		it('should be able to change liquidationFeeBPs', async () => {
+			const originalValue = await futuresMarketSettings.liquidationFeeBPs();
+			await futuresMarketSettings.setLiquidationFeeBPs(originalValue.mul(toBN(2)), { from: owner });
+			const newValue = await futuresMarketSettings.liquidationFeeBPs.call();
+			assert.bnEqual(newValue, originalValue.mul(toBN(2)));
+		});
+
+		it('only owner is permitted to change liquidationFeeBPs', async () => {
+			await onlyGivenAddressCanInvoke({
+				fnc: futuresMarketSettings.setLiquidationFeeBPs,
+				args: [liquidationFeeBPs.toString()],
+				address: owner,
+				accounts,
+				reason: 'Only the contract owner may perform this action',
+			});
+		});
+
+		it('should emit event on successful liquidationFeeBPs change', async () => {
+			const newValue = toBN(100);
+			const txn = await futuresMarketSettings.setLiquidationFeeBPs(newValue, {
+				from: owner,
+			});
+			assert.eventEqual(txn, 'LiquidationFeeBPsUpdated', {
+				bps: newValue,
+			});
+		});
+	});
+
+	describe('setLiquidationBufferBPs()', () => {
+		let liquidationBufferBPs;
+		beforeEach(async () => {
+			liquidationBufferBPs = await futuresMarketSettings.liquidationBufferBPs();
+		});
+		it('should be able to change liquidationBufferBPs', async () => {
+			const originalValue = await futuresMarketSettings.liquidationBufferBPs();
+			await futuresMarketSettings.setLiquidationBufferBPs(originalValue.mul(toBN(2)), {
+				from: owner,
+			});
+			const newValue = await futuresMarketSettings.liquidationBufferBPs.call();
+			assert.bnEqual(newValue, originalValue.mul(toBN(2)));
+		});
+
+		it('only owner is permitted to change liquidationBufferBPs', async () => {
+			await onlyGivenAddressCanInvoke({
+				fnc: futuresMarketSettings.setLiquidationBufferBPs,
+				args: [liquidationBufferBPs.toString()],
+				address: owner,
+				accounts,
+				reason: 'Only the contract owner may perform this action',
+			});
+		});
+
+		it('should emit event on successful liquidationBufferBPs change', async () => {
+			const newValue = toBN(100);
+			const txn = await futuresMarketSettings.setLiquidationBufferBPs(newValue, {
+				from: owner,
+			});
+			assert.eventEqual(txn, 'LiquidationBufferBPsUpdated', {
+				bps: newValue,
 			});
 		});
 	});

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -27,7 +27,7 @@ const {
 		ETHER_WRAPPER_MAX_ETH,
 		ETHER_WRAPPER_MINT_FEE_RATE,
 		ETHER_WRAPPER_BURN_FEE_RATE,
-		FUTURES_LIQUIDATION_FEE,
+		FUTURES_MIN_LIQUIDATION_FEE,
 		FUTURES_MIN_INITIAL_MARGIN,
 	},
 } = require('../../');
@@ -1143,7 +1143,7 @@ const setupAllContracts = async ({
 				returnObj['FuturesMarketSettings'].setMinInitialMargin(FUTURES_MIN_INITIAL_MARGIN, {
 					from: owner,
 				}),
-				returnObj['FuturesMarketSettings'].setLiquidationFee(FUTURES_LIQUIDATION_FEE, {
+				returnObj['FuturesMarketSettings'].setMinLiquidationFee(FUTURES_MIN_LIQUIDATION_FEE, {
 					from: owner,
 				}),
 			];

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -28,8 +28,8 @@ const {
 		ETHER_WRAPPER_MINT_FEE_RATE,
 		ETHER_WRAPPER_BURN_FEE_RATE,
 		FUTURES_MIN_LIQUIDATION_FEE,
-		FUTURES_LIQUIDATION_FEE_BPS,
-		FUTURES_LIQUIDATION_BUFFER_BPS,
+		FUTURES_LIQUIDATION_FEE_RATIO,
+		FUTURES_LIQUIDATION_BUFFER_RATIO,
 		FUTURES_MIN_INITIAL_MARGIN,
 	},
 } = require('../../');
@@ -1148,12 +1148,15 @@ const setupAllContracts = async ({
 				returnObj['FuturesMarketSettings'].setMinLiquidationFee(FUTURES_MIN_LIQUIDATION_FEE, {
 					from: owner,
 				}),
-				returnObj['FuturesMarketSettings'].setLiquidationFeeBPs(FUTURES_LIQUIDATION_FEE_BPS, {
+				returnObj['FuturesMarketSettings'].setLiquidationFeeRatio(FUTURES_LIQUIDATION_FEE_RATIO, {
 					from: owner,
 				}),
-				returnObj['FuturesMarketSettings'].setLiquidationBufferBPs(FUTURES_LIQUIDATION_BUFFER_BPS, {
-					from: owner,
-				}),
+				returnObj['FuturesMarketSettings'].setLiquidationBufferRatio(
+					FUTURES_LIQUIDATION_BUFFER_RATIO,
+					{
+						from: owner,
+					}
+				),
 			];
 
 			// TODO: fetch settings per-market programmatically

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -28,6 +28,8 @@ const {
 		ETHER_WRAPPER_MINT_FEE_RATE,
 		ETHER_WRAPPER_BURN_FEE_RATE,
 		FUTURES_MIN_LIQUIDATION_FEE,
+		FUTURES_LIQUIDATION_FEE_BPS,
+		FUTURES_LIQUIDATION_BUFFER_BPS,
 		FUTURES_MIN_INITIAL_MARGIN,
 	},
 } = require('../../');
@@ -1144,6 +1146,12 @@ const setupAllContracts = async ({
 					from: owner,
 				}),
 				returnObj['FuturesMarketSettings'].setMinLiquidationFee(FUTURES_MIN_LIQUIDATION_FEE, {
+					from: owner,
+				}),
+				returnObj['FuturesMarketSettings'].setLiquidationFeeBPs(FUTURES_LIQUIDATION_FEE_BPS, {
+					from: owner,
+				}),
+				returnObj['FuturesMarketSettings'].setLiquidationBufferBPs(FUTURES_LIQUIDATION_BUFFER_BPS, {
 					from: owner,
 				}),
 			];

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -582,6 +582,7 @@ module.exports = ({ web3 } = {}) => {
 
 		toUnit,
 		fromUnit,
+		toBN,
 
 		toPreciseUnit,
 		fromPreciseUnit,


### PR DESCRIPTION
Updates the futures liquidation related logic for the first two items of https://github.com/synthetixio/issues/issues/352:
1. Proportional liquidation fee - to incentivise liquidations of larger positions first. Tentatively set to 35 bps.
2. Proportional liquidation margin buffer - to prevent negative margin liquidation, and to allow proportional fee to be paid to the fee pool. Tentatively set at 25 bps. If this buffer will not be needed in practice for safety (or for fees), the value can be set to 0 in the future.

These two values now allow controlling the proportional liquidation margin, and the allocation of that margin upon liquidation to the liquidator and fee pool. 

Other important changes in this PR:
- Adding the parameters to `FuturesMarketSettings`: `liquidationFeeBPs` and `liquidationBufferBPs`
- Adding new views to `FuturesMarket`: `liquidaionFee` and `liquidationMargin`
- Changing the logic of `_liquidationPrice` to calculate unrecorded funding using the current price.
- Changing the event and debt adjustment during `_liquidatePosition` to use the current price instead of the `liquidationPrice` (which may be higher or lower than actual price at that time, depending on the parameters, buffer, and oracle price).
- Sending any positive remainder of the margin to Fee Pool after deducting the `liquidationFee` (that goes to liquidator).