### PR TITLE
Futures dynamic fee

### DIFF
--- a/contracts/ExchangeCircuitBreaker.sol
+++ b/contracts/ExchangeCircuitBreaker.sol
@@ -201,13 +201,6 @@ contract ExchangeCircuitBreaker is Owned, MixinSystemSettings, IExchangeCircuitB
         return false;
     }
 
-    // ========== MODIFIERS ==========
-
-    modifier onlyExchangeRates() {
-        require(msg.sender == address(_exchangeRates()), "Restricted to ExchangeRates");
-        _;
-    }
-
     // ========== EVENTS ==========
 
     // @notice signals that a the "last rate" was overriden by one of the admin methods

--- a/contracts/FuturesMarketBase.sol
+++ b/contracts/FuturesMarketBase.sol
@@ -15,6 +15,7 @@ import "./SafeDecimalMath.sol";
 // Internal references
 import "./interfaces/IExchangeCircuitBreaker.sol";
 import "./interfaces/IExchangeRates.sol";
+import "./interfaces/IExchanger.sol";
 import "./interfaces/ISystemStatus.sol";
 import "./interfaces/IERC20.sol";
 
@@ -92,6 +93,9 @@ contract FuturesMarketBase is Owned, Proxyable, MixinFuturesMarketSettings, IFut
     // This is the same unit as used inside `SignedSafeDecimalMath`.
     int private constant _UNIT = int(10**uint(18));
 
+    //slither-disable-next-line naming-convention
+    bytes32 internal constant sUSD = "sUSD";
+
     /* ========== STATE VARIABLES ========== */
 
     // The asset being traded in this market. This should be a valid key into the ExchangeRates contract.
@@ -140,6 +144,7 @@ contract FuturesMarketBase is Owned, Proxyable, MixinFuturesMarketSettings, IFut
     /* ---------- Address Resolver Configuration ---------- */
 
     bytes32 internal constant CONTRACT_CIRCUIT_BREAKER = "ExchangeCircuitBreaker";
+    bytes32 internal constant CONTRACT_EXCHANGER = "Exchanger";
     bytes32 internal constant CONTRACT_FUTURESMARKETMANAGER = "FuturesMarketManager";
     bytes32 internal constant CONTRACT_FUTURESMARKETSETTINGS = "FuturesMarketSettings";
     bytes32 internal constant CONTRACT_SYSTEMSTATUS = "SystemStatus";
@@ -177,6 +182,7 @@ contract FuturesMarketBase is Owned, Proxyable, MixinFuturesMarketSettings, IFut
         _errorMessages[uint8(Status.NotPermitted)] = "Not permitted by this address";
         _errorMessages[uint8(Status.NilOrder)] = "Cannot submit empty order";
         _errorMessages[uint8(Status.NoPositionOpen)] = "No position open";
+        _errorMessages[uint8(Status.PriceTooVolatile)] = "Price too volatile";
     }
 
     /* ========== VIEWS ========== */
@@ -185,16 +191,21 @@ contract FuturesMarketBase is Owned, Proxyable, MixinFuturesMarketSettings, IFut
 
     function resolverAddressesRequired() public view returns (bytes32[] memory addresses) {
         bytes32[] memory existingAddresses = MixinFuturesMarketSettings.resolverAddressesRequired();
-        bytes32[] memory newAddresses = new bytes32[](4);
-        newAddresses[0] = CONTRACT_CIRCUIT_BREAKER;
-        newAddresses[1] = CONTRACT_FUTURESMARKETMANAGER;
-        newAddresses[2] = CONTRACT_FUTURESMARKETSETTINGS;
-        newAddresses[3] = CONTRACT_SYSTEMSTATUS;
+        bytes32[] memory newAddresses = new bytes32[](5);
+        newAddresses[0] = CONTRACT_EXCHANGER;
+        newAddresses[1] = CONTRACT_CIRCUIT_BREAKER;
+        newAddresses[2] = CONTRACT_FUTURESMARKETMANAGER;
+        newAddresses[3] = CONTRACT_FUTURESMARKETSETTINGS;
+        newAddresses[4] = CONTRACT_SYSTEMSTATUS;
         addresses = combineArrays(existingAddresses, newAddresses);
     }
 
     function _exchangeCircuitBreaker() internal view returns (IExchangeCircuitBreaker) {
         return IExchangeCircuitBreaker(requireAndGetAddress(CONTRACT_CIRCUIT_BREAKER));
+    }
+
+    function _exchanger() internal view returns (IExchanger) {
+        return IExchanger(requireAndGetAddress(CONTRACT_EXCHANGER));
     }
 
     function _systemStatus() internal view returns (ISystemStatus) {
@@ -542,22 +553,25 @@ contract FuturesMarketBase is Owned, Proxyable, MixinFuturesMarketSettings, IFut
         return _notionalValue(position.size, price).divideDecimal(int(remainingMargin_));
     }
 
-    function _orderFee(TradeParams memory params) internal view returns (uint fee) {
+    function _orderFee(TradeParams memory params, uint dynamicFeeRate) internal view returns (uint fee) {
+        // usd value of the difference in position
         int notionalDiff = params.sizeDelta.multiplyDecimal(int(params.price));
 
-        if (_sameSide(notionalDiff, marketSkew)) {
-            // If the order is submitted on the same side as the skew, increasing it.
-            // The taker fee is charged on the increase.
-            fee = _abs(notionalDiff.multiplyDecimal(int(params.takerFee)));
-        } else {
-            // Otherwise if the order is opposite to the skew,
-            // the maker fee is charged on new notional value up to the size of the existing skew,
-            // and the taker fee is charged on any new skew they induce on the order's side of the market.
-            fee = _abs(notionalDiff.multiplyDecimal(int(params.makerFee)));
-        }
-
+        // If the order is submitted on the same side as the skew, increasing it. The taker fee is charged.
+        // Otherwise if the order is opposite to the skew, the maker fee is charged.
         // the case where the order flips the skew is ignored for simplicity due to being negligible
         // in both size of effect and frequency of occurrence
+        uint staticRate = _sameSide(notionalDiff, marketSkew) ? params.takerFee : params.makerFee;
+        uint feeRate = staticRate.add(dynamicFeeRate);
+        return _abs(notionalDiff.multiplyDecimal(int(feeRate)));
+    }
+
+    /// Uses the exchanger to get the dynamic fee (SIP-184) for trading from sUSD to baseAsset
+    /// this assumes dynamic fee is symmetric in direction of trade.
+    /// @dev this is a pretty expensive action in terms of execution gas as it queries a lot
+    ///   of past rates from oracle. Shoudn't be much on an issue on a rollup though.
+    function _dynamicFeeRate() internal view returns (uint feeRate, bool tooVolatile) {
+        return _exchanger().dynamicFeeRateForExchange(sUSD, baseAsset);
     }
 
     function _postTradeDetails(Position memory oldPos, TradeParams memory params)
@@ -581,9 +595,17 @@ contract FuturesMarketBase is Owned, Proxyable, MixinFuturesMarketSettings, IFut
 
         int newSize = int(oldPos.size).add(params.sizeDelta);
 
+        // get the dynamic fee rate SIP-184
+        (uint dynamicFeeRate, bool tooVolatile) = _dynamicFeeRate();
+        if (tooVolatile) {
+            return (oldPos, 0, Status.PriceTooVolatile);
+        }
+
+        // calculate the total fee for exchange
+        fee = _orderFee(params, dynamicFeeRate);
+
         // Deduct the fee.
         // It is an error if the realised margin minus the fee is negative or subject to liquidation.
-        fee = _orderFee(params);
         (uint newMargin, Status status) = _realisedMargin(oldPos, params.fundingIndex, params.price, -int(fee));
         if (_isError(status)) {
             return (oldPos, 0, status);
@@ -702,8 +724,14 @@ contract FuturesMarketBase is Owned, Proxyable, MixinFuturesMarketSettings, IFut
         // check that synth is active, and wasn't suspended, revert with appropriate message
         _systemStatus().requireSynthActive(baseAsset);
         // check if circuit breaker if price is within deviation tolerance and system & synth is active
+        // note: mutative rateWithBreakCircuit is used here instead of rateWithInvalid view, despite
+        //  reverting immediately after if circuit is broken. This is in order to persist last-rate
+        //  exchangeCircuitBreaker in the happy case (last rate is what used for determining the deviation)
         (uint price, bool circuitBroken) = _exchangeCircuitBreaker().rateWithBreakCircuit(baseAsset);
         // revert if price is invalid or circuit was broken
+        // note: we revert here, which means that circuit is not really broken (is not persisted), this is
+        //  because the futures methods and interface are designed for reverts, and do not support no-op
+        //  return values.
         _revertIfError(circuitBroken, Status.InvalidPrice);
         return price;
     }

--- a/contracts/FuturesMarketBase.sol
+++ b/contracts/FuturesMarketBase.sol
@@ -569,7 +569,7 @@ contract FuturesMarketBase is Owned, Proxyable, MixinFuturesMarketSettings, IFut
     /// Uses the exchanger to get the dynamic fee (SIP-184) for trading from sUSD to baseAsset
     /// this assumes dynamic fee is symmetric in direction of trade.
     /// @dev this is a pretty expensive action in terms of execution gas as it queries a lot
-    ///   of past rates from oracle. Shoudn't be much on an issue on a rollup though.
+    ///   of past rates from oracle. Shoudn't be much of an issue on a rollup though.
     function _dynamicFeeRate() internal view returns (uint feeRate, bool tooVolatile) {
         return _exchanger().dynamicFeeRateForExchange(sUSD, baseAsset);
     }
@@ -724,9 +724,10 @@ contract FuturesMarketBase is Owned, Proxyable, MixinFuturesMarketSettings, IFut
         // check that synth is active, and wasn't suspended, revert with appropriate message
         _systemStatus().requireSynthActive(baseAsset);
         // check if circuit breaker if price is within deviation tolerance and system & synth is active
-        // note: mutative rateWithBreakCircuit is used here instead of rateWithInvalid view, despite
-        //  reverting immediately after if circuit is broken. This is in order to persist last-rate
-        //  exchangeCircuitBreaker in the happy case (last rate is what used for determining the deviation)
+        // note: rateWithBreakCircuit (mutative) is used here instead of rateWithInvalid (view). This is
+        //  despite reverting immediately after if circuit is broken, which may seem silly.
+        //  This is in order to persist last-rate in exchangeCircuitBreaker in the happy case
+        //  because last-rate is what used for measuring the deviation for subsequent trades.
         (uint price, bool circuitBroken) = _exchangeCircuitBreaker().rateWithBreakCircuit(baseAsset);
         // revert if price is invalid or circuit was broken
         // note: we revert here, which means that circuit is not really broken (is not persisted), this is

--- a/contracts/MixinFuturesNextPriceOrders.sol
+++ b/contracts/MixinFuturesNextPriceOrders.sol
@@ -214,7 +214,7 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
         // This is to prevent free cancellation manipulations (by e.g. withdrawing the margin).
         // The dynamic fee rate is passed as 0 since for the purposes of the commitment deposit
         // it is not important since at the time of order execution it will be refunded and the correct
-        // dynamic fee will be charded.
+        // dynamic fee will be charged.
         return _orderFee(params, 0);
     }
 

--- a/contracts/MixinFuturesNextPriceOrders.sol
+++ b/contracts/MixinFuturesNextPriceOrders.sol
@@ -125,7 +125,7 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
     /**
      * @notice Tries to execute a previously submitted next-price order.
      * Reverts if:
-     * - There is no otder
+     * - There is no order
      * - Target roundId wasn't reached yet
      * - Order is stale (target roundId is too low compared to current roundId).
      * - Order fails for accounting reason (e.g. margin was removed, leverage exceeded, etc)
@@ -210,9 +210,12 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
         // modify params to spot fee
         params.takerFee = _takerFee(baseAsset);
         params.makerFee = _makerFee(baseAsset);
-        // commit fee is equal to the spot fee that would be paid
-        // this is to prevent free cancellation manipulations (by e.g. withdrawing the margin)
-        return _orderFee(params);
+        // Commit fee is equal to the spot fee that would be paid.
+        // This is to prevent free cancellation manipulations (by e.g. withdrawing the margin).
+        // The dynamic fee rate is passed as 0 since for the purposes of the commitment deposit
+        // it is not important since at the time of order execution it will be refunded and the correct
+        // dynamic fee will be charded.
+        return _orderFee(params, 0);
     }
 
     ///// Events

--- a/contracts/interfaces/IFuturesMarketBaseTypes.sol
+++ b/contracts/interfaces/IFuturesMarketBaseTypes.sol
@@ -14,7 +14,8 @@ interface IFuturesMarketBaseTypes {
         InsufficientMargin,
         NotPermitted,
         NilOrder,
-        NoPositionOpen
+        NoPositionOpen,
+        PriceTooVolatile
     }
 
     // If margin/size are positive, the position is long; if negative then it is short.

--- a/test/contracts/FuturesMarket.js
+++ b/test/contracts/FuturesMarket.js
@@ -26,6 +26,7 @@ const Status = {
 	NotPermitted: 8,
 	NilOrder: 9,
 	NoPositionOpen: 10,
+	PriceTooVolatile: 11,
 };
 
 contract('FuturesMarket', accounts => {
@@ -40,6 +41,7 @@ contract('FuturesMarket', accounts => {
 		synthetix,
 		feePool,
 		debtCache,
+		systemSettings,
 		systemStatus;
 
 	const owner = accounts[1];
@@ -109,6 +111,7 @@ contract('FuturesMarket', accounts => {
 			FeePool: feePool,
 			DebtCache: debtCache,
 			SystemStatus: systemStatus,
+			SystemSettings: systemSettings,
 		} = await setupAllContracts({
 			accounts,
 			synths: ['sUSD', 'sBTC', 'sETH'],
@@ -121,6 +124,7 @@ contract('FuturesMarket', accounts => {
 				'ExchangeRates',
 				'ExchangeCircuitBreaker',
 				'SystemStatus',
+				'SystemSettings',
 				'Synthetix',
 				'CollateralManager',
 				'DebtCache',
@@ -129,6 +133,10 @@ contract('FuturesMarket', accounts => {
 
 		// Update the rate so that it is not invalid
 		await setPrice(baseAsset, initialPrice);
+
+		// disable dynamic fee for most tests
+		// it will be enabled for specific tests
+		await systemSettings.setExchangeDynamicFeeRounds('0', { from: owner });
 
 		// Issue the trader some sUSD
 		for (const t of [trader, trader2, trader3]) {

--- a/test/contracts/FuturesMarket.js
+++ b/test/contracts/FuturesMarket.js
@@ -1,7 +1,10 @@
 const { artifacts, contract, web3 } = require('hardhat');
-const { toBytes32 } = require('../..');
-const { currentTime, fastForward, toUnit, multiplyDecimal, divideDecimal } = require('../utils')();
+const {
+	toBytes32,
+	defaults: { EXCHANGE_DYNAMIC_FEE_THRESHOLD },
+} = require('../..');
 const { toBN } = web3.utils;
+const { currentTime, fastForward, toUnit, multiplyDecimal, divideDecimal } = require('../utils')();
 
 const { setupAllContracts } = require('./setup');
 const { assert, addSnapshotBeforeRestoreAfterEach } = require('./common');
@@ -35,6 +38,7 @@ contract('FuturesMarket', accounts => {
 		futuresMarketManager,
 		futuresMarket,
 		exchangeRates,
+		exchanger,
 		exchangeCircuitBreaker,
 		addressResolver,
 		sUSD,
@@ -104,6 +108,7 @@ contract('FuturesMarket', accounts => {
 			FuturesMarketManager: futuresMarketManager,
 			FuturesMarketBTC: futuresMarket,
 			ExchangeRates: exchangeRates,
+			Exchanger: exchanger,
 			ExchangeCircuitBreaker: exchangeCircuitBreaker,
 			AddressResolver: addressResolver,
 			SynthsUSD: sUSD,
@@ -122,6 +127,7 @@ contract('FuturesMarket', accounts => {
 				'AddressResolver',
 				'FeePool',
 				'ExchangeRates',
+				'Exchanger',
 				'ExchangeCircuitBreaker',
 				'SystemStatus',
 				'SystemSettings',
@@ -3698,6 +3704,160 @@ contract('FuturesMarket', accounts => {
 					from: trader,
 				});
 				assert.bnEqual(await exchangeCircuitBreaker.lastExchangeRate(baseAsset), newPrice);
+			});
+		});
+	});
+
+	describe('when dynamic fee is enabled', () => {
+		beforeEach(async () => {
+			const dynamicFeeRounds = 4;
+			// set multiple past rounds
+			for (let i = 0; i < dynamicFeeRounds; i++) {
+				await setPrice(baseAsset, initialPrice);
+			}
+			// enable dynamic fees
+			await systemSettings.setExchangeDynamicFeeRounds(dynamicFeeRounds, { from: owner });
+		});
+
+		describe('when tooVolatile is true', () => {
+			beforeEach(async () => {
+				// set up a healthy position
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('1'), { from: trader });
+
+				// set up a would be liqudatable position
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
+				await futuresMarket.modifyPosition(toUnit('-100'), { from: trader2 });
+
+				// spike the price
+				await setPrice(baseAsset, multiplyDecimal(initialPrice, toUnit(1.1)));
+				// check is too volatile
+				assert.ok(
+					(await exchanger.dynamicFeeRateForExchange(toBytes32('sUSD'), baseAsset)).tooVolatile
+				);
+			});
+
+			it('position modifying actions revert', async () => {
+				const revertMessage = 'Price too volatile';
+
+				await assert.revert(
+					futuresMarket.modifyPosition(toUnit('1'), { from: trader }),
+					revertMessage
+				);
+				await assert.revert(
+					futuresMarket.modifyPositionWithPriceBounds(toUnit('1'), toUnit('105'), toUnit('115'), {
+						from: trader,
+					}),
+					revertMessage
+				);
+				await assert.revert(futuresMarket.closePosition({ from: trader }), revertMessage);
+				await assert.revert(
+					futuresMarket.closePositionWithPriceBounds(toUnit('105'), toUnit('115'), {
+						from: trader,
+					}),
+					revertMessage
+				);
+			});
+
+			it('margin modifying actions do not revert', async () => {
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.withdrawAllMargin({ from: trader });
+			});
+
+			it('liquidations do not revert', async () => {
+				await futuresMarket.liquidatePosition(trader2, { from: trader });
+			});
+
+			it('futuresMarketSettings parameter changes do not revert', async () => {
+				await futuresMarketSettings.setMaxFundingRate(baseAsset, 0, { from: owner });
+				await futuresMarketSettings.setSkewScaleUSD(baseAsset, toUnit('100'), { from: owner });
+				await futuresMarketSettings.setMaxFundingRateDelta(baseAsset, 0, { from: owner });
+				await futuresMarketSettings.setParameters(baseAsset, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, {
+					from: owner,
+				});
+			});
+		});
+
+		describe('when dynamic fee is non zero, but tooVolatile false', () => {
+			const priceDiff = 1.03;
+			const spikedRate = multiplyDecimal(initialPrice, toUnit(priceDiff));
+			const threshold = toBN(EXCHANGE_DYNAMIC_FEE_THRESHOLD);
+			const expectedRate = toUnit(priceDiff)
+				.sub(toUnit(1))
+				.sub(threshold);
+			const margin = toUnit('1000');
+
+			beforeEach(async () => {
+				// set up margin
+				await futuresMarket.transferMargin(margin, { from: trader });
+				// spike the price
+				await setPrice(baseAsset, spikedRate);
+				// check is not too volatile
+				const res = await exchanger.dynamicFeeRateForExchange(toBytes32('sUSD'), baseAsset);
+				// check dynamic fee is as expected
+				assert.bnClose(res.feeRate, expectedRate, toUnit('0.0000001'));
+				assert.notOk(res.tooVolatile);
+			});
+
+			it('order fee is calculated and applied correctly', async () => {
+				const orderSize = toUnit('1');
+
+				// expected fee is dynamic fee + taker fee
+				const expectedFee = multiplyDecimal(spikedRate, expectedRate.add(takerFee));
+
+				// check view
+				const res = await futuresMarket.orderFee(orderSize);
+				assert.bnClose(res.fee, expectedFee, toUnit('0.0000001'));
+
+				// check event from modifying a position
+				const tx = await futuresMarket.modifyPosition(orderSize, { from: trader });
+
+				// correct fee is properly recorded and deducted.
+				const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [futuresMarket] });
+
+				decodedEventEqual({
+					event: 'PositionModified',
+					emittedFrom: proxyFuturesMarket.address,
+					args: [
+						toBN('1'),
+						trader,
+						margin.sub(expectedFee),
+						orderSize,
+						orderSize,
+						spikedRate,
+						toBN(3),
+						expectedFee,
+					],
+					log: decodedLogs[2],
+					bnCloseVariance: toUnit('0.0000001'),
+				});
+			});
+
+			it('mutative actions do not revert', async () => {
+				await futuresMarket.modifyPosition(toUnit('1'), { from: trader });
+				await futuresMarket.closePosition({ from: trader });
+
+				await futuresMarket.modifyPositionWithPriceBounds(
+					toUnit('1'),
+					toUnit('100'),
+					toUnit('115'),
+					{ from: trader }
+				);
+				await futuresMarket.closePositionWithPriceBounds(toUnit('100'), toUnit('115'), {
+					from: trader,
+				});
+
+				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
+				await futuresMarket.withdrawAllMargin({ from: trader });
+			});
+
+			it('futuresMarketSettings parameter changes do not revert', async () => {
+				await futuresMarketSettings.setMaxFundingRate(baseAsset, 0, { from: owner });
+				await futuresMarketSettings.setSkewScaleUSD(baseAsset, toUnit('100'), { from: owner });
+				await futuresMarketSettings.setMaxFundingRateDelta(baseAsset, 0, { from: owner });
+				await futuresMarketSettings.setParameters(baseAsset, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, {
+					from: owner,
+				});
 			});
 		});
 	});

--- a/test/contracts/FuturesMarket.nextPrice.js
+++ b/test/contracts/FuturesMarket.nextPrice.js
@@ -15,6 +15,7 @@ contract('FuturesMarket MixinFuturesNextPriceOrders', accounts => {
 		exchangeRates,
 		exchangeCircuitBreaker,
 		sUSD,
+		systemSettings,
 		feePool;
 
 	const owner = accounts[1];
@@ -48,6 +49,7 @@ contract('FuturesMarket MixinFuturesNextPriceOrders', accounts => {
 			ExchangeCircuitBreaker: exchangeCircuitBreaker,
 			SynthsUSD: sUSD,
 			FeePool: feePool,
+			SystemSettings: systemSettings,
 		} = await setupAllContracts({
 			accounts,
 			synths: ['sUSD', 'sBTC', 'sETH'],
@@ -60,6 +62,7 @@ contract('FuturesMarket MixinFuturesNextPriceOrders', accounts => {
 				'ExchangeRates',
 				'ExchangeCircuitBreaker',
 				'SystemStatus',
+				'SystemSettings',
 				'Synthetix',
 				'CollateralManager',
 				'DebtCache',
@@ -68,6 +71,10 @@ contract('FuturesMarket MixinFuturesNextPriceOrders', accounts => {
 
 		// Update the rate so that it is not invalid
 		await setPrice(baseAsset, initialPrice);
+
+		// disable dynamic fee for most tests
+		// it will be enabled for specific tests
+		await systemSettings.setExchangeDynamicFeeRounds('0', { from: owner });
 
 		// Issue the trader some sUSD
 		for (const t of [trader, trader2, trader3]) {

--- a/test/contracts/FuturesMarketData.js
+++ b/test/contracts/FuturesMarketData.js
@@ -18,6 +18,7 @@ contract('FuturesMarketData', accounts => {
 		exchangeRates,
 		exchangeCircuitBreaker,
 		sUSD,
+		systemSettings,
 		baseAsset;
 	const newAsset = toBytes32('sETH');
 
@@ -47,6 +48,7 @@ contract('FuturesMarketData', accounts => {
 			ExchangeRates: exchangeRates,
 			ExchangeCircuitBreaker: exchangeCircuitBreaker,
 			SynthsUSD: sUSD,
+			SystemSettings: systemSettings,
 		} = await setupAllContracts({
 			accounts,
 			synths: ['sUSD', 'sBTC', 'sETH', 'sLINK'],
@@ -60,6 +62,7 @@ contract('FuturesMarketData', accounts => {
 				'ExchangeRates',
 				'ExchangeCircuitBreaker',
 				'SystemStatus',
+				'SystemSettings',
 				'Synthetix',
 				'CollateralManager',
 			],
@@ -116,6 +119,9 @@ contract('FuturesMarketData', accounts => {
 
 		// Update the rates to ensure they aren't stale
 		await setPrice(baseAsset, toUnit(100));
+
+		// disable dynamic fee for simpler testing
+		await systemSettings.setExchangeDynamicFeeRounds('0', { from: owner });
 
 		// Issue the traders some sUSD
 		await sUSD.issue(trader1, traderInitialBalance);


### PR DESCRIPTION
Use dynamic fee during modifying positions actions in futures:
- Fee is applied to trades (modify position, close position, next price orders)
- Fee is not applied to liquidations (different fee structure)

Dynamic fee over max reverts modifying positions, but does not revert margin actions and liquidations.