### PR TITLE
Ensuring job-compile size check matches build command

### DIFF
--- a/hardhat/util/collectContractBytecodes.js
+++ b/hardhat/util/collectContractBytecodes.js
@@ -42,7 +42,7 @@ function collectContractBytesCodes() {
 				const jsonFileContents = fs.readFileSync(jsonfilePath);
 				const artifacts = JSON.parse(jsonFileContents);
 
-				contractBytecodes[contractName] = artifacts.bytecode;
+				contractBytecodes[contractName] = artifacts.deployedBytecode;
 			} else {
 				searchRecurse({ entryPath: path.join(entryPath, contractFolder) });
 			}

--- a/publish/src/contract-size.js
+++ b/publish/src/contract-size.js
@@ -100,12 +100,12 @@ module.exports = {
 		};
 		const entries = sizeOfContracts({ contractToObjectMap });
 		const tableData = [
-			['Contract', 'Size', 'Percent of Limit', 'Increase'].map(x => yellow(x)),
+			['Contract', 'Length', 'KB', 'Percent of Limit', 'Increase'].map(x => yellow(x)),
 		].concat(
-			entries.reverse().map(({ file, length, pcent }) => {
+			entries.reverse().map(({ file, length, bytes, pcent }) => {
 				const prevSizeIfAny = previousSizes.find(candidate => candidate.file === file);
 
-				return [file, length, pcent, sizeChange({ prevSizeIfAny, length })].map(content =>
+				return [file, length, bytes, pcent, sizeChange({ prevSizeIfAny, length })].map(content =>
 					pcentToColorFnc({ pcent, content })
 				);
 			})


### PR DESCRIPTION
This meant that `job-compile` could fail oversize even though technically the contract was not too big to deploy. 

Before in `develop`

| `npx hardhat compile --optimizer --showsize` | `node publish build --show-size` |
| - | - |
| ![image](https://user-images.githubusercontent.com/799038/145333871-6c92d1e9-01c2-49cd-9529-dea3b0bce431.png) | 
![image](https://user-images.githubusercontent.com/799038/145334050-4cf1e04d-2f4d-440c-87db-06a52b3239d4.png)
|

This PR

| `npx hardhat compile --optimizer --showsize` | `node publish build --show-size` |
| - | - |
| ![image](https://user-images.githubusercontent.com/799038/145335852-51d4a364-9e57-4c62-a64a-1209ceb3c663.png) | ![image](https://user-images.githubusercontent.com/799038/145336402-ec3ea7eb-db38-42aa-ad16-61b3765fd85e.png) |
