### PR TITLE
reduce storage variables sizes for gas savings

### DIFF
--- a/contracts/FuturesMarketData.sol
+++ b/contracts/FuturesMarketData.sol
@@ -247,15 +247,20 @@ contract FuturesMarketData {
         view
         returns (IFuturesMarketBaseTypes.Position memory)
     {
-        (uint positionId, uint positionMargin, int positionSize, uint positionEntryPrice, uint positionEntryIndex) =
-            market.positions(account);
+        (
+            uint64 positionId,
+            uint64 positionEntryIndex,
+            uint128 positionMargin,
+            uint128 positionEntryPrice,
+            int128 positionSize
+        ) = market.positions(account);
         return
             IFuturesMarketBaseTypes.Position(
                 positionId,
+                positionEntryIndex,
                 positionMargin,
-                positionSize,
                 positionEntryPrice,
-                positionEntryIndex
+                positionSize
             );
     }
 

--- a/contracts/MixinFuturesNextPriceOrders.sol
+++ b/contracts/MixinFuturesNextPriceOrders.sol
@@ -61,10 +61,10 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
         uint targetRoundId = _exchangeRates().getCurrentRoundId(baseAsset) + 1; // next round
         NextPriceOrder memory order =
             NextPriceOrder({
-                sizeDelta: sizeDelta,
-                targetRoundId: targetRoundId,
-                commitDeposit: commitDeposit,
-                keeperDeposit: keeperDeposit
+                sizeDelta: int128(sizeDelta),
+                targetRoundId: uint128(targetRoundId),
+                commitDeposit: uint128(commitDeposit),
+                keeperDeposit: uint128(keeperDeposit)
             });
         // emit event
         emitNextPriceOrderSubmitted(messageSender, order);

--- a/contracts/interfaces/IFuturesMarket.sol
+++ b/contracts/interfaces/IFuturesMarket.sol
@@ -21,11 +21,11 @@ interface IFuturesMarket {
         external
         view
         returns (
-            uint id,
-            uint margin,
-            int size,
-            uint lastPrice,
-            uint fundingIndex
+            uint64 id,
+            uint64 fundingIndex,
+            uint128 margin,
+            uint128 lastPrice,
+            int128 size
         );
 
     function assetPrice() external view returns (uint price, bool invalid);

--- a/contracts/interfaces/IFuturesMarketBaseTypes.sol
+++ b/contracts/interfaces/IFuturesMarketBaseTypes.sol
@@ -19,18 +19,18 @@ interface IFuturesMarketBaseTypes {
 
     // If margin/size are positive, the position is long; if negative then it is short.
     struct Position {
-        uint id;
-        uint margin;
-        int size;
-        uint lastPrice;
-        uint fundingIndex;
+        uint64 id;
+        uint64 fundingIndex;
+        uint128 margin;
+        uint128 lastPrice;
+        int128 size;
     }
 
     // next-price order storage
     struct NextPriceOrder {
-        int sizeDelta; // difference in position to pass to modifyPosition
-        uint targetRoundId; // price oracle roundId using which price this order needs to exucted
-        uint commitDeposit; // the commitDeposit paid upon submitting that needs to be refunded if order succeeds
-        uint keeperDeposit; // the keeperDeposit paid upon submitting that needs to be paid / refunded on tx confirmation
+        int128 sizeDelta; // difference in position to pass to modifyPosition
+        uint128 targetRoundId; // price oracle roundId using which price this order needs to exucted
+        uint128 commitDeposit; // the commitDeposit paid upon submitting that needs to be refunded if order succeeds
+        uint128 keeperDeposit; // the keeperDeposit paid upon submitting that needs to be paid / refunded on tx confirmation
     }
 }


### PR DESCRIPTION
This reduces the stored variables sizes for some gas savings. 

Main savings are for the most expensive methods - `modifyPosition` and `executeNextPriceOrder` of around 80K gas:
- `modifyPosition` : 420K gas -> 340K gas
- `executeNextPriceOrder`: 470K gas -> 390K gas

On OVM this will translate to minor savings at this time because L2 gas is not the main cost, but given possible future added complexity and rising prices, it's still wise to take advantage of the easy savings. 

In terms of savings on calldata (for the L1 part of cost) - it's already minimal with most methods accepting at most one argument.

-----------------
Full tables (third numeric:

### Before
```
|  Contract                     ·  Method                            ·  Min         ·  Max        ·  Avg              ·  # calls      ·  usd (avg)  │
|  TestableFuturesMarket        ·  transferMargin                    ·      135898  ·     314024  ·           296034  ·          307  ·          -  │
|  TestableFuturesMarket        ·  withdrawAllMargin                 ·      173682  ·     277950  ·           245639  ·           19  ·          -  │
|  TestableFuturesMarket        ·  closePosition                     ·      303863  ·     330149  ·           313949  ·           45  ·          -  │
|  TestableFuturesMarket        ·  liquidatePosition                 ·      258390  ·     323471  ·           283890  ·           15  ·          -  │
|  TestableFuturesMarket        ·  modifyPosition                    ·      304164  ·     453436  ·           422787  ·          256  ·          -  │
|  TestableFuturesMarket        ·  submitNextPriceOrder              ·      327384  ·     368257  ·           336695  ·           35  ·          -  │
|  TestableFuturesMarket        ·  executeNextPriceOrder             ·      439018  ·     506507  ·           471997  ·           16  ·          -  │
|  TestableFuturesMarket        ·  cancelNextPriceOrder              ·      199686  ·     339162  ·           275570  ·           12  ·          -  │
```

### After
```
|  Contract                     ·  Method                            ·  Min         ·  Max        ·  Avg              ·  # calls      ·  usd (avg)  │
|  TestableFuturesMarket        ·  transferMargin                    ·      136421  ·     296422  ·           280604  ·          307  ·      26.56  │
|  TestableFuturesMarket        ·  withdrawAllMargin                 ·      167044  ·     273247  ·           241681  ·           19  ·      22.88  │
|  TestableFuturesMarket        ·  closePosition                     ·      292804  ·     312440  ·           300439  ·           45  ·      28.44  │
|  TestableFuturesMarket        ·  liquidatePosition                 ·      234595  ·     305572  ·           269646  ·           15  ·      25.53  │
|  TestableFuturesMarket        ·  modifyPosition                    ·      304005  ·     364752  ·           344986  ·          256  ·      32.66  │
|  TestableFuturesMarket        ·  submitNextPriceOrder              ·      277397  ·     299843  ·           283778  ·           35  ·      26.86  │
|  TestableFuturesMarket        ·  executeNextPriceOrder             ·      368287  ·     418676  ·           392716  ·           16  ·      37.18  │
|  TestableFuturesMarket        ·  cancelNextPriceOrder              ·      200720  ·     319312  ·           270256  ·           12  ·      25.58  │
```