### PR TITLE
Sip 120 minor issues

### DIFF
--- a/contracts/ExchangeRatesWithDexPricing.sol
+++ b/contracts/ExchangeRatesWithDexPricing.sol
@@ -92,8 +92,21 @@ contract ExchangeRatesWithDexPricing is ExchangeRates {
         uint priceBuffer = sourceBuffer > destBuffer ? sourceBuffer : destBuffer; // max
         uint pClbufValue = systemValue.multiplyDecimal(SafeDecimalMath.unit().sub(priceBuffer));
 
+        // refactired due to stack too deep
+        uint pDexValue = _dexPriceDestinationValue(sourceEquivalent, destEquivalent, sourceAmount);
+
+        // Final value is minimum output between P_CLBUF and P_TWAP
+        value = pClbufValue < pDexValue ? pClbufValue : pDexValue; // min
+    }
+
+    function _dexPriceDestinationValue(
+        IERC20 sourceEquivalent,
+        IERC20 destEquivalent,
+        uint sourceAmount
+    ) internal view returns (uint) {
         // Normalize decimals in case equivalent asset uses different decimals from internal unit
-        uint sourceAmountInEquivalent = (sourceAmount * 10**uint(sourceEquivalent.decimals())) / SafeDecimalMath.unit();
+        uint sourceAmountInEquivalent =
+            (sourceAmount.mul(10**uint(sourceEquivalent.decimals()))).div(SafeDecimalMath.unit());
 
         uint twapWindow = getAtomicTwapWindow();
         require(twapWindow != 0, "Uninitialized atomic twap window");
@@ -105,12 +118,10 @@ contract ExchangeRatesWithDexPricing is ExchangeRates {
                 address(destEquivalent),
                 twapWindow
             );
+        require(twapValueInEquivalent > 0, "dex price returned 0");
 
         // Similar to source amount, normalize decimals back to internal unit for output amount
-        uint pDexValue = (twapValueInEquivalent * SafeDecimalMath.unit()) / 10**uint(destEquivalent.decimals());
-
-        // Final value is minimum output between P_CLBUF and P_TWAP
-        value = pClbufValue < pDexValue ? pClbufValue : pDexValue; // min
+        return (twapValueInEquivalent.mul(SafeDecimalMath.unit())).div(10**uint(destEquivalent.decimals()));
     }
 
     function synthTooVolatileForAtomicExchange(bytes32 currencyKey) external view returns (bool) {

--- a/contracts/SystemSettings.sol
+++ b/contracts/SystemSettings.sol
@@ -489,6 +489,7 @@ contract SystemSettings is Owned, MixinSystemSettings, ISystemSettings {
     }
 
     function setAtomicEquivalentForDexPricing(bytes32 _currencyKey, address _equivalent) external onlyOwner {
+        require(_equivalent != address(0), "Atomic equivalent is 0 address");
         flexibleStorage().setAddressValue(
             SETTING_CONTRACT_NAME,
             keccak256(abi.encodePacked(SETTING_ATOMIC_EQUIVALENT_FOR_DEX_PRICING, _currencyKey)),

--- a/contracts/interfaces/IDexPriceAggregator.sol
+++ b/contracts/interfaces/IDexPriceAggregator.sol
@@ -1,5 +1,10 @@
 pragma solidity ^0.5.16;
 
+// https://sips.synthetix.io/sips/sip-120/
+// Uniswap V3 based DecPriceAggregator (unaudited) e.g. https://etherscan.io/address/0xf120f029ac143633d1942e48ae2dfa2036c5786c#code
+// https://github.com/sohkai/uniswap-v3-spot-twap-oracle
+//  inteface: https://github.com/sohkai/uniswap-v3-spot-twap-oracle/blob/8f9777a6160a089c99f39f2ee297119ee293bc4b/contracts/interfaces/IDexPriceAggregator.sol
+//  implementation: https://github.com/sohkai/uniswap-v3-spot-twap-oracle/blob/8f9777a6160a089c99f39f2ee297119ee293bc4b/contracts/DexPriceAggregatorUniswapV3.sol
 interface IDexPriceAggregator {
     function assetToAsset(
         address tokenIn,

--- a/test/contracts/ExchangeRates.js
+++ b/test/contracts/ExchangeRates.js
@@ -2795,7 +2795,7 @@ contract('Exchange Rates', async accounts => {
 		});
 
 		describe('synthTooVolatileForAtomicExchange', async () => {
-			const minute = 60 * 60;
+			const minute = 60;
 			const synth = sETH;
 			let aggregator;
 
@@ -2856,7 +2856,8 @@ contract('Exchange Rates', async accounts => {
 						volatile,
 					}) {
 						beforeEach('set aggregator updates', async () => {
-							oracleUpdateTimesFromNow.sort().reverse(); // ensure the update times go from farthest to most recent
+							// JS footgun: .sort() sorts numbers as strings!
+							oracleUpdateTimesFromNow.sort((a, b) => b - a); // ensure the update times go from farthest to most recent
 							const now = await currentTime();
 							for (const timeFromNow of oracleUpdateTimesFromNow) {
 								await aggregator.setLatestAnswer(convertToDecimals(1, 8), now - timeFromNow);

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -2535,8 +2535,18 @@ contract('Exchanger (spec tests)', async accounts => {
 			describe('when a user has 1000 sUSD', () => {
 				describe('when the necessary configuration been set', () => {
 					const ethOnDex = toUnit('0.005'); // this should be chosen over the 100 (0.01) specified by default
+					const ethOnCL = toUnit('200'); // 1 over the ethOnDex
 
 					beforeEach(async () => {
+						// CL aggregator with past price data
+						const aggregator = await MockAggregator.new({ from: owner });
+						await exchangeRates.addAggregator(sETH, aggregator.address, { from: owner });
+						// set prices with no valatility
+						await aggregator.setLatestAnswer(ethOnCL, (await currentTime()) - 20 * 60);
+						await aggregator.setLatestAnswer(ethOnCL, (await currentTime()) - 15 * 60);
+						await aggregator.setLatestAnswer(ethOnCL, (await currentTime()) - 10 * 60);
+						await aggregator.setLatestAnswer(ethOnCL, (await currentTime()) - 5 * 60);
+
 						// DexPriceAggregator
 						const dexPriceAggregator = await MockDexPriceAggregator.new();
 						await dexPriceAggregator.setAssetToAssetRate(ethOnDex);
@@ -2559,6 +2569,16 @@ contract('Exchanger (spec tests)', async accounts => {
 								from: owner,
 							}
 						);
+						await systemSettings.setAtomicVolatilityConsiderationWindow(
+							sETH,
+							web3.utils.toBN(600), // 10 minutes
+							{
+								from: owner,
+							}
+						);
+						await systemSettings.setAtomicVolatilityUpdateThreshold(sETH, web3.utils.toBN(2), {
+							from: owner,
+						});
 					});
 
 					describe('when the user exchanges into sETH using an atomic exchange with a tracking code', () => {

--- a/test/contracts/SystemSettings.js
+++ b/test/contracts/SystemSettings.js
@@ -1145,9 +1145,17 @@ contract('SystemSettings', async accounts => {
 				);
 			});
 
+			it('cannot be set to 0 address', async () => {
+				await assert.revert(
+					systemSettings.setAtomicEquivalentForDexPricing(sETH, ZERO_ADDRESS, { from: owner }),
+					'Atomic equivalent is 0 address'
+				);
+			});
+
 			it('allows to be reset', async () => {
-				await systemSettings.setAtomicEquivalentForDexPricing(sETH, ZERO_ADDRESS, { from: owner });
-				assert.equal(await systemSettings.atomicEquivalentForDexPricing(sETH), ZERO_ADDRESS);
+				// using account1 (although it's EOA) for simplicity
+				await systemSettings.setAtomicEquivalentForDexPricing(sETH, account1, { from: owner });
+				assert.equal(await systemSettings.atomicEquivalentForDexPricing(sETH), account1);
 			});
 		});
 	});


### PR DESCRIPTION
This PR addresses several minor issues in https://github.com/Synthetixio/synthetix/pull/1127 contract changes:
- Not using safemath for price and amount calculations in `ExchangeRatesWithDexPricing`
- Allowing setting dex oracle to zero address in `SystemSettings`
- Not checking dex oracle returned price to at least not be 0 in `effectiveAtomicValueAndRates`
- Not having comments about the the dex oracle `IDexPriceAggregator`: impelementation source, refernce interface source.

This PR also fixes a few issues with tests in that PR:
- Tests for `exchangeAtomically` not being correctly set up to trigger volatility checks (no configurtion for the check which causes the check to be skipped comletely). Which makes the test skip an important part of functionality it's testing, and also makes gas measurement inaccureate.
- Using `.sort()` for numeric times incorrectly (using alphabetic sort for numbers) - and so setting up the mock correctly only for some test values. 
- Setting minutes to 3600 seconds in tests instead of 60 seconds, which makes the test use numbers that are too different from the values used in real world config.