### PR TITLE
Ensuring fork tests do compile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
           command: |
             NEW_CONTRACTS=$(node bin.js sips --layer=base --unreleased --with-sources)
             if [ -z "$NEW_CONTRACTS" ]; then
-              npx hardhat test:integration:l2 --use-fork
+              npx hardhat test:integration:l2 --compile --use-fork
             else
               npx hardhat test:integration:l2 --compile --deploy --use-sips --use-fork
             fi;
@@ -88,7 +88,7 @@ jobs:
           command: |
             NEW_CONTRACTS=$(node bin.js sips --layer=base --unreleased --with-sources)
             if [ -z "$NEW_CONTRACTS" ]; then
-              npx hardhat test:integration:l1 --use-fork --provider-port 9545
+              npx hardhat test:integration:l1 --compile --use-fork --provider-port 9545
             else
               npx hardhat test:integration:l1 --compile --deploy --use-sips --use-fork --provider-port 9545
             fi;

--- a/.circleci/src/jobs/job-fork-tests-ovm.yml
+++ b/.circleci/src/jobs/job-fork-tests-ovm.yml
@@ -15,7 +15,7 @@ steps:
         # Only compile and deploy when there are new contracts
         NEW_CONTRACTS=$(node bin.js sips --layer=base --unreleased --with-sources)
         if [ -z "$NEW_CONTRACTS" ]; then
-          npx hardhat test:integration:l2 --use-fork
+          npx hardhat test:integration:l2 --compile --use-fork
         else
           npx hardhat test:integration:l2 --compile --deploy --use-sips --use-fork
         fi;

--- a/.circleci/src/jobs/job-fork-tests.yml
+++ b/.circleci/src/jobs/job-fork-tests.yml
@@ -15,7 +15,7 @@ steps:
         # Only compile and deploy when there are new contracts
         NEW_CONTRACTS=$(node bin.js sips --layer=base --unreleased --with-sources)
         if [ -z "$NEW_CONTRACTS" ]; then
-          npx hardhat test:integration:l1 --use-fork --provider-port 9545
+          npx hardhat test:integration:l1 --compile --use-fork --provider-port 9545
         else
           npx hardhat test:integration:l1 --compile --deploy --use-sips --use-fork --provider-port 9545
         fi;


### PR DESCRIPTION
Compilation is required for a few of the fork tests, regardless of whether or not new files are added:

```
 1) Liquidations (L2)
       liquidating
         "before all" hook: exchange rate is set for "cannot be liquidated at this point":
     TypeError: Cannot read properties of undefined (reading 'MockAggregatorV2V3')
      at createMockAggregatorFactory (test/utils/index.js:539:15)
      at addAggregatorAndSetRate (test/integration/utils/rates.js:34:38)
      at Context.<anonymous> (test/integration/behaviors/liquidations.behavior.js:49:10)
      at processTicksAndRejections (node:internal/process/task_queues:96:5)
```

and

```
 2) WrapperFactory integration tests (L2)
       "before all" hook in "WrapperFactory integration tests (L2)":
     TypeError: Cannot read properties of undefined (reading 'Wrapper')
      at Context.<anonymous> (test/integration/l2/WrapperFactory.l2.integration.js:56:13)
```