### PR TITLE
Remove legacy deployments

### DIFF
--- a/publish/deployed/kovan-ovm/deployment.json
+++ b/publish/deployed/kovan-ovm/deployment.json
@@ -72,15 +72,6 @@
 			"txn": "",
 			"network": "kovan"
 		},
-		"RewardEscrow": {
-			"name": "RewardEscrow",
-			"address": "0x9952e42fF92149f48b3b7dee3f921A6DD106F79F",
-			"source": "RewardEscrow",
-			"link": "https://kovan-explorer.optimism.io/address/0x9952e42fF92149f48b3b7dee3f921A6DD106F79F",
-			"timestamp": "2021-01-14T17:20:33.145Z",
-			"txn": "",
-			"network": "kovan"
-		},
 		"RewardEscrowV2": {
 			"name": "RewardEscrowV2",
 			"address": "0xB613d148E47525478bD8A91eF7Cf2F7F63d81858",

--- a/publish/deployed/mainnet-ovm/deployment.json
+++ b/publish/deployed/mainnet-ovm/deployment.json
@@ -72,15 +72,6 @@
 			"txn": "",
 			"network": "mainnet"
 		},
-		"RewardEscrow": {
-			"name": "RewardEscrow",
-			"address": "0xd32138018210edA0028240638f35b70ECC0D8C22",
-			"source": "RewardEscrow",
-			"link": "https://etherscan.io/address/0xd32138018210edA0028240638f35b70ECC0D8C22",
-			"timestamp": "2021-01-15T05:40:59.117Z",
-			"txn": "",
-			"network": "mainnet"
-		},
 		"RewardEscrowV2": {
 			"name": "RewardEscrowV2",
 			"address": "0x47eE58801C1AC44e54FF2651aE50525c5cfc66d0",


### PR DESCRIPTION
Remove old `RewardEscrow` deployment artifacts from mainnet-ovm and kovan-ovm `deployment.json` files