### PR TITLE
fix duplicate fee reporting on WrapperFactory

### DIFF
--- a/contracts/WrapperFactory.sol
+++ b/contracts/WrapperFactory.sol
@@ -93,9 +93,6 @@ contract WrapperFactory is Owned, MixinResolver, IWrapperFactory {
             // Transfer sUSD to the fee pool
             bool success = synthsUSD().transfer(feePool().FEE_ADDRESS(), amountSUSD);
             require(success, "Transfer did not succeed");
-
-            // this is supposed to be done automatically by `transfer` but for some reason that doesn't happen
-            feePool().recordFeePaid(amountSUSD);
         }
     }
 

--- a/publish/releases.json
+++ b/publish/releases.json
@@ -411,8 +411,7 @@
 		{
 			"sip": 192,
 			"layer": "both",
-			"sources": ["WrapperFactory"],
-			"released": "both"
+			"sources": ["WrapperFactory"]
 		}
 	],
 	"releases": [

--- a/publish/releases.json
+++ b/publish/releases.json
@@ -407,6 +407,12 @@
 			"layer": "both",
 			"sources": ["DebtCache", "Issuer"],
 			"released": "both"
+		},
+		{
+			"sip": 192,
+			"layer": "both",
+			"sources": ["WrapperFactory"],
+			"released": "both"
 		}
 	],
 	"releases": [

--- a/publish/src/commands/deploy/index.js
+++ b/publish/src/commands/deploy/index.js
@@ -325,6 +325,7 @@ const deploy = async ({
 		limitPromise,
 		newContractsBeingAdded,
 		runStep,
+		network,
 		useOvm,
 	});
 

--- a/publish/src/commands/deploy/rebuild-resolver-caches.js
+++ b/publish/src/commands/deploy/rebuild-resolver-caches.js
@@ -30,29 +30,45 @@ module.exports = async ({
 	// add deployed wrappers
 	const wrapperCreatedLogs = await deployer.provider.getLogs({
 		fromBlock: 0,
-		topics: [ethers.utils.id('WrapperCreated(address,bytes32,address)')]
+		topics: [ethers.utils.id('WrapperCreated(address,bytes32,address)')],
 	});
 
-	const wrappers = wrapperCreatedLogs.map((rawLog) => {
+	const wrappers = wrapperCreatedLogs.map(rawLog => {
 		const log = WrapperFactory.interface.parseLog(rawLog);
 		return [
 			`Wrapper for ${ethers.utils.parseBytes32String(log.args.currencyKey)}`,
-			new ethers.Contract(log.args.wrapperAddress, WrapperFactory.interface, deployer.provider)
+			new ethers.Contract(log.args.wrapperAddress, WrapperFactory.interface, deployer.provider),
 		]; // interface doesn't matter as long as it responds to MixinResolver
 	});
 
 	// OVM pre-regenesis
 	if (network === 'mainnet' && useOvm) {
-		wrappers.push([
-			'Wrapper for sETH',
-			new ethers.Contract('0x6202A3B0bE1D222971E93AaB084c6E584C29DB70', WrapperFactory.interface, deployer.provider)
-		], [
-			'Wrapper for sUSD',
-			new ethers.Contract('0xad32aA4Bff8b61B4aE07E3BA437CF81100AF0cD7', WrapperFactory.interface, deployer.provider)
-		], [
-			'Wrapper for sUSD',
-			new ethers.Contract('0x8A91e92FDd86e734781c38DB52a390e1B99fba7c', WrapperFactory.interface, deployer.provider)
-		]);
+		wrappers.push(
+			[
+				'Wrapper for sETH',
+				new ethers.Contract(
+					'0x6202A3B0bE1D222971E93AaB084c6E584C29DB70',
+					WrapperFactory.interface,
+					deployer.provider
+				),
+			],
+			[
+				'Wrapper for sUSD',
+				new ethers.Contract(
+					'0xad32aA4Bff8b61B4aE07E3BA437CF81100AF0cD7',
+					WrapperFactory.interface,
+					deployer.provider
+				),
+			],
+			[
+				'Wrapper for sUSD',
+				new ethers.Contract(
+					'0x8A91e92FDd86e734781c38DB52a390e1B99fba7c',
+					WrapperFactory.interface,
+					deployer.provider
+				),
+			]
+		);
 	}
 
 	console.log(gray(`found ${wrappers.length} wrapper addresses`));

--- a/publish/src/commands/deploy/rebuild-resolver-caches.js
+++ b/publish/src/commands/deploy/rebuild-resolver-caches.js
@@ -13,11 +13,12 @@ module.exports = async ({
 	limitPromise,
 	newContractsBeingAdded,
 	runStep,
+	network,
 	useOvm,
 }) => {
 	console.log(gray(`\n------ REBUILD RESOLVER CACHES ------\n`));
 
-	const { AddressResolver } = deployer.deployedContracts;
+	const { AddressResolver, WrapperFactory } = deployer.deployedContracts;
 
 	const filterTargetsWith = ({ prop }) =>
 		Object.entries(deployer.deployedContracts).filter(([, target]) => {
@@ -25,6 +26,38 @@ module.exports = async ({
 		});
 
 	const contractsWithRebuildableCache = filterTargetsWith({ prop: 'rebuildCache' });
+
+	// add deployed wrappers
+	const wrapperCreatedLogs = await deployer.provider.getLogs({
+		fromBlock: 0,
+		topics: [ethers.utils.id('WrapperCreated(address,bytes32,address)')]
+	});
+
+	const wrappers = wrapperCreatedLogs.map((rawLog) => {
+		const log = WrapperFactory.interface.parseLog(rawLog);
+		return [
+			`Wrapper for ${ethers.utils.parseBytes32String(log.args.currencyKey)}`,
+			new ethers.Contract(log.args.wrapperAddress, WrapperFactory.interface, deployer.provider)
+		]; // interface doesn't matter as long as it responds to MixinResolver
+	});
+
+	// OVM pre-regenesis
+	if (network === 'mainnet' && useOvm) {
+		wrappers.push([
+			'Wrapper for sETH',
+			new ethers.Contract('0x6202A3B0bE1D222971E93AaB084c6E584C29DB70', WrapperFactory.interface, deployer.provider)
+		], [
+			'Wrapper for sUSD',
+			new ethers.Contract('0xad32aA4Bff8b61B4aE07E3BA437CF81100AF0cD7', WrapperFactory.interface, deployer.provider)
+		], [
+			'Wrapper for sUSD',
+			new ethers.Contract('0x8A91e92FDd86e734781c38DB52a390e1B99fba7c', WrapperFactory.interface, deployer.provider)
+		]);
+	}
+
+	console.log(gray(`found ${wrappers.length} wrapper addresses`));
+
+	contractsWithRebuildableCache.push(...wrappers);
 
 	// collect all resolver addresses required
 	const contractToDepMap = {};

--- a/publish/src/commands/deploy/rebuild-resolver-caches.js
+++ b/publish/src/commands/deploy/rebuild-resolver-caches.js
@@ -27,25 +27,62 @@ module.exports = async ({
 
 	const contractsWithRebuildableCache = filterTargetsWith({ prop: 'rebuildCache' });
 
-	// add deployed wrappers
-	const wrapperCreatedLogs = await deployer.provider.getLogs({
-		fromBlock: 0,
-		topics: [ethers.utils.id('WrapperCreated(address,bytes32,address)')],
-	});
+	const wrappers = [];
 
-	const wrappers = wrapperCreatedLogs.map(rawLog => {
-		const log = WrapperFactory.interface.parseLog(rawLog);
-		return [
-			`Wrapper for ${ethers.utils.parseBytes32String(log.args.currencyKey)}`,
-			new ethers.Contract(log.args.wrapperAddress, WrapperFactory.interface, deployer.provider),
-		]; // interface doesn't matter as long as it responds to MixinResolver
-	});
+	// add deployed wrappers
+	try {
+		const wrapperCreatedLogs = await deployer.provider.getLogs({
+			fromBlock: 0,
+			topics: [ethers.utils.id('WrapperCreated(address,bytes32,address)')],
+		});
+
+		for (const rawLog of wrapperCreatedLogs) {
+			const log = WrapperFactory.interface.parseLog(rawLog);
+			wrappers.push([
+				`Wrapper for ${yellow(
+					ethers.utils.parseBytes32String(log.args.currencyKey)
+				)} via token ${yellow(
+					await new ethers.Contract(
+						log.args.token,
+						[
+							{
+								constant: true,
+								inputs: [],
+								name: 'name',
+								outputs: [
+									{
+										type: 'string',
+									},
+								],
+								payable: false,
+								stateMutability: 'view',
+								type: 'function',
+							},
+						],
+						deployer.provider
+					).name()
+				)}`,
+				new ethers.Contract(log.args.wrapperAddress, WrapperFactory.interface, deployer.provider),
+			]); // interface doesn't matter as long as it responds to MixinResolver
+		}
+	} catch (err) {
+		if (/eth_getLogs are limited to a 10,000 blocks range/.test(err.message)) {
+			console.log(
+				yellow.bold(
+					'Warning: Cannot fetch logs on this network. Known limitation on OVM mainnet - cannot search back greater than 10k blocks'
+				)
+			);
+		} else {
+			throw err;
+		}
+	}
 
 	// OVM pre-regenesis
 	if (network === 'mainnet' && useOvm) {
+		console.log(gray('Adding 3 known OVM wrapper pre-regenesis'));
 		wrappers.push(
 			[
-				'Wrapper for sETH',
+				'WETHWrapper',
 				new ethers.Contract(
 					'0x6202A3B0bE1D222971E93AaB084c6E584C29DB70',
 					WrapperFactory.interface,
@@ -53,7 +90,7 @@ module.exports = async ({
 				),
 			],
 			[
-				'Wrapper for sUSD',
+				'DAIWrapper',
 				new ethers.Contract(
 					'0xad32aA4Bff8b61B4aE07E3BA437CF81100AF0cD7',
 					WrapperFactory.interface,
@@ -61,7 +98,7 @@ module.exports = async ({
 				),
 			],
 			[
-				'Wrapper for sUSD',
+				'LUSDWrapper',
 				new ethers.Contract(
 					'0x8A91e92FDd86e734781c38DB52a390e1B99fba7c',
 					WrapperFactory.interface,
@@ -71,7 +108,9 @@ module.exports = async ({
 		);
 	}
 
-	console.log(gray(`found ${wrappers.length} wrapper addresses`));
+	console.log(gray(`found ${yellow(wrappers.length)} wrapper addresses`));
+
+	wrappers.forEach(([label, target]) => console.log(gray(label, 'at', yellow(target.address))));
 
 	contractsWithRebuildableCache.push(...wrappers);
 

--- a/test/contracts/WrapperFactory.js
+++ b/test/contracts/WrapperFactory.js
@@ -207,7 +207,7 @@ contract('WrapperFactory', async accounts => {
 					.find(({ name }) => name === 'Transfer'),
 			});
 		});
-		
+
 		it('records fee paid', async () => {
 			const recentFeePeriod = await feePool.recentFeePeriods(0);
 

--- a/test/contracts/WrapperFactory.js
+++ b/test/contracts/WrapperFactory.js
@@ -187,6 +187,7 @@ contract('WrapperFactory', async accounts => {
 			feesEscrowed = await wrapperFactory.feesEscrowed();
 			tx = await wrapperFactory.distributeFees();
 		});
+
 		it('issues sUSD to the feepool', async () => {
 			const logs = await getDecodedLogs({
 				hash: tx.tx,
@@ -205,6 +206,16 @@ contract('WrapperFactory', async accounts => {
 					.filter(l => !!l)
 					.find(({ name }) => name === 'Transfer'),
 			});
+		});
+		
+		it('records fee paid', async () => {
+			const recentFeePeriod = await feePool.recentFeePeriods(0);
+
+			console.log(FEE_ADDRESS);
+			console.log(await sUSDSynth.balanceOf(FEE_ADDRESS));
+
+			assert.bnNotEqual(toUnit(0), feesEscrowed); // because i'm paranoid
+			assert.bnEqual(recentFeePeriod.feesToDistribute, feesEscrowed);
 		});
 
 		it('feesEscrowed = 0', async () => {

--- a/test/contracts/WrapperFactory.js
+++ b/test/contracts/WrapperFactory.js
@@ -211,9 +211,6 @@ contract('WrapperFactory', async accounts => {
 		it('records fee paid', async () => {
 			const recentFeePeriod = await feePool.recentFeePeriods(0);
 
-			console.log(FEE_ADDRESS);
-			console.log(await sUSDSynth.balanceOf(FEE_ADDRESS));
-
 			assert.bnNotEqual(toUnit(0), feesEscrowed); // because i'm paranoid
 			assert.bnEqual(recentFeePeriod.feesToDistribute, feesEscrowed);
 		});

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -1125,11 +1125,11 @@ const setupAllContracts = async ({
 		]);
 	}
 
-	// finally if any of our contracts have setSystemStatus (from MockSynth), then invoke it
+	// finally if any of our contracts have setAddressResolver (from MockSynth), then invoke it
 	await Promise.all(
 		Object.values(returnObj)
-			.filter(contract => contract.setSystemStatus)
-			.map(mock => mock.setSystemStatus(returnObj['SystemStatus'].address))
+			.filter(contract => contract.setAddressResolver)
+			.map(mock => mock.setAddressResolver(returnObj['AddressResolver'].address))
 	);
 
 	return returnObj;


### PR DESCRIPTION
`WrapperFactory` is submitting a second `recordFeePaid` call. We need to fund the fee pool the missing $257k, and update the fee pool afterwards to ensure correct accounting.

The error was covered by unit tests prior to the discovery of this bug, but it lead to diverging functionality on-chain because the Synth used for `sUSD` is a `MockSynth`, not the actual `Synth`. This lead to coming to the wrong conclusion that having the additional `recordFeePaid()` was actually necessary.

To correct the unit tests, `MockSynth` was updated to match the functieonality of the `Synth` class with regards to the Fee period record fee paid.

This bug affects both L1 and L2, but only L2 will require funding or fee pool correction.