### PR TITLE
Upgrade Integration Tests to use OVM 2.0 tooling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,19 +79,12 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - restore_cache:
-          keys:
-            - v6-optimism-build-{{ checksum "package-lock.json" }}
       - run:
           name: Build docker containers if necessary
           command: |
             if [ ! -d ./optimism ]; then
               npx hardhat ops --fresh --build --build-ops
             fi;
-      - save_cache:
-          key: v6-optimism-build-{{ checksum "package-lock.json" }}
-          paths:
-            - ./optimism
       - run:
           name: Start docker chains
           background: true

--- a/.circleci/src/jobs/job-integration-tests.yml
+++ b/.circleci/src/jobs/job-integration-tests.yml
@@ -8,19 +8,19 @@ steps:
   - checkout
   - attach_workspace:
       at: .
-  - restore_cache:
-      keys:
-        - v6-optimism-build-{{ checksum "package-lock.json" }}
+  # - restore_cache:
+  #     keys:
+  #       - v6-optimism-build-{{ checksum "package-lock.json" }}
   - run:
       name: Build docker containers if necessary
       command: |
         if [ ! -d ./optimism ]; then
           npx hardhat ops --fresh --build --build-ops
         fi;
-  - save_cache:
-      key: v6-optimism-build-{{ checksum "package-lock.json" }}
-      paths:
-        - ./optimism
+  # - save_cache:
+  #     key: v6-optimism-build-{{ checksum "package-lock.json" }}
+  #     paths:
+  #       - ./optimism
   - run:
       name: Start docker chains
       background: true

--- a/hardhat/tasks/task-ops.js
+++ b/hardhat/tasks/task-ops.js
@@ -25,7 +25,7 @@ task('ops', 'Run Optimism chain')
 	.addOptionalParam(
 		'optimismCommit',
 		'Commit to checkout',
-		'05ace3ae2c12c6ba5a4a0ac33254f9547cc4557c'
+		'f1631a5f7ddb6eb4a342bfbd7d46233a43412f9b'
 	)
 	.setAction(async (taskArguments, hre, runSuper) => {
 		taskArguments.maxMemory = true;


### PR DESCRIPTION
Upgrading to this change: https://github.com/ethereum-optimism/optimism/pull/1732 