### PR TITLE
Update kovan-ovm feeds with new aggregator contracts

### DIFF
--- a/publish/deployed/kovan-ovm/feeds.json
+++ b/publish/deployed/kovan-ovm/feeds.json
@@ -1,19 +1,19 @@
 {
 	"SNX": {
 		"asset": "SNX",
-		"feed": "0xd9E9047ED2d6e2130395a2Fe08033e756CC7e288"
+		"feed": "0xd2906e9fDA8BE1418614f614FE393f2fFbd1Cb4A"
 	},
 	"ETH": {
 		"asset": "ETH",
-		"feed": "0xCb7895bDC70A1a1Dce69b689FD7e43A627475A06"
+		"feed": "0xa35dB7f3aBE4091999143dA8AdC20B6ad9e514c4"
 	},
 	"BTC": {
 		"asset": "BTC",
-		"feed": "0x81AE7F8fF54070C52f0eB4EB5b8890e1506AA4f4"
+		"feed": "0xfb510c34959E51986d0b73c345fd9d5A9090ED15"
 	},
 	"LINK": {
 		"asset": "LINK",
-		"feed": "0xb37aA79EBc31B93864Bff2d5390b385bE482897b"
+		"feed": "0x087bcF4C0aa8Ff652a9BDd6E1b2Ea8C2Ee8f5F8c"
 	},
 	"UNI": {
 		"asset": "UNI",


### PR DESCRIPTION
The ChainLink OCR proxies are not yet ready on `kovan-ovm`, but the aggregators are up running smoothly.  We can use these in the interim until the proxies are deployed.

⚠️ *Note these are aggregator contracts -- **not** the proxies.*