### PR TITLE
split caching and legacy rates mappings

### DIFF
--- a/contracts/interfaces/IExchangeRates.sol
+++ b/contracts/interfaces/IExchangeRates.sol
@@ -15,8 +15,6 @@ interface IExchangeRates {
 
     function anyRateIsInvalid(bytes32[] calldata currencyKeys) external view returns (bool);
 
-    function currentRoundForRate(bytes32 currencyKey) external view returns (uint);
-
     function currenciesUsingAggregator(address aggregator) external view returns (bytes32[] memory);
 
     function effectiveValue(

--- a/test/contracts/ExchangeRates.js
+++ b/test/contracts/ExchangeRates.js
@@ -1859,19 +1859,18 @@ contract('Exchange Rates', async accounts => {
 		});
 
 		describe('roundIds for historical rates', () => {
-			it('getCurrentRoundId() by default is 0 for all synths except sUSD which is 1', async () => {
+			it('getCurrentRoundId() by default is 0 for all synths including sUSD', async () => {
 				// Note: rates that were set in the truffle migration will be at 1, so we need to check
 				// other synths
 				assert.equal(await instance.getCurrentRoundId(sJPY), '0');
 				assert.equal(await instance.getCurrentRoundId(sBNB), '0');
-				assert.equal(await instance.getCurrentRoundId(sUSD), '1');
+				assert.equal(await instance.getCurrentRoundId(sUSD), '0');
 			});
 
 			it('ratesAndUpdatedTimeForCurrencyLastNRounds() shows first entry for sUSD', async () => {
-				const timeOfsUSDRateSetOnInit = await instance.lastRateUpdateTimes(sUSD);
 				assert.deepEqual(await instance.ratesAndUpdatedTimeForCurrencyLastNRounds(sUSD, '3', '0'), [
 					[toUnit('1'), '0', '0'],
-					[timeOfsUSDRateSetOnInit, '0', '0'],
+					['0', '0', '0'],
 				]);
 			});
 			it('ratesAndUpdatedTimeForCurrencyLastNRounds() returns 0s for other currency keys', async () => {

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -2594,6 +2594,9 @@ contract('Exchanger (spec tests)', async accounts => {
 					const ethOnCL = toUnit('200'); // 1 over the ethOnDex
 
 					beforeEach(async () => {
+						// set dynamic fee to a low value because it won't accept 0 prices rounds
+						await systemSettings.setExchangeDynamicFeeRounds('3', { from: owner });
+
 						// CL aggregator with past price data
 						const aggregator = await MockAggregator.new({ from: owner });
 						await exchangeRates.addAggregator(sETH, aggregator.address, { from: owner });


### PR DESCRIPTION
This splits the mappings in writing and reading and renames the oracle related variables to "deprecated" to prevent using them in anything.

There is also a test fix for atomic exchange which I'm not sure exactly how it worked before because it wasn't setting all needed prices, but it wasn't disabling dynamic fees either.