### PR TITLE
SIP-194 Fix Liquidations on L2

### DIFF
--- a/contracts/BaseSynthetix.sol
+++ b/contracts/BaseSynthetix.sol
@@ -305,6 +305,22 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
         return issuer().burnSynthsToTargetOnBehalf(burnForAddress, messageSender);
     }
 
+    function liquidateDelinquentAccount(address account, uint susdAmount)
+        external
+        systemActive
+        optionalProxy
+        returns (bool)
+    {
+        (uint totalRedeemed, uint amountLiquidated) =
+            issuer().liquidateDelinquentAccount(account, susdAmount, messageSender);
+
+        emitAccountLiquidated(account, totalRedeemed, amountLiquidated, messageSender);
+
+        // Transfer SNX redeemed to messageSender
+        // Reverts if amount to redeem is more than balanceOf account, ie due to escrowed balance
+        return _transferByProxy(account, messageSender, totalRedeemed);
+    }
+
     function exchangeWithTrackingForInitiator(
         bytes32,
         uint,
@@ -334,10 +350,6 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
     }
 
     function mint() external returns (bool) {
-        _notImplemented();
-    }
-
-    function liquidateDelinquentAccount(address, uint) external returns (bool) {
         _notImplemented();
     }
 
@@ -396,6 +408,25 @@ contract BaseSynthetix is IERC20, ExternStateToken, MixinResolver, ISynthetix {
     }
 
     // ========== EVENTS ==========
+    event AccountLiquidated(address indexed account, uint snxRedeemed, uint amountLiquidated, address liquidator);
+    bytes32 internal constant ACCOUNTLIQUIDATED_SIG = keccak256("AccountLiquidated(address,uint256,uint256,address)");
+
+    function emitAccountLiquidated(
+        address account,
+        uint256 snxRedeemed,
+        uint256 amountLiquidated,
+        address liquidator
+    ) internal {
+        proxy._emit(
+            abi.encode(snxRedeemed, amountLiquidated, liquidator),
+            2,
+            ACCOUNTLIQUIDATED_SIG,
+            addressToBytes32(account),
+            0,
+            0
+        );
+    }
+
     event SynthExchange(
         address indexed account,
         bytes32 fromCurrencyKey,

--- a/contracts/Synthetix.sol
+++ b/contracts/Synthetix.sol
@@ -167,22 +167,6 @@ contract Synthetix is BaseSynthetix {
         return true;
     }
 
-    function liquidateDelinquentAccount(address account, uint susdAmount)
-        external
-        systemActive
-        optionalProxy
-        returns (bool)
-    {
-        (uint totalRedeemed, uint amountLiquidated) =
-            issuer().liquidateDelinquentAccount(account, susdAmount, messageSender);
-
-        emitAccountLiquidated(account, totalRedeemed, amountLiquidated, messageSender);
-
-        // Transfer SNX redeemed to messageSender
-        // Reverts if amount to redeem is more than balanceOf account, ie due to escrowed balance
-        return _transferByProxy(account, messageSender, totalRedeemed);
-    }
-
     /* Once off function for SIP-60 to migrate SNX balances in the RewardEscrow contract
      * To the new RewardEscrowV2 contract
      */
@@ -196,24 +180,6 @@ contract Synthetix is BaseSynthetix {
     }
 
     // ========== EVENTS ==========
-    event AccountLiquidated(address indexed account, uint snxRedeemed, uint amountLiquidated, address liquidator);
-    bytes32 internal constant ACCOUNTLIQUIDATED_SIG = keccak256("AccountLiquidated(address,uint256,uint256,address)");
-
-    function emitAccountLiquidated(
-        address account,
-        uint256 snxRedeemed,
-        uint256 amountLiquidated,
-        address liquidator
-    ) internal {
-        proxy._emit(
-            abi.encode(snxRedeemed, amountLiquidated, liquidator),
-            2,
-            ACCOUNTLIQUIDATED_SIG,
-            addressToBytes32(account),
-            0,
-            0
-        );
-    }
 
     event AtomicSynthExchange(
         address indexed account,

--- a/publish/releases.json
+++ b/publish/releases.json
@@ -413,6 +413,11 @@
 			"layer": "both",
 			"sources": ["WrapperFactory"],
 			"released": "both"
+		},
+		{
+			"sip": 194,
+			"layer": "ovm",
+			"sources": ["Synthetix"]
 		}
 	],
 	"releases": [

--- a/test/contracts/BaseSynthetix.js
+++ b/test/contracts/BaseSynthetix.js
@@ -183,14 +183,6 @@ contract('BaseSynthetix', async accounts => {
 			});
 		});
 
-		it('liquidateDelinquentAccount should revert no matter who the caller is', async () => {
-			await onlyGivenAddressCanInvoke({
-				fnc: baseSynthetix.liquidateDelinquentAccount,
-				accounts,
-				args: [account1, amount],
-				reason: 'Cannot be run on this layer',
-			});
-		});
 		it('mintSecondary should revert no matter who the caller is', async () => {
 			await onlyGivenAddressCanInvoke({
 				fnc: baseSynthetix.mintSecondary,


### PR DESCRIPTION
The `liquidateDelinquentAccount` logic from `Issuer.sol` was indeed added to OVM during the [Menkalinan release](https://blog.synthetix.io/the-menkalinan-release/) however it can only be invoked via `Synthetix` which was not updated during that release.

This addresses that by moving the logic to the base class which both layers use.