### PR TITLE
Futures size reduction

### DIFF
--- a/contracts/FuturesMarket.sol
+++ b/contracts/FuturesMarket.sol
@@ -61,10 +61,5 @@ import "./interfaces/IFuturesMarket.sol";
 
 // https://docs.synthetix.io/contracts/source/contracts/FuturesMarket
 contract FuturesMarket is IFuturesMarket, FuturesMarketBase, MixinFuturesNextPriceOrders, MixinFuturesViews {
-    constructor(
-        address payable _proxy,
-        address _owner,
-        address _resolver,
-        bytes32 _baseAsset
-    ) public FuturesMarketBase(_proxy, _owner, _resolver, _baseAsset) {}
+    constructor(address _resolver, bytes32 _baseAsset) public FuturesMarketBase(_resolver, _baseAsset) {}
 }

--- a/contracts/FuturesMarketBase.sol
+++ b/contracts/FuturesMarketBase.sol
@@ -205,10 +205,6 @@ contract FuturesMarketBase is MixinFuturesMarketSettings, IFuturesMarketBaseType
         return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS));
     }
 
-    function systemStatus() internal view returns (ISystemStatus) {
-        return ISystemStatus(requireAndGetAddress(CONTRACT_SYSTEMSTATUS));
-    }
-
     function _manager() internal view returns (IFuturesMarketManagerInternal) {
         return IFuturesMarketManagerInternal(requireAndGetAddress(CONTRACT_FUTURESMARKETMANAGER));
     }

--- a/contracts/FuturesMarketBase.sol
+++ b/contracts/FuturesMarketBase.sol
@@ -215,13 +215,6 @@ contract FuturesMarketBase is MixinFuturesMarketSettings, IFuturesMarketBaseType
 
     /* ---------- Market Details ---------- */
 
-    function _assetPrice() internal view returns (uint price, bool invalid) {
-        (price, invalid) = _exchangeCircuitBreaker().rateWithInvalid(baseAsset);
-        // Ensure we catch uninitialised rates or suspended state / synth
-        invalid = invalid || price == 0 || _systemStatus().synthSuspended(baseAsset);
-        return (price, invalid);
-    }
-
     /*
      * The size of the skew relative to the size of the market skew scaler.
      * This value can be outside of [-1, 1] values.

--- a/contracts/FuturesMarketData.sol
+++ b/contracts/FuturesMarketData.sol
@@ -57,7 +57,6 @@ contract FuturesMarketData {
     struct FundingParameters {
         uint maxFundingRate;
         uint skewScaleUSD;
-        uint maxFundingRateDelta;
     }
 
     struct FeeRates {
@@ -145,8 +144,7 @@ contract FuturesMarketData {
             uint maxLeverage,
             uint maxMarketValueUSD,
             uint maxFundingRate,
-            uint skewScaleUSD,
-            uint maxFundingRateDelta
+            uint skewScaleUSD
         ) = _futuresMarketSettings().parameters(baseAsset);
         return
             IFuturesMarketSettings.Parameters(
@@ -158,8 +156,7 @@ contract FuturesMarketData {
                 maxLeverage,
                 maxMarketValueUSD,
                 maxFundingRate,
-                skewScaleUSD,
-                maxFundingRateDelta
+                skewScaleUSD
             );
     }
 
@@ -207,7 +204,7 @@ contract FuturesMarketData {
         pure
         returns (FundingParameters memory)
     {
-        return FundingParameters(params.maxFundingRate, params.skewScaleUSD, params.maxFundingRateDelta);
+        return FundingParameters(params.maxFundingRate, params.skewScaleUSD);
     }
 
     function _marketSizes(IFuturesMarket market) internal view returns (Sides memory) {

--- a/contracts/FuturesMarketData.sol
+++ b/contracts/FuturesMarketData.sol
@@ -287,7 +287,7 @@ contract FuturesMarketData {
     }
 
     function _liquidationPrice(IFuturesMarket market, address account) internal view returns (uint) {
-        (uint liquidationPrice, ) = market.liquidationPrice(account, true);
+        (uint liquidationPrice, ) = market.liquidationPrice(account);
         return liquidationPrice;
     }
 

--- a/contracts/FuturesMarketSettings.sol
+++ b/contracts/FuturesMarketSettings.sol
@@ -103,18 +103,26 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
         external
         view
         returns (
-            uint _takerFee,
-            uint _makerFee,
-            uint _takerFeeNextPrice,
-            uint _makerFeeNextPrice,
-            uint _nextPriceConfirmWindow,
-            uint _maxLeverage,
-            uint _maxMarketValueUSD,
-            uint _maxFundingRate,
-            uint _skewScaleUSD
+            uint takerFee,
+            uint makerFee,
+            uint takerFeeNextPrice,
+            uint makerFeeNextPrice,
+            uint nextPriceConfirmWindow,
+            uint maxLeverage,
+            uint maxMarketValueUSD,
+            uint maxFundingRate,
+            uint skewScaleUSD
         )
     {
-        return _parameters(_baseAsset);
+        takerFee = _takerFee(_baseAsset);
+        makerFee = _makerFee(_baseAsset);
+        takerFeeNextPrice = _takerFeeNextPrice(_baseAsset);
+        makerFeeNextPrice = _makerFeeNextPrice(_baseAsset);
+        nextPriceConfirmWindow = _nextPriceConfirmWindow(_baseAsset);
+        maxLeverage = _maxLeverage(_baseAsset);
+        maxMarketValueUSD = _maxMarketValueUSD(_baseAsset);
+        maxFundingRate = _maxFundingRate(_baseAsset);
+        skewScaleUSD = _skewScaleUSD(_baseAsset);
     }
 
     /*

--- a/contracts/FuturesMarketSettings.sol
+++ b/contracts/FuturesMarketSettings.sol
@@ -99,13 +99,6 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
         return _skewScaleUSD(_baseAsset);
     }
 
-    /*
-     * The maximum speed that the funding rate can move per day.
-     */
-    function maxFundingRateDelta(bytes32 _baseAsset) public view returns (uint) {
-        return _maxFundingRateDelta(_baseAsset);
-    }
-
     function parameters(bytes32 _baseAsset)
         external
         view
@@ -118,8 +111,7 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
             uint _maxLeverage,
             uint _maxMarketValueUSD,
             uint _maxFundingRate,
-            uint _skewScaleUSD,
-            uint _maxFundingRateDelta
+            uint _skewScaleUSD
         )
     {
         return _parameters(_baseAsset);
@@ -223,11 +215,6 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
         _setParameter(_baseAsset, PARAMETER_MIN_SKEW_SCALE, _skewScaleUSD);
     }
 
-    function setMaxFundingRateDelta(bytes32 _baseAsset, uint _maxFundingRateDelta) public onlyOwner {
-        _recomputeFunding(_baseAsset);
-        _setParameter(_baseAsset, PARAMETER_MAX_FUNDING_RATE_DELTA, _maxFundingRateDelta);
-    }
-
     function setParameters(
         bytes32 _baseAsset,
         uint _takerFee,
@@ -238,8 +225,7 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
         uint _maxLeverage,
         uint _maxMarketValueUSD,
         uint _maxFundingRate,
-        uint _skewScaleUSD,
-        uint _maxFundingRateDelta
+        uint _skewScaleUSD
     ) external onlyOwner {
         _recomputeFunding(_baseAsset);
         setTakerFee(_baseAsset, _takerFee);
@@ -251,7 +237,6 @@ contract FuturesMarketSettings is Owned, MixinFuturesMarketSettings, IFuturesMar
         setMaxMarketValueUSD(_baseAsset, _maxMarketValueUSD);
         setMaxFundingRate(_baseAsset, _maxFundingRate);
         setSkewScaleUSD(_baseAsset, _skewScaleUSD);
-        setMaxFundingRateDelta(_baseAsset, _maxFundingRateDelta);
     }
 
     function setMinKeeperFee(uint _sUSD) external onlyOwner {

--- a/contracts/MixinFuturesMarketSettings.sol
+++ b/contracts/MixinFuturesMarketSettings.sol
@@ -23,7 +23,6 @@ contract MixinFuturesMarketSettings is MixinResolver {
     bytes32 internal constant PARAMETER_MAX_MARKET_VALUE = "maxMarketValueUSD";
     bytes32 internal constant PARAMETER_MAX_FUNDING_RATE = "maxFundingRate";
     bytes32 internal constant PARAMETER_MIN_SKEW_SCALE = "skewScaleUSD";
-    bytes32 internal constant PARAMETER_MAX_FUNDING_RATE_DELTA = "maxFundingRateDelta";
 
     // Global settings
     // minimum liquidation fee payable to liquidator
@@ -95,10 +94,6 @@ contract MixinFuturesMarketSettings is MixinResolver {
         return _parameter(_baseAsset, PARAMETER_MAX_FUNDING_RATE);
     }
 
-    function _maxFundingRateDelta(bytes32 _baseAsset) internal view returns (uint) {
-        return _parameter(_baseAsset, PARAMETER_MAX_FUNDING_RATE_DELTA);
-    }
-
     function _parameters(bytes32 _baseAsset)
         internal
         view
@@ -111,8 +106,7 @@ contract MixinFuturesMarketSettings is MixinResolver {
             uint maxLeverage,
             uint maxMarketValueUSD,
             uint maxFundingRate,
-            uint skewScaleUSD,
-            uint maxFundingRateDelta
+            uint skewScaleUSD
         )
     {
         takerFee = _takerFee(_baseAsset);
@@ -124,7 +118,6 @@ contract MixinFuturesMarketSettings is MixinResolver {
         maxMarketValueUSD = _maxMarketValueUSD(_baseAsset);
         maxFundingRate = _maxFundingRate(_baseAsset);
         skewScaleUSD = _skewScaleUSD(_baseAsset);
-        maxFundingRateDelta = _maxFundingRateDelta(_baseAsset);
     }
 
     function _minKeeperFee() internal view returns (uint) {

--- a/contracts/MixinFuturesMarketSettings.sol
+++ b/contracts/MixinFuturesMarketSettings.sol
@@ -94,32 +94,6 @@ contract MixinFuturesMarketSettings is MixinResolver {
         return _parameter(_baseAsset, PARAMETER_MAX_FUNDING_RATE);
     }
 
-    function _parameters(bytes32 _baseAsset)
-        internal
-        view
-        returns (
-            uint takerFee,
-            uint makerFee,
-            uint takerFeeNextPrice,
-            uint makerFeeNextPrice,
-            uint nextPriceConfirmWindow,
-            uint maxLeverage,
-            uint maxMarketValueUSD,
-            uint maxFundingRate,
-            uint skewScaleUSD
-        )
-    {
-        takerFee = _takerFee(_baseAsset);
-        makerFee = _makerFee(_baseAsset);
-        takerFeeNextPrice = _takerFeeNextPrice(_baseAsset);
-        makerFeeNextPrice = _makerFeeNextPrice(_baseAsset);
-        nextPriceConfirmWindow = _nextPriceConfirmWindow(_baseAsset);
-        maxLeverage = _maxLeverage(_baseAsset);
-        maxMarketValueUSD = _maxMarketValueUSD(_baseAsset);
-        maxFundingRate = _maxFundingRate(_baseAsset);
-        skewScaleUSD = _skewScaleUSD(_baseAsset);
-    }
-
     function _minKeeperFee() internal view returns (uint) {
         return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_KEEPER_FEE);
     }

--- a/contracts/MixinFuturesNextPriceOrders.sol
+++ b/contracts/MixinFuturesNextPriceOrders.sol
@@ -43,7 +43,6 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
             TradeParams({
                 sizeDelta: sizeDelta,
                 price: price,
-                fundingIndex: fundingIndex,
                 takerFee: _takerFeeNextPrice(baseAsset),
                 makerFee: _makerFeeNextPrice(baseAsset)
             });
@@ -53,7 +52,7 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
         // deduct fees from margin
         uint commitDeposit = _nextPriceCommitDeposit(params);
         uint keeperDeposit = _minKeeperFee();
-        _updatePositionMargin(position, fundingIndex, price, -int(commitDeposit + keeperDeposit));
+        _updatePositionMargin(position, price, -int(commitDeposit + keeperDeposit));
         // emit event for modidying the position (subtracting the fees from margin)
         emit PositionModified(position.id, msg.sender, position.margin, position.size, 0, price, fundingIndex, 0);
 
@@ -104,7 +103,7 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
             Position storage position = positions[account];
             uint price = _assetPriceRequireChecks();
             uint fundingIndex = _recomputeFunding(price);
-            _updatePositionMargin(position, fundingIndex, price, int(order.keeperDeposit));
+            _updatePositionMargin(position, price, int(order.keeperDeposit));
 
             // emit event for modidying the position (add the fee to margin)
             emit PositionModified(position.id, account, position.margin, position.size, 0, price, fundingIndex, 0);
@@ -180,7 +179,7 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
         uint fundingIndex = _recomputeFunding(currentPrice);
         // refund the commitFee (and possibly the keeperFee) to the margin before executing the order
         // if the order later fails this is reverted of course
-        _updatePositionMargin(position, fundingIndex, currentPrice, int(toRefund));
+        _updatePositionMargin(position, currentPrice, int(toRefund));
         // emit event for modidying the position (refunding fee/s)
         emit PositionModified(position.id, account, position.margin, position.size, 0, currentPrice, fundingIndex, 0);
 
@@ -192,7 +191,6 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
             TradeParams({
                 sizeDelta: order.sizeDelta, // using the pastPrice from the target roundId
                 price: pastPrice, // the funding is applied only from order confirmation time
-                fundingIndex: fundingIndex, // using the next-price fees
                 takerFee: _takerFeeNextPrice(baseAsset),
                 makerFee: _makerFeeNextPrice(baseAsset)
             })

--- a/contracts/MixinFuturesNextPriceOrders.sol
+++ b/contracts/MixinFuturesNextPriceOrders.sol
@@ -28,12 +28,12 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
      * incorrectly submitted orders (that cannot be filled).
      * @param sizeDelta size in baseAsset (notional terms) of the order, similar to `modifyPosition` interface
      */
-    function submitNextPriceOrder(int sizeDelta) external optionalProxy {
+    function submitNextPriceOrder(int sizeDelta) external {
         // check that a previous order doesn't exist
-        require(nextPriceOrders[messageSender].sizeDelta == 0, "previous order exists");
+        require(nextPriceOrders[msg.sender].sizeDelta == 0, "previous order exists");
 
         // storage position as it's going to be modified to deduct commitFee and keeperFee
-        Position storage position = positions[messageSender];
+        Position storage position = positions[msg.sender];
 
         // to prevent submitting bad orders in good faith and being charged commitDeposit for them
         // simulate the order with current price and market and check that the order doesn't revert
@@ -55,7 +55,7 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
         uint keeperDeposit = _minKeeperFee();
         _updatePositionMargin(position, fundingIndex, price, -int(commitDeposit + keeperDeposit));
         // emit event for modidying the position (subtracting the fees from margin)
-        emitPositionModified(position.id, messageSender, position.margin, position.size, 0, price, fundingIndex, 0);
+        emit PositionModified(position.id, msg.sender, position.margin, position.size, 0, price, fundingIndex, 0);
 
         // create order
         uint targetRoundId = _exchangeRates().getCurrentRoundId(baseAsset) + 1; // next round
@@ -67,9 +67,15 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
                 keeperDeposit: uint128(keeperDeposit)
             });
         // emit event
-        emitNextPriceOrderSubmitted(messageSender, order);
+        emit NextPriceOrderSubmitted(
+            msg.sender,
+            order.sizeDelta,
+            order.targetRoundId,
+            order.commitDeposit,
+            order.keeperDeposit
+        );
         // store order
-        nextPriceOrders[messageSender] = order;
+        nextPriceOrders[msg.sender] = order;
     }
 
     /**
@@ -84,15 +90,15 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
      *  or send to the msg.sender if it's not the account holder.
      * @param account the account for which the stored order should be cancelled
      */
-    function cancelNextPriceOrder(address account) external optionalProxy {
-        // important!! order of the account, not the messageSender
+    function cancelNextPriceOrder(address account) external {
+        // important!! order of the account, not the msg.sender
         NextPriceOrder memory order = nextPriceOrders[account];
         // check that a previous order exists
         require(order.sizeDelta != 0, "no previous order");
 
         uint currentRoundId = _exchangeRates().getCurrentRoundId(baseAsset);
 
-        if (account == messageSender) {
+        if (account == msg.sender) {
             // this is account owner
             // refund keeper fee to margin
             Position storage position = positions[account];
@@ -101,7 +107,7 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
             _updatePositionMargin(position, fundingIndex, price, int(order.keeperDeposit));
 
             // emit event for modidying the position (add the fee to margin)
-            emitPositionModified(position.id, account, position.margin, position.size, 0, price, fundingIndex, 0);
+            emit PositionModified(position.id, account, position.margin, position.size, 0, price, fundingIndex, 0);
         } else {
             // this is someone else (like a keeper)
             // cancellation by third party is only possible when execution cannot be attempted any longer
@@ -109,17 +115,24 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
             require(_confirmationWindowOver(currentRoundId, order.targetRoundId), "cannot be cancelled by keeper yet");
 
             // send keeper fee to keeper
-            _manager().issueSUSD(messageSender, order.keeperDeposit);
+            _manager().issueSUSD(msg.sender, order.keeperDeposit);
         }
 
         // pay the commitDeposit as fee to the FeePool
         _manager().payFee(order.commitDeposit);
 
         // remove stored order
-        // important!! position of the account, not the messageSender
+        // important!! position of the account, not the msg.sender
         delete nextPriceOrders[account];
         // emit event
-        emitNextPriceOrderRemoved(account, currentRoundId, order);
+        emit NextPriceOrderRemoved(
+            account,
+            currentRoundId,
+            order.sizeDelta,
+            order.targetRoundId,
+            order.commitDeposit,
+            order.keeperDeposit
+        );
     }
 
     /**
@@ -135,7 +148,7 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
      *  otherwise it sent to the msg.sender.
      * @param account address of the account for which to try to execute a next-price order
      */
-    function executeNextPriceOrder(address account) external optionalProxy {
+    function executeNextPriceOrder(address account) external {
         // important!: order  of the account, not the sender!
         NextPriceOrder memory order = nextPriceOrders[account];
         // check that a previous order exists
@@ -156,10 +169,10 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
         uint toRefund = order.commitDeposit; // refund the commitment deposit
 
         // refund keeperFee to margin if it's the account holder
-        if (messageSender == account) {
+        if (msg.sender == account) {
             toRefund += order.keeperDeposit;
         } else {
-            _manager().issueSUSD(messageSender, order.keeperDeposit);
+            _manager().issueSUSD(msg.sender, order.keeperDeposit);
         }
 
         Position storage position = positions[account];
@@ -169,7 +182,7 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
         // if the order later fails this is reverted of course
         _updatePositionMargin(position, fundingIndex, currentPrice, int(toRefund));
         // emit event for modidying the position (refunding fee/s)
-        emitPositionModified(position.id, account, position.margin, position.size, 0, currentPrice, fundingIndex, 0);
+        emit PositionModified(position.id, account, position.margin, position.size, 0, currentPrice, fundingIndex, 0);
 
         // the correct price for the past round
         (uint pastPrice, ) = _exchangeRates().rateAndTimestampAtRound(baseAsset, order.targetRoundId);
@@ -188,7 +201,14 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
         // remove stored order
         delete nextPriceOrders[account];
         // emit event
-        emitNextPriceOrderRemoved(account, currentRoundId, order);
+        emit NextPriceOrderRemoved(
+            account,
+            currentRoundId,
+            order.sizeDelta,
+            order.targetRoundId,
+            order.commitDeposit,
+            order.keeperDeposit
+        );
     }
 
     ///// Internal views
@@ -219,7 +239,6 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
     }
 
     ///// Events
-
     event NextPriceOrderSubmitted(
         address indexed account,
         int sizeDelta,
@@ -227,20 +246,6 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
         uint commitDeposit,
         uint keeperDeposit
     );
-
-    bytes32 internal constant SIG_NEXTPRICEORDERSUBMITTED =
-        keccak256("NextPriceOrderSubmitted(address,int256,uint256,uint256,uint256)");
-
-    function emitNextPriceOrderSubmitted(address account, NextPriceOrder memory order) internal {
-        proxy._emit(
-            abi.encode(order.sizeDelta, order.targetRoundId, order.commitDeposit, order.keeperDeposit),
-            2,
-            SIG_NEXTPRICEORDERSUBMITTED,
-            addressToBytes32(account),
-            0,
-            0
-        );
-    }
 
     event NextPriceOrderRemoved(
         address indexed account,
@@ -250,22 +255,4 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
         uint commitDeposit,
         uint keeperDeposit
     );
-
-    bytes32 internal constant SIG_NEXTPRICEORDERREMOVED =
-        keccak256("NextPriceOrderRemoved(address,uint256,int256,uint256,uint256,uint256)");
-
-    function emitNextPriceOrderRemoved(
-        address account,
-        uint currentRoundId,
-        NextPriceOrder memory order
-    ) internal {
-        proxy._emit(
-            abi.encode(currentRoundId, order.sizeDelta, order.targetRoundId, order.commitDeposit, order.keeperDeposit),
-            2,
-            SIG_NEXTPRICEORDERREMOVED,
-            addressToBytes32(account),
-            0,
-            0
-        );
-    }
 }

--- a/contracts/MixinFuturesNextPriceOrders.sol
+++ b/contracts/MixinFuturesNextPriceOrders.sol
@@ -186,17 +186,17 @@ contract MixinFuturesNextPriceOrders is FuturesMarketBase {
 
         // the correct price for the past round
         (uint pastPrice, ) = _exchangeRates().rateAndTimestampAtRound(baseAsset, order.targetRoundId);
-        // set up the trade params
-        TradeParams memory params =
+        // execute or revert
+        _modifyPosition(
+            account,
             TradeParams({
                 sizeDelta: order.sizeDelta, // using the pastPrice from the target roundId
                 price: pastPrice, // the funding is applied only from order confirmation time
                 fundingIndex: fundingIndex, // using the next-price fees
                 takerFee: _takerFeeNextPrice(baseAsset),
                 makerFee: _makerFeeNextPrice(baseAsset)
-            });
-        // execute or revert
-        _modifyPosition(account, params);
+            })
+        );
 
         // remove stored order
         delete nextPriceOrders[account];

--- a/contracts/MixinFuturesViews.sol
+++ b/contracts/MixinFuturesViews.sol
@@ -11,47 +11,20 @@ contract MixinFuturesViews is FuturesMarketBase {
     /*
      * The current base price from the oracle, and whether that price was invalid. Zero prices count as invalid.
      */
-    function assetPrice() external view returns (uint price, bool invalid) {
-        return _assetPrice();
+    function assetPrice() public view returns (uint price, bool invalid) {
+        (price, invalid) = _exchangeCircuitBreaker().rateWithInvalid(baseAsset);
+        // Ensure we catch uninitialised rates or suspended state / synth
+        invalid = invalid || price == 0 || _systemStatus().synthSuspended(baseAsset);
+        return (price, invalid);
     }
 
-    function _marketSizes() internal view returns (uint long, uint short) {
+    /*
+     * Sizes of the long and short sides of the market (in sUSD)
+     */
+    function marketSizes() public view returns (uint long, uint short) {
         int size = int(marketSize);
         int skew = marketSkew;
         return (_abs(size.add(skew).div(2)), _abs(size.sub(skew).div(2)));
-    }
-
-    /*
-     * The total number of base units on each side of the market.
-     */
-    function marketSizes() external view returns (uint long, uint short) {
-        return _marketSizes();
-    }
-
-    /*
-     * The remaining units on each side of the market left to be filled before hitting the cap.
-     */
-    function _maxOrderSizes(uint price) internal view returns (uint, uint) {
-        (uint long, uint short) = _marketSizes();
-        int sizeLimit = int(_maxMarketValueUSD(baseAsset)).divideDecimal(int(price));
-        return (uint(sizeLimit.sub(_min(int(long), sizeLimit))), uint(sizeLimit.sub(_min(int(short), sizeLimit))));
-    }
-
-    /*
-     * The maximum size in base units of an order on each side of the market that will not exceed the max market value.
-     */
-    function maxOrderSizes()
-        external
-        view
-        returns (
-            uint long,
-            uint short,
-            bool invalid
-        )
-    {
-        (uint price, bool isInvalid) = _assetPrice();
-        (uint longSize, uint shortSize) = _maxOrderSizes(price);
-        return (longSize, shortSize, isInvalid);
     }
 
     /*
@@ -59,29 +32,8 @@ contract MixinFuturesViews is FuturesMarketBase {
      * The total market debt is equivalent to the sum of remaining margins in all open positions.
      */
     function marketDebt() external view returns (uint debt, bool invalid) {
-        (uint price, bool isInvalid) = _assetPrice();
+        (uint price, bool isInvalid) = assetPrice();
         return (_marketDebt(price), isInvalid);
-    }
-
-    /*
-     * The basic settings of this market, which determine trading fees and funding rate behaviour.
-     */
-    function parameters()
-        external
-        view
-        returns (
-            uint takerFee,
-            uint makerFee,
-            uint takerFeeNextPrice,
-            uint makerFeeNextPrice,
-            uint nextPriceConfirmWindow,
-            uint maxLeverage,
-            uint maxMarketValueUSD,
-            uint maxFundingRate,
-            uint skewScaleUSD
-        )
-    {
-        return _parameters(baseAsset);
     }
 
     /*
@@ -89,7 +41,7 @@ contract MixinFuturesViews is FuturesMarketBase {
      * If this is positive, shorts pay longs, if it is negative, longs pay shorts.
      */
     function currentFundingRate() external view returns (int) {
-        (uint price, ) = _assetPrice();
+        (uint price, ) = assetPrice();
         return _currentFundingRate(price);
     }
 
@@ -98,17 +50,8 @@ contract MixinFuturesViews is FuturesMarketBase {
      * been persisted in the funding sequence.
      */
     function unrecordedFunding() external view returns (int funding, bool invalid) {
-        (uint price, bool isInvalid) = _assetPrice();
+        (uint price, bool isInvalid) = assetPrice();
         return (_unrecordedFunding(price), isInvalid);
-    }
-
-    /*
-     * Computes the net funding that was accrued between any two funding sequence indices.
-     * If endIndex is equal to the funding sequence length, then unrecorded funding will be included.
-     */
-    function netFundingPerUnit(uint startIndex, uint endIndex) external view returns (int funding, bool invalid) {
-        (uint price, bool isInvalid) = _assetPrice();
-        return (_netFundingPerUnit(startIndex, endIndex, price), isInvalid);
     }
 
     /*
@@ -122,7 +65,7 @@ contract MixinFuturesViews is FuturesMarketBase {
      * The notional value of a position is its size multiplied by the current price. Margin and leverage are ignored.
      */
     function notionalValue(address account) external view returns (int value, bool invalid) {
-        (uint price, bool isInvalid) = _assetPrice();
+        (uint price, bool isInvalid) = assetPrice();
         return (_notionalValue(positions[account].size, price), isInvalid);
     }
 
@@ -130,7 +73,7 @@ contract MixinFuturesViews is FuturesMarketBase {
      * The PnL of a position is the change in its notional value. Funding is not taken into account.
      */
     function profitLoss(address account) external view returns (int pnl, bool invalid) {
-        (uint price, bool isInvalid) = _assetPrice();
+        (uint price, bool isInvalid) = assetPrice();
         return (_profitLoss(positions[account], price), isInvalid);
     }
 
@@ -138,7 +81,7 @@ contract MixinFuturesViews is FuturesMarketBase {
      * The funding accrued in a position since it was opened; this does not include PnL.
      */
     function accruedFunding(address account) external view returns (int funding, bool invalid) {
-        (uint price, bool isInvalid) = _assetPrice();
+        (uint price, bool isInvalid) = assetPrice();
         return (_accruedFunding(positions[account], fundingSequence.length, price), isInvalid);
     }
 
@@ -146,7 +89,7 @@ contract MixinFuturesViews is FuturesMarketBase {
      * The initial margin plus profit and funding; returns zero balance if losses exceed the initial margin.
      */
     function remainingMargin(address account) external view returns (uint marginRemaining, bool invalid) {
-        (uint price, bool isInvalid) = _assetPrice();
+        (uint price, bool isInvalid) = assetPrice();
         return (_remainingMargin(positions[account], fundingSequence.length, price), isInvalid);
     }
 
@@ -155,20 +98,8 @@ contract MixinFuturesViews is FuturesMarketBase {
      * true value slightly.
      */
     function accessibleMargin(address account) external view returns (uint marginAccessible, bool invalid) {
-        (uint price, bool isInvalid) = _assetPrice();
+        (uint price, bool isInvalid) = assetPrice();
         return (_accessibleMargin(positions[account], fundingSequence.length, price), isInvalid);
-    }
-
-    /**
-     * The minimal margin at which liquidation can happen. Is the sum of liquidationBuffer and liquidationFee.
-     * Reverts if position size is 0.
-     * @param account address of the position account
-     * @return lMargin liquidation margin to maintain in sUSD fixed point decimal units
-     */
-    function liquidationMargin(address account) external view returns (uint lMargin) {
-        require(positions[account].size != 0, "0 size position");
-        (uint price, ) = _assetPrice();
-        return _liquidationMargin(int(positions[account].size), price);
     }
 
     /*
@@ -179,7 +110,7 @@ contract MixinFuturesViews is FuturesMarketBase {
      * A position's accurate liquidation price can move around slightly due to accrued funding.
      */
     function liquidationPrice(address account) external view returns (uint price, bool invalid) {
-        (uint aPrice, bool isInvalid) = _assetPrice();
+        (uint aPrice, bool isInvalid) = assetPrice();
         uint liqPrice = _liquidationPrice(positions[account], aPrice);
         return (liqPrice, isInvalid);
     }
@@ -192,7 +123,7 @@ contract MixinFuturesViews is FuturesMarketBase {
      *  in sUSD fixed point decimal units or 0 if account is not liquidatable.
      */
     function liquidationFee(address account) external view returns (uint) {
-        (uint price, bool invalid) = _assetPrice();
+        (uint price, bool invalid) = assetPrice();
         if (!invalid && _canLiquidate(positions[account], fundingSequence.length, price)) {
             return _liquidationFee(int(positions[account].size), price);
         } else {
@@ -207,18 +138,8 @@ contract MixinFuturesViews is FuturesMarketBase {
      * True if and only if a position is ready to be liquidated.
      */
     function canLiquidate(address account) external view returns (bool) {
-        (uint price, bool invalid) = _assetPrice();
+        (uint price, bool invalid) = assetPrice();
         return !invalid && _canLiquidate(positions[account], fundingSequence.length, price);
-    }
-
-    /*
-     * Equivalent to the position's notional value divided by its remaining margin.
-     */
-    function currentLeverage(address account) external view returns (int leverage, bool invalid) {
-        (uint price, bool isInvalid) = _assetPrice();
-        Position storage position = positions[account];
-        uint remainingMargin_ = _remainingMargin(position, fundingSequence.length, price);
-        return (_currentLeverage(position, price, remainingMargin_), isInvalid);
     }
 
     /*
@@ -230,7 +151,7 @@ contract MixinFuturesViews is FuturesMarketBase {
      * too high due to recent volatility.
      */
     function orderFee(int sizeDelta) external view returns (uint fee, bool invalid) {
-        (uint price, bool isInvalid) = _assetPrice();
+        (uint price, bool isInvalid) = assetPrice();
         (uint dynamicFeeRate, bool tooVolatile) = _dynamicFeeRate();
         TradeParams memory params =
             TradeParams({
@@ -259,7 +180,7 @@ contract MixinFuturesViews is FuturesMarketBase {
         )
     {
         bool invalid;
-        (price, invalid) = _assetPrice();
+        (price, invalid) = assetPrice();
         if (invalid) {
             return (0, 0, 0, 0, 0, Status.InvalidPrice);
         }

--- a/contracts/MixinFuturesViews.sol
+++ b/contracts/MixinFuturesViews.sol
@@ -82,7 +82,7 @@ contract MixinFuturesViews is FuturesMarketBase {
      */
     function accruedFunding(address account) external view returns (int funding, bool invalid) {
         (uint price, bool isInvalid) = assetPrice();
-        return (_accruedFunding(positions[account], fundingSequence.length, price), isInvalid);
+        return (_accruedFunding(positions[account], price), isInvalid);
     }
 
     /*
@@ -90,7 +90,7 @@ contract MixinFuturesViews is FuturesMarketBase {
      */
     function remainingMargin(address account) external view returns (uint marginRemaining, bool invalid) {
         (uint price, bool isInvalid) = assetPrice();
-        return (_remainingMargin(positions[account], fundingSequence.length, price), isInvalid);
+        return (_remainingMargin(positions[account], price), isInvalid);
     }
 
     /*
@@ -99,7 +99,7 @@ contract MixinFuturesViews is FuturesMarketBase {
      */
     function accessibleMargin(address account) external view returns (uint marginAccessible, bool invalid) {
         (uint price, bool isInvalid) = assetPrice();
-        return (_accessibleMargin(positions[account], fundingSequence.length, price), isInvalid);
+        return (_accessibleMargin(positions[account], price), isInvalid);
     }
 
     /*
@@ -124,7 +124,7 @@ contract MixinFuturesViews is FuturesMarketBase {
      */
     function liquidationFee(address account) external view returns (uint) {
         (uint price, bool invalid) = assetPrice();
-        if (!invalid && _canLiquidate(positions[account], fundingSequence.length, price)) {
+        if (!invalid && _canLiquidate(positions[account], price)) {
             return _liquidationFee(int(positions[account].size), price);
         } else {
             // theoretically we can calculate a value, but this value is always incorrect because
@@ -139,7 +139,7 @@ contract MixinFuturesViews is FuturesMarketBase {
      */
     function canLiquidate(address account) external view returns (bool) {
         (uint price, bool invalid) = assetPrice();
-        return !invalid && _canLiquidate(positions[account], fundingSequence.length, price);
+        return !invalid && _canLiquidate(positions[account], price);
     }
 
     /*
@@ -157,7 +157,6 @@ contract MixinFuturesViews is FuturesMarketBase {
             TradeParams({
                 sizeDelta: sizeDelta,
                 price: price,
-                fundingIndex: 0, // doesn't matter for fee calculation
                 takerFee: _takerFee(baseAsset),
                 makerFee: _makerFee(baseAsset)
             });
@@ -189,7 +188,6 @@ contract MixinFuturesViews is FuturesMarketBase {
             TradeParams({
                 sizeDelta: sizeDelta,
                 price: price,
-                fundingIndex: fundingSequence.length,
                 takerFee: _takerFee(baseAsset),
                 makerFee: _makerFee(baseAsset)
             });

--- a/contracts/MixinFuturesViews.sol
+++ b/contracts/MixinFuturesViews.sol
@@ -108,7 +108,7 @@ contract MixinFuturesViews is FuturesMarketBase {
      */
     function netFundingPerUnit(uint startIndex, uint endIndex) external view returns (int funding, bool invalid) {
         (uint price, bool isInvalid) = _assetPrice();
-        return (_netFundingPerUnit(startIndex, endIndex, fundingSequence.length, price), isInvalid);
+        return (_netFundingPerUnit(startIndex, endIndex, price), isInvalid);
     }
 
     /*
@@ -176,12 +176,11 @@ contract MixinFuturesViews is FuturesMarketBase {
      * margin has run out. When they have just enough margin left to pay a liquidator, then they are liquidated.
      * If a position is long, then it is safe as long as the current price is above the liquidation price; if it is
      * short, then it is safe whenever the current price is below the liquidation price.
-     * A position's accurate liquidation price can move around slightly due to accrued funding - this contribution
-     * can be omitted by passing false to includeFunding.
+     * A position's accurate liquidation price can move around slightly due to accrued funding.
      */
-    function liquidationPrice(address account, bool includeFunding) external view returns (uint price, bool invalid) {
+    function liquidationPrice(address account) external view returns (uint price, bool invalid) {
         (uint aPrice, bool isInvalid) = _assetPrice();
-        uint liqPrice = _liquidationPrice(positions[account], includeFunding, aPrice);
+        uint liqPrice = _liquidationPrice(positions[account], aPrice);
         return (liqPrice, isInvalid);
     }
 
@@ -275,7 +274,7 @@ contract MixinFuturesViews is FuturesMarketBase {
             });
         (Position memory newPosition, uint fee_, Status status_) = _postTradeDetails(positions[sender], params);
 
-        liqPrice = _liquidationPrice(newPosition, true, newPosition.lastPrice);
+        liqPrice = _liquidationPrice(newPosition, newPosition.lastPrice);
         return (newPosition.margin, newPosition.size, newPosition.lastPrice, liqPrice, fee_, status_);
     }
 }

--- a/contracts/MixinFuturesViews.sol
+++ b/contracts/MixinFuturesViews.sol
@@ -78,8 +78,7 @@ contract MixinFuturesViews is FuturesMarketBase {
             uint maxLeverage,
             uint maxMarketValueUSD,
             uint maxFundingRate,
-            uint skewScaleUSD,
-            uint maxFundingRateDelta
+            uint skewScaleUSD
         )
     {
         return _parameters(baseAsset);

--- a/contracts/interfaces/IFuturesMarket.sol
+++ b/contracts/interfaces/IFuturesMarket.sol
@@ -78,7 +78,7 @@ interface IFuturesMarket {
 
     function accessibleMargin(address account) external view returns (uint marginAccessible, bool invalid);
 
-    function liquidationPrice(address account, bool includeFunding) external view returns (uint price, bool invalid);
+    function liquidationPrice(address account) external view returns (uint price, bool invalid);
 
     function liquidationMargin(address account) external view returns (uint lMargin);
 

--- a/contracts/interfaces/IFuturesMarket.sol
+++ b/contracts/interfaces/IFuturesMarket.sol
@@ -32,37 +32,11 @@ interface IFuturesMarket {
 
     function marketSizes() external view returns (uint long, uint short);
 
-    function maxOrderSizes()
-        external
-        view
-        returns (
-            uint long,
-            uint short,
-            bool invalid
-        );
-
     function marketDebt() external view returns (uint debt, bool isInvalid);
-
-    function parameters()
-        external
-        view
-        returns (
-            uint takerFee,
-            uint makerFee,
-            uint takerFeeNextPrice,
-            uint makerFeeNextPrice,
-            uint nextPriceConfirmWindow,
-            uint maxLeverage,
-            uint maxMarketValueUSD,
-            uint maxFundingRate,
-            uint skewScaleUSD
-        );
 
     function currentFundingRate() external view returns (int fundingRate);
 
     function unrecordedFunding() external view returns (int funding, bool invalid);
-
-    function netFundingPerUnit(uint startIndex, uint endIndex) external view returns (int funding, bool invalid);
 
     function fundingSequenceLength() external view returns (uint length);
 
@@ -80,13 +54,9 @@ interface IFuturesMarket {
 
     function liquidationPrice(address account) external view returns (uint price, bool invalid);
 
-    function liquidationMargin(address account) external view returns (uint lMargin);
-
     function liquidationFee(address account) external view returns (uint);
 
     function canLiquidate(address account) external view returns (bool);
-
-    function currentLeverage(address account) external view returns (int leverage, bool invalid);
 
     function orderFee(int sizeDelta) external view returns (uint fee, bool invalid);
 

--- a/contracts/interfaces/IFuturesMarket.sol
+++ b/contracts/interfaces/IFuturesMarket.sol
@@ -55,8 +55,7 @@ interface IFuturesMarket {
             uint maxLeverage,
             uint maxMarketValueUSD,
             uint maxFundingRate,
-            uint skewScaleUSD,
-            uint maxFundingRateDelta
+            uint skewScaleUSD
         );
 
     function currentFundingRate() external view returns (int fundingRate);

--- a/contracts/interfaces/IFuturesMarket.sol
+++ b/contracts/interfaces/IFuturesMarket.sol
@@ -88,15 +88,7 @@ interface IFuturesMarket {
 
     function executeNextPriceOrder(address account) external;
 
-    function modifyPositionWithPriceBounds(
-        int sizeDelta,
-        uint minPrice,
-        uint maxPrice
-    ) external;
-
     function closePosition() external;
-
-    function closePositionWithPriceBounds(uint minPrice, uint maxPrice) external;
 
     function liquidatePosition(address account) external;
 }

--- a/contracts/interfaces/IFuturesMarketSettings.sol
+++ b/contracts/interfaces/IFuturesMarketSettings.sol
@@ -11,7 +11,6 @@ interface IFuturesMarketSettings {
         uint maxMarketValueUSD;
         uint maxFundingRate;
         uint skewScaleUSD;
-        uint maxFundingRateDelta;
     }
 
     function takerFee(bytes32 _baseAsset) external view returns (uint);
@@ -32,8 +31,6 @@ interface IFuturesMarketSettings {
 
     function skewScaleUSD(bytes32 _baseAsset) external view returns (uint);
 
-    function maxFundingRateDelta(bytes32 _baseAsset) external view returns (uint);
-
     function parameters(bytes32 _baseAsset)
         external
         view
@@ -46,8 +43,7 @@ interface IFuturesMarketSettings {
             uint _maxLeverage,
             uint _maxMarketValueUSD,
             uint _maxFundingRate,
-            uint _skewScaleUSD,
-            uint _maxFundingRateDelta
+            uint _skewScaleUSD
         );
 
     function minKeeperFee() external view returns (uint);

--- a/contracts/test-helpers/TestableFuturesMarket.sol
+++ b/contracts/test-helpers/TestableFuturesMarket.sol
@@ -57,7 +57,7 @@ contract TestableFuturesMarket is FuturesMarket {
     function currentLeverage(address account) external view returns (int leverage, bool invalid) {
         (uint price, bool isInvalid) = assetPrice();
         Position storage position = positions[account];
-        uint remainingMargin_ = _remainingMargin(position, fundingSequence.length, price);
+        uint remainingMargin_ = _remainingMargin(position, price);
         return (_currentLeverage(position, price, remainingMargin_), isInvalid);
     }
 }

--- a/contracts/test-helpers/TestableFuturesMarket.sol
+++ b/contracts/test-helpers/TestableFuturesMarket.sol
@@ -3,12 +3,7 @@ pragma solidity ^0.5.16;
 import "../FuturesMarket.sol";
 
 contract TestableFuturesMarket is FuturesMarket {
-    constructor(
-        address payable _proxy,
-        address _owner,
-        address _resolver,
-        bytes32 _baseAsset
-    ) public FuturesMarket(_proxy, _owner, _resolver, _baseAsset) {}
+    constructor(address _resolver, bytes32 _baseAsset) public FuturesMarket(_resolver, _baseAsset) {}
 
     function entryDebtCorrection() external view returns (int) {
         return _entryDebtCorrection;

--- a/contracts/test-helpers/TestableFuturesMarket.sol
+++ b/contracts/test-helpers/TestableFuturesMarket.sol
@@ -10,11 +10,54 @@ contract TestableFuturesMarket is FuturesMarket {
     }
 
     function proportionalSkew() external view returns (int) {
-        (uint price, ) = _assetPrice();
+        (uint price, ) = assetPrice();
         return _proportionalSkew(price);
     }
 
     function maxFundingRate() external view returns (uint) {
         return _maxFundingRate(baseAsset);
+    }
+
+    /*
+     * The maximum size in base units of an order on each side of the market that will not exceed the max market value.
+     */
+    function maxOrderSizes()
+        external
+        view
+        returns (
+            uint long,
+            uint short,
+            bool invalid
+        )
+    {
+        uint price;
+        (price, invalid) = assetPrice();
+        int sizeLimit = int(_maxMarketValueUSD(baseAsset)).divideDecimal(int(price));
+        (uint longSize, uint shortSize) = marketSizes();
+        long = uint(sizeLimit.sub(_min(int(longSize), sizeLimit)));
+        short = uint(sizeLimit.sub(_min(int(shortSize), sizeLimit)));
+        return (long, short, invalid);
+    }
+
+    /**
+     * The minimal margin at which liquidation can happen. Is the sum of liquidationBuffer and liquidationFee.
+     * Reverts if position size is 0.
+     * @param account address of the position account
+     * @return lMargin liquidation margin to maintain in sUSD fixed point decimal units
+     */
+    function liquidationMargin(address account) external view returns (uint lMargin) {
+        require(positions[account].size != 0, "0 size position");
+        (uint price, ) = assetPrice();
+        return _liquidationMargin(int(positions[account].size), price);
+    }
+
+    /*
+     * Equivalent to the position's notional value divided by its remaining margin.
+     */
+    function currentLeverage(address account) external view returns (int leverage, bool invalid) {
+        (uint price, bool isInvalid) = assetPrice();
+        Position storage position = positions[account];
+        uint remainingMargin_ = _remainingMargin(position, fundingSequence.length, price);
+        return (_currentLeverage(position, price, remainingMargin_), isInvalid);
     }
 }

--- a/publish/deployed/kovan-ovm-futures/futures-markets.json
+++ b/publish/deployed/kovan-ovm-futures/futures-markets.json
@@ -9,8 +9,7 @@
 		"maxLeverage": "10",
 		"maxMarketValueUSD": "1000000000",
 		"maxFundingRate": "0.1",
-		"skewScaleUSD": "50000000",
-		"maxFundingRateDelta": "0.0125"
+		"skewScaleUSD": "50000000"
 	},
 	{
 		"asset": "sETH",
@@ -22,8 +21,7 @@
 		"maxLeverage": "10",
 		"maxMarketValueUSD": "1000000000",
 		"maxFundingRate": "0.1",
-		"skewScaleUSD": "50000000",
-		"maxFundingRateDelta": "0.0125"
+		"skewScaleUSD": "50000000"
 	},
 	{
 		"asset": "sLINK",
@@ -35,7 +33,6 @@
 		"maxLeverage": "10",
 		"maxMarketValueUSD": "1000000000",
 		"maxFundingRate": "0.1",
-		"skewScaleUSD": "50000000",
-		"maxFundingRateDelta": "0.0125"
+		"skewScaleUSD": "50000000"
 	}
 ]

--- a/publish/deployed/local-ovm/futures-markets.json
+++ b/publish/deployed/local-ovm/futures-markets.json
@@ -9,8 +9,7 @@
 		"maxLeverage": "10",
 		"maxMarketValueUSD": "1000000000",
 		"maxFundingRate": "0.1",
-		"skewScaleUSD": "50000000",
-		"maxFundingRateDelta": "0.0125"
+		"skewScaleUSD": "50000000"
 	},
 	{
 		"asset": "sETH",
@@ -22,8 +21,7 @@
 		"maxLeverage": "10",
 		"maxMarketValueUSD": "1000000000",
 		"maxFundingRate": "0.1",
-		"skewScaleUSD": "50000000",
-		"maxFundingRateDelta": "0.0125"
+		"skewScaleUSD": "50000000"
 	},
 	{
 		"asset": "sLINK",
@@ -35,7 +33,6 @@
 		"maxLeverage": "10",
 		"maxMarketValueUSD": "1000000000",
 		"maxFundingRate": "0.1",
-		"skewScaleUSD": "50000000",
-		"maxFundingRateDelta": "0.0125"
+		"skewScaleUSD": "50000000"
 	}
 ]

--- a/publish/src/commands/deploy/configure-futures.js
+++ b/publish/src/commands/deploy/configure-futures.js
@@ -103,7 +103,6 @@ module.exports = async ({
 			maxMarketValueUSD,
 			maxFundingRate,
 			skewScaleUSD,
-			maxFundingRateDelta,
 		} = market;
 
 		console.log(gray(`\n   --- MARKET ${asset} ---\n`));
@@ -120,7 +119,6 @@ module.exports = async ({
 			maxMarketValueUSD: w3utils.toWei(maxMarketValueUSD),
 			maxFundingRate: w3utils.toWei(maxFundingRate),
 			skewScaleUSD: w3utils.toWei(skewScaleUSD),
-			maxFundingRateDelta: w3utils.toWei(maxFundingRateDelta),
 		};
 
 		for (const setting in settings) {

--- a/publish/src/commands/deploy/deploy-futures.js
+++ b/publish/src/commands/deploy/deploy-futures.js
@@ -26,34 +26,15 @@ module.exports = async ({
 
 	console.log(gray(`\n------ DEPLOY FUTURES MARKETS ------\n`));
 
-	const proxyFuturesMarketManager = await deployer.deployContract({
-		name: 'ProxyFuturesMarketManager',
-		source: 'Proxy',
-		args: [account],
-	});
-
 	const futuresMarketManager = await deployer.deployContract({
 		name: 'FuturesMarketManager',
 		source: useOvm ? 'FuturesMarketManager' : 'EmptyFuturesMarketManager',
-		args: useOvm
-			? [addressOf(proxyFuturesMarketManager), account, addressOf(ReadProxyAddressResolver)]
-			: [],
+		args: useOvm ? [account, addressOf(ReadProxyAddressResolver)] : [],
 		deps: ['ReadProxyAddressResolver'],
 	});
 
 	if (!useOvm) {
 		return;
-	}
-
-	if (proxyFuturesMarketManager && futuresMarketManager) {
-		await runStep({
-			contract: 'ProxyFuturesMarketManager',
-			target: proxyFuturesMarketManager,
-			read: 'target',
-			expected: input => input === addressOf(futuresMarketManager),
-			write: 'setTarget',
-			writeArg: addressOf(futuresMarketManager),
-		});
 	}
 
 	// This belongs in dapp-utils, but since we are only deploying futures on L2,

--- a/publish/src/commands/deploy/deploy-futures.js
+++ b/publish/src/commands/deploy/deploy-futures.js
@@ -73,39 +73,16 @@ module.exports = async ({
 
 	for (const asset of futuresMarkets.map(x => x.asset)) {
 		const marketName = 'FuturesMarket' + asset.slice('1'); // remove s prefix
-		const proxyName = 'Proxy' + marketName;
 		const baseAsset = toBytes32(asset);
-
-		const proxyFuturesMarket = await deployer.deployContract({
-			name: proxyName,
-			source: 'Proxy',
-			args: [account],
-		});
 
 		const futuresMarket = await deployer.deployContract({
 			name: marketName,
 			source: 'FuturesMarket',
-			args: [
-				addressOf(proxyFuturesMarket),
-				account,
-				addressOf(ReadProxyAddressResolver),
-				baseAsset,
-			],
+			args: [addressOf(ReadProxyAddressResolver), baseAsset],
 		});
 
 		if (futuresMarket) {
 			deployedFuturesMarkets.push(addressOf(futuresMarket));
-		}
-
-		if (proxyFuturesMarket && futuresMarket) {
-			await runStep({
-				contract: proxyName,
-				target: proxyFuturesMarket,
-				read: 'target',
-				expected: input => input === addressOf(futuresMarket),
-				write: 'setTarget',
-				writeArg: addressOf(futuresMarket),
-			});
 		}
 	}
 

--- a/test/contracts/FuturesMarket.js
+++ b/test/contracts/FuturesMarket.js
@@ -33,8 +33,7 @@ const Status = {
 };
 
 contract('FuturesMarket', accounts => {
-	let proxyFuturesMarket,
-		futuresMarketSettings,
+	let futuresMarketSettings,
 		futuresMarketManager,
 		futuresMarket,
 		exchangeRates,
@@ -103,7 +102,6 @@ contract('FuturesMarket', accounts => {
 
 	before(async () => {
 		({
-			ProxyFuturesMarketBTC: proxyFuturesMarket,
 			FuturesMarketSettings: futuresMarketSettings,
 			FuturesMarketManager: futuresMarketManager,
 			FuturesMarketBTC: futuresMarket,
@@ -165,7 +163,7 @@ contract('FuturesMarket', accounts => {
 		it('Only expected functions are mutative', () => {
 			ensureOnlyExpectedMutativeFunctions({
 				abi: futuresMarket.abi,
-				ignoreParents: ['Owned', 'Proxyable', 'MixinFuturesMarketSettings'],
+				ignoreParents: ['MixinFuturesMarketSettings'],
 				expected: [
 					'transferMargin',
 					'withdrawAllMargin',
@@ -357,7 +355,7 @@ contract('FuturesMarket', accounts => {
 
 					decodedEventEqual({
 						event: 'PositionModified',
-						emittedFrom: proxyFuturesMarket.address,
+						emittedFrom: futuresMarket.address,
 						args: [
 							toBN('1'),
 							trader,
@@ -699,14 +697,14 @@ contract('FuturesMarket', accounts => {
 
 				decodedEventEqual({
 					event: 'MarginTransferred',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [trader3, toUnit('1000')],
 					log: decodedLogs[2],
 				});
 
 				decodedEventEqual({
 					event: 'PositionModified',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [
 						toBN('1'),
 						trader3,
@@ -745,14 +743,14 @@ contract('FuturesMarket', accounts => {
 
 				decodedEventEqual({
 					event: 'MarginTransferred',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [trader3, toUnit('-1000')],
 					log: decodedLogs[2],
 				});
 
 				decodedEventEqual({
 					event: 'PositionModified',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [
 						toBN('1'),
 						trader3,
@@ -913,7 +911,7 @@ contract('FuturesMarket', accounts => {
 			});
 			decodedEventEqual({
 				event: 'PositionModified',
-				emittedFrom: proxyFuturesMarket.address,
+				emittedFrom: futuresMarket.address,
 				args: [toBN('1'), trader, margin.sub(fee), size, size, price, toBN(2), fee],
 				log: decodedLogs[2],
 			});
@@ -1414,7 +1412,7 @@ contract('FuturesMarket', accounts => {
 
 				decodedEventEqual({
 					event: 'PositionModified',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [
 						toBN('1'),
 						trader,
@@ -3255,7 +3253,7 @@ contract('FuturesMarket', accounts => {
 				});
 				decodedEventEqual({
 					event: 'PositionModified',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [
 						positionId,
 						trader,
@@ -3270,7 +3268,7 @@ contract('FuturesMarket', accounts => {
 				});
 				decodedEventEqual({
 					event: 'PositionLiquidated',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [positionId, trader, noBalance, positionSize, newPrice, liquidationFee],
 					log: decodedLogs[3],
 					bnCloseVariance: toUnit('0.001'),
@@ -3356,7 +3354,7 @@ contract('FuturesMarket', accounts => {
 				});
 				decodedEventEqual({
 					event: 'PositionModified',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [
 						positionId,
 						trader3,
@@ -3371,7 +3369,7 @@ contract('FuturesMarket', accounts => {
 				});
 				decodedEventEqual({
 					event: 'PositionLiquidated',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [positionId, trader3, noBalance, positionSize, newPrice, liquidationFee],
 					log: decodedLogs[3],
 					bnCloseVariance: toUnit('0.001'),
@@ -3445,7 +3443,7 @@ contract('FuturesMarket', accounts => {
 				const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
 				decodedEventEqual({
 					event: 'PositionModified',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [
 						positionId,
 						trader,
@@ -3460,7 +3458,7 @@ contract('FuturesMarket', accounts => {
 				});
 				decodedEventEqual({
 					event: 'PositionLiquidated',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [positionId, trader, noBalance, positionSize, newPrice, toUnit('100')],
 					log: decodedLogs[3],
 					bnCloseVariance: toUnit('0.001'),
@@ -3817,7 +3815,7 @@ contract('FuturesMarket', accounts => {
 
 				decodedEventEqual({
 					event: 'PositionModified',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [
 						toBN('1'),
 						trader,

--- a/test/contracts/FuturesMarket.js
+++ b/test/contracts/FuturesMarket.js
@@ -180,8 +180,8 @@ contract('FuturesMarket', accounts => {
 		});
 
 		it('static parameters are set properly at construction', async () => {
-			const parameters = await futuresMarket.parameters();
 			assert.equal(await futuresMarket.baseAsset(), baseAsset);
+			const parameters = await futuresMarketSettings.parameters(baseAsset);
 			assert.bnEqual(parameters.takerFee, takerFee);
 			assert.bnEqual(parameters.makerFee, makerFee);
 			assert.bnEqual(parameters.takerFeeNextPrice, takerFeeNextPrice);
@@ -202,7 +202,7 @@ contract('FuturesMarket', accounts => {
 		});
 
 		it('market size and skew', async () => {
-			const minScale = (await futuresMarket.parameters()).skewScaleUSD;
+			const minScale = (await futuresMarketSettings.parameters(baseAsset)).skewScaleUSD;
 			const price = 100;
 			let sizes = await futuresMarket.marketSizes();
 			let marketSkew = await futuresMarket.marketSkew();
@@ -2386,7 +2386,10 @@ contract('FuturesMarket', accounts => {
 
 			assert.bnEqual(await futuresMarket.currentFundingRate(), toUnit(0));
 
-			const minScale = divideDecimal((await futuresMarket.parameters()).skewScaleUSD, price);
+			const minScale = divideDecimal(
+				(await futuresMarketSettings.parameters(baseAsset)).skewScaleUSD,
+				price
+			);
 			const maxFundingRate = await futuresMarket.maxFundingRate();
 			// Market is 24 units long skewed (24 / 100000)
 			await futuresMarket.modifyPosition(toUnit('24'), { from: trader });

--- a/test/contracts/FuturesMarket.js
+++ b/test/contracts/FuturesMarket.js
@@ -63,7 +63,6 @@ contract('FuturesMarket', accounts => {
 	const maxMarketValueUSD = toUnit('100000');
 	const maxFundingRate = toUnit('0.1');
 	const skewScaleUSD = toUnit('100000');
-	const maxFundingRateDelta = toUnit('0.0125');
 	const initialPrice = toUnit('100');
 	const minKeeperFee = toUnit('20');
 	const minInitialMargin = toUnit('100');
@@ -191,7 +190,6 @@ contract('FuturesMarket', accounts => {
 			assert.bnEqual(parameters.maxMarketValueUSD, maxMarketValueUSD);
 			assert.bnEqual(parameters.maxFundingRate, maxFundingRate);
 			assert.bnEqual(parameters.skewScaleUSD, skewScaleUSD);
-			assert.bnEqual(parameters.maxFundingRateDelta, maxFundingRateDelta);
 		});
 
 		it('prices are properly fetched', async () => {
@@ -2641,7 +2639,7 @@ contract('FuturesMarket', accounts => {
 				assert.bnClose((await futuresMarket.unrecordedFunding())[0], toUnit('-6'), toUnit('0.01'));
 
 				await futuresMarketSettings.setMaxFundingRate(baseAsset, toUnit('0.2'), { from: owner });
-				let time = await currentTime();
+				const time = await currentTime();
 
 				assert.bnEqual(
 					await futuresMarket.fundingSequenceLength(),
@@ -2669,22 +2667,6 @@ contract('FuturesMarket', accounts => {
 				assert.bnClose(
 					(await futuresMarket.unrecordedFunding())[0],
 					toUnit('-120'),
-					toUnit('0.01')
-				);
-
-				await futuresMarketSettings.setMaxFundingRateDelta(baseAsset, toUnit('0.05'), {
-					from: owner,
-				});
-				time = await currentTime();
-
-				assert.bnEqual(
-					await futuresMarket.fundingSequenceLength(),
-					initialFundingIndex.add(toBN(8))
-				);
-				assert.bnEqual(await futuresMarket.fundingLastRecomputed(), time);
-				assert.bnClose(
-					await futuresMarket.fundingSequence(initialFundingIndex.add(toBN(7))),
-					toUnit('-126'),
 					toUnit('0.01')
 				);
 			});
@@ -3576,11 +3558,7 @@ contract('FuturesMarket', accounts => {
 					'Invalid price'
 				);
 				await assert.revert(
-					futuresMarketSettings.setMaxFundingRateDelta(baseAsset, 0, { from: owner }),
-					'Invalid price'
-				);
-				await assert.revert(
-					futuresMarketSettings.setParameters(baseAsset, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, {
+					futuresMarketSettings.setParameters(baseAsset, 0, 0, 0, 0, 0, 0, 0, 0, 0, {
 						from: owner,
 					}),
 					'Invalid price'
@@ -3769,8 +3747,7 @@ contract('FuturesMarket', accounts => {
 			it('futuresMarketSettings parameter changes do not revert', async () => {
 				await futuresMarketSettings.setMaxFundingRate(baseAsset, 0, { from: owner });
 				await futuresMarketSettings.setSkewScaleUSD(baseAsset, toUnit('100'), { from: owner });
-				await futuresMarketSettings.setMaxFundingRateDelta(baseAsset, 0, { from: owner });
-				await futuresMarketSettings.setParameters(baseAsset, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, {
+				await futuresMarketSettings.setParameters(baseAsset, 0, 0, 0, 0, 0, 0, 0, 0, 1, {
 					from: owner,
 				});
 			});
@@ -3852,8 +3829,7 @@ contract('FuturesMarket', accounts => {
 			it('futuresMarketSettings parameter changes do not revert', async () => {
 				await futuresMarketSettings.setMaxFundingRate(baseAsset, 0, { from: owner });
 				await futuresMarketSettings.setSkewScaleUSD(baseAsset, toUnit('100'), { from: owner });
-				await futuresMarketSettings.setMaxFundingRateDelta(baseAsset, 0, { from: owner });
-				await futuresMarketSettings.setParameters(baseAsset, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, {
+				await futuresMarketSettings.setParameters(baseAsset, 0, 0, 0, 0, 0, 0, 0, 0, 1, {
 					from: owner,
 				});
 			});

--- a/test/contracts/FuturesMarket.nextPrice.js
+++ b/test/contracts/FuturesMarket.nextPrice.js
@@ -8,8 +8,7 @@ const { assert, addSnapshotBeforeRestoreAfterEach } = require('./common');
 const { getDecodedLogs, decodedEventEqual, updateAggregatorRates } = require('./helpers');
 
 contract('FuturesMarket MixinFuturesNextPriceOrders', accounts => {
-	let proxyFuturesMarket,
-		futuresMarketSettings,
+	let futuresMarketSettings,
 		// futuresMarketManager,
 		futuresMarket,
 		exchangeRates,
@@ -41,7 +40,6 @@ contract('FuturesMarket MixinFuturesNextPriceOrders', accounts => {
 
 	before(async () => {
 		({
-			ProxyFuturesMarketBTC: proxyFuturesMarket,
 			FuturesMarketSettings: futuresMarketSettings,
 			// FuturesMarketManager: futuresMarketManager,
 			FuturesMarketBTC: futuresMarket,
@@ -121,14 +119,14 @@ contract('FuturesMarket MixinFuturesNextPriceOrders', accounts => {
 			// PositionModified
 			decodedEventEqual({
 				event: 'PositionModified',
-				emittedFrom: proxyFuturesMarket.address,
+				emittedFrom: futuresMarket.address,
 				args: [toBN('1'), trader, expectedMargin, 0, 0, price, toBN(2), 0],
 				log: decodedLogs[1],
 			});
 			// NextPriceOrderSubmitted
 			decodedEventEqual({
 				event: 'NextPriceOrderSubmitted',
-				emittedFrom: proxyFuturesMarket.address,
+				emittedFrom: futuresMarket.address,
 				args: [trader, size, roundId.add(toBN(1)), spotFee, keeperFee],
 				log: decodedLogs[2],
 			});
@@ -207,7 +205,7 @@ contract('FuturesMarket MixinFuturesNextPriceOrders', accounts => {
 					// PositionModified
 					decodedEventEqual({
 						event: 'PositionModified',
-						emittedFrom: proxyFuturesMarket.address,
+						emittedFrom: futuresMarket.address,
 						args: [toBN('1'), trader, currentMargin.add(keeperFee), 0, 0, price, toBN(2), 0],
 						log: decodedLogs[1],
 					});
@@ -232,7 +230,7 @@ contract('FuturesMarket MixinFuturesNextPriceOrders', accounts => {
 				// NextPriceOrderRemoved
 				decodedEventEqual({
 					event: 'NextPriceOrderRemoved',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [trader, roundId, size, roundId.add(toBN(1)), spotFee, keeperFee],
 					log: decodedLogs.slice(-1)[0],
 				});
@@ -473,7 +471,7 @@ contract('FuturesMarket MixinFuturesNextPriceOrders', accounts => {
 				const currentPrice = (await futuresMarket.assetPrice()).price;
 				decodedEventEqual({
 					event: 'PositionModified',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [toBN('1'), trader, expectedMargin, 0, 0, currentPrice, toBN(2), 0],
 					log: decodedLogs.slice(-4, -3)[0],
 				});
@@ -490,7 +488,7 @@ contract('FuturesMarket MixinFuturesNextPriceOrders', accounts => {
 
 				decodedEventEqual({
 					event: 'PositionModified',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [toBN('1'), trader, expectedMargin, size, size, targetPrice, toBN(2), expectedFee],
 					log: decodedLogs.slice(-2, -1)[0],
 				});
@@ -498,7 +496,7 @@ contract('FuturesMarket MixinFuturesNextPriceOrders', accounts => {
 				// NextPriceOrderRemoved
 				decodedEventEqual({
 					event: 'NextPriceOrderRemoved',
-					emittedFrom: proxyFuturesMarket.address,
+					emittedFrom: futuresMarket.address,
 					args: [trader, roundId, size, roundId.add(toBN(1)), commitFee, keeperFee],
 					log: decodedLogs.slice(-1)[0],
 				});

--- a/test/contracts/FuturesMarketData.js
+++ b/test/contracts/FuturesMarketData.js
@@ -218,7 +218,7 @@ contract('FuturesMarketData', accounts => {
 			assert.bnEqual(details2.remainingMargin, remaining.marginRemaining);
 			const accessible = await futuresMarket.accessibleMargin(trader1);
 			assert.bnEqual(details2.accessibleMargin, accessible.marginAccessible);
-			const lp = await futuresMarket.liquidationPrice(trader1, true);
+			const lp = await futuresMarket.liquidationPrice(trader1);
 			assert.bnEqual(details2.liquidationPrice, lp[0]);
 			assert.equal(details.canLiquidatePosition, await futuresMarket.canLiquidate(trader1));
 		});

--- a/test/contracts/FuturesMarketData.js
+++ b/test/contracts/FuturesMarketData.js
@@ -70,13 +70,6 @@ contract('FuturesMarketData', accounts => {
 
 		// Add a couple of additional markets.
 		for (const symbol of ['sETH', 'sLINK']) {
-			const proxy = await setupContract({
-				accounts,
-				contract: 'ProxyFuturesMarket' + symbol,
-				source: 'Proxy',
-				args: [accounts[1]],
-				cache: { FuturesMarketManager: futuresMarketManager },
-			});
 			const assetKey = toBytes32(symbol);
 
 			const market = await setupContract({
@@ -84,14 +77,11 @@ contract('FuturesMarketData', accounts => {
 				contract: 'FuturesMarket' + symbol,
 				source: 'FuturesMarket',
 				args: [
-					proxy.address,
-					accounts[1],
 					addressResolver.address,
 					assetKey, // base asset
 				],
 			});
 
-			await proxy.setTarget(market.address, { from: owner });
 			await addressResolver.rebuildCaches([market.address], { from: owner });
 			await futuresMarketManager.addMarkets([market.address], { from: owner });
 

--- a/test/contracts/FuturesMarketData.js
+++ b/test/contracts/FuturesMarketData.js
@@ -100,7 +100,6 @@ contract('FuturesMarketData', accounts => {
 				toWei('1000000'), // 1000000 max total margin
 				toWei('0.2'), // 20% max funding rate
 				toWei('100000'), // 100000 USD skewScaleUSD
-				toWei('0.025'), // 2.5% per hour max funding rate of change
 				{ from: owner }
 			);
 		}
@@ -178,7 +177,6 @@ contract('FuturesMarketData', accounts => {
 
 			assert.bnEqual(details.fundingParameters.maxFundingRate, params.maxFundingRate);
 			assert.bnEqual(details.fundingParameters.skewScaleUSD, params.skewScaleUSD);
-			assert.bnEqual(details.fundingParameters.maxFundingRateDelta, params.maxFundingRateDelta);
 
 			assert.bnEqual(details.marketSizeDetails.marketSize, await futuresMarket.marketSize());
 			const marketSizes = await futuresMarket.marketSizes();

--- a/test/contracts/FuturesMarketManager.js
+++ b/test/contracts/FuturesMarketManager.js
@@ -15,14 +15,13 @@ const ZERO_ADDRESS = constants.ZERO_ADDRESS;
 const MockExchanger = artifacts.require('MockExchanger');
 
 contract('FuturesMarketManager', accounts => {
-	let proxyFuturesMarketManager, futuresMarketManager, sUSD, debtCache, synthetix, addressResolver;
+	let futuresMarketManager, sUSD, debtCache, synthetix, addressResolver;
 	const owner = accounts[1];
 	const trader = accounts[2];
 	const initialMint = toUnit('100000');
 
 	before(async () => {
 		({
-			ProxyFuturesMarketManager: proxyFuturesMarketManager,
 			FuturesMarketManager: futuresMarketManager,
 			SynthsUSD: sUSD,
 			DebtCache: debtCache,
@@ -33,7 +32,6 @@ contract('FuturesMarketManager', accounts => {
 			synths: ['sUSD'],
 			contracts: [
 				'FuturesMarketManager',
-				// 'Proxy',
 				'AddressResolver',
 				'FeePool',
 				'ExchangeRates',
@@ -60,7 +58,7 @@ contract('FuturesMarketManager', accounts => {
 		it('only expected functions are mutable', () => {
 			ensureOnlyExpectedMutativeFunctions({
 				abi: futuresMarketManager.abi,
-				ignoreParents: ['Owned', 'MixinResolver', 'Proxyable'],
+				ignoreParents: ['Owned', 'MixinResolver'],
 				expected: [
 					'addMarkets',
 					'removeMarkets',
@@ -133,13 +131,13 @@ contract('FuturesMarketManager', accounts => {
 			assert.equal(decodedLogs.length, 2);
 			decodedEventEqual({
 				event: 'MarketAdded',
-				emittedFrom: proxyFuturesMarketManager.address,
+				emittedFrom: futuresMarketManager.address,
 				args: [addresses[0], keys[0]],
 				log: decodedLogs[0],
 			});
 			decodedEventEqual({
 				event: 'MarketAdded',
-				emittedFrom: proxyFuturesMarketManager.address,
+				emittedFrom: futuresMarketManager.address,
 				args: [addresses[1], keys[1]],
 				log: decodedLogs[1],
 			});
@@ -182,13 +180,13 @@ contract('FuturesMarketManager', accounts => {
 			assert.equal(decodedLogs.length, 2);
 			decodedEventEqual({
 				event: 'MarketRemoved',
-				emittedFrom: proxyFuturesMarketManager.address,
+				emittedFrom: futuresMarketManager.address,
 				args: [addresses[0], currencyKeys[0]],
 				log: decodedLogs[0],
 			});
 			decodedEventEqual({
 				event: 'MarketRemoved',
-				emittedFrom: proxyFuturesMarketManager.address,
+				emittedFrom: futuresMarketManager.address,
 				args: [addresses[1], currencyKeys[1]],
 				log: decodedLogs[1],
 			});
@@ -243,13 +241,15 @@ contract('FuturesMarketManager', accounts => {
 				skipPostDeploy: true,
 			});
 
+			const revertReason = 'Only the contract owner may perform this action';
+
 			await onlyGivenAddressCanInvoke({
 				fnc: futuresMarketManager.addMarkets,
 				args: [[market.address]],
 				accounts,
 				address: owner,
 				skipPassCheck: false,
-				reason: 'Owner only function',
+				reason: revertReason,
 			});
 
 			await onlyGivenAddressCanInvoke({
@@ -258,7 +258,7 @@ contract('FuturesMarketManager', accounts => {
 				accounts,
 				address: owner,
 				skipPassCheck: false,
-				reason: 'Owner only function',
+				reason: revertReason,
 			});
 
 			await onlyGivenAddressCanInvoke({
@@ -267,7 +267,7 @@ contract('FuturesMarketManager', accounts => {
 				accounts,
 				address: owner,
 				skipPassCheck: false,
-				reason: 'Owner only function',
+				reason: revertReason,
 			});
 		});
 	});

--- a/test/contracts/FuturesMarketSettings.js
+++ b/test/contracts/FuturesMarketSettings.js
@@ -32,7 +32,6 @@ contract('FuturesMarketSettings', accounts => {
 
 	const maxFundingRate = toUnit('0.1');
 	const skewScaleUSD = toUnit('10000');
-	const maxFundingRateDelta = toUnit('0.0125');
 
 	before(async () => {
 		({
@@ -96,7 +95,6 @@ contract('FuturesMarketSettings', accounts => {
 				'setMaxMarketValueUSD',
 				'setMaxFundingRate',
 				'setSkewScaleUSD',
-				'setMaxFundingRateDelta',
 				'setParameters',
 				'setMinKeeperFee',
 				'setLiquidationFeeRatio',
@@ -120,7 +118,6 @@ contract('FuturesMarketSettings', accounts => {
 				maxMarketValueUSD,
 				maxFundingRate,
 				skewScaleUSD,
-				maxFundingRateDelta,
 			}).map(([key, val]) => {
 				const capKey = key.charAt(0).toUpperCase() + key.slice(1);
 				return [key, val, futuresMarketSettings[`set${capKey}`], futuresMarketSettings[`${key}`]];

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -283,14 +283,10 @@ const setupContract = async ({
 		],
 		FuturesMarketSettings: [owner, tryGetAddressOf('AddressResolver')],
 		FuturesMarketBTC: [
-			tryGetAddressOf('ProxyFuturesMarketBTC'),
-			owner,
 			tryGetAddressOf('AddressResolver'),
 			toBytes32('sBTC'), // base asset
 		],
 		FuturesMarketETH: [
-			tryGetAddressOf('ProxyFuturesMarketETH'),
-			owner,
 			tryGetAddressOf('AddressResolver'),
 			toBytes32('sETH'), // base asset
 		],
@@ -569,19 +565,11 @@ const setupContract = async ({
 		async FuturesMarketBTC() {
 			await Promise.all([
 				cache['FuturesMarketManager'].addMarkets([instance.address], { from: owner }),
-				cache['ProxyFuturesMarketBTC'].setTarget(instance.address, { from: owner }),
-				instance.setProxy(cache['ProxyFuturesMarketBTC'].address, {
-					from: owner,
-				}),
 			]);
 		},
 		async FuturesMarketETH() {
 			await Promise.all([
 				cache['FuturesMarketManager'].addMarkets([instance.address], { from: owner }),
-				cache['ProxyFuturesMarketETH'].setTarget(instance.address, { from: owner }),
-				instance.setProxy(cache['ProxyFuturesMarketETH'].address, {
-					from: owner,
-				}),
 			]);
 		},
 		async GenericMock() {
@@ -986,15 +974,10 @@ const setupAllContracts = async ({
 			contract: 'FuturesMarketSettings',
 			deps: ['AddressResolver', 'FlexibleStorage'],
 		},
-		{ contract: 'Proxy', forContract: 'FuturesMarketBTC' },
 		{
-			// contract: 'TestableFuturesMarket',
-			// forContract: 'FuturesMarketBTC',
-			// resolverAlias: 'FuturesMarketBTC',
 			contract: 'FuturesMarketBTC',
 			source: 'TestableFuturesMarket',
 			deps: [
-				'Proxy',
 				'AddressResolver',
 				'FuturesMarketManager',
 				'FuturesMarketSettings',
@@ -1003,12 +986,10 @@ const setupAllContracts = async ({
 				'ExchangeCircuitBreaker',
 			],
 		},
-		{ contract: 'Proxy', forContract: 'FuturesMarketETH' },
 		{
 			contract: 'FuturesMarketETH',
 			source: 'TestableFuturesMarket',
 			deps: [
-				'Proxy',
 				'AddressResolver',
 				'FuturesMarketManager',
 				'FlexibleStorage',

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -276,11 +276,7 @@ const setupContract = async ({
 		],
 		WETH: [],
 		SynthRedeemer: [tryGetAddressOf('AddressResolver')],
-		FuturesMarketManager: [
-			tryGetAddressOf('ProxyFuturesMarketManager'),
-			owner,
-			tryGetAddressOf('AddressResolver'),
-		],
+		FuturesMarketManager: [owner, tryGetAddressOf('AddressResolver')],
 		FuturesMarketSettings: [owner, tryGetAddressOf('AddressResolver')],
 		FuturesMarketBTC: [
 			tryGetAddressOf('AddressResolver'),
@@ -553,14 +549,6 @@ const setupContract = async ({
 				[true, true, true, true, true],
 				{ from: owner }
 			);
-		},
-		async FuturesMarketManager() {
-			await Promise.all([
-				cache['ProxyFuturesMarketManager'].setTarget(instance.address, { from: owner }),
-				instance.setProxy(cache['ProxyFuturesMarketManager'].address, {
-					from: owner,
-				}),
-			]);
 		},
 		async FuturesMarketBTC() {
 			await Promise.all([
@@ -965,7 +953,6 @@ const setupAllContracts = async ({
 			contract: 'CollateralShort',
 			deps: ['Collateral', 'CollateralManager', 'AddressResolver', 'CollateralUtil'],
 		},
-		{ contract: 'Proxy', forContract: 'FuturesMarketManager' },
 		{
 			contract: 'FuturesMarketManager',
 			deps: ['AddressResolver', 'Exchanger'],

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -1267,7 +1267,6 @@ const setupAllContracts = async ({
 						toWei('100000'), // 100000 max market debt
 						toWei('0.1'), // 10% max funding rate
 						toWei('100000'), // 100000 USD skewScaleUSD
-						toWei('0.0125'), // 1.25% per hour max funding rate of change
 						{ from: owner }
 					),
 				]);


### PR DESCRIPTION
https://github.com/synthetixio/issues/issues/414

## Reduced contract size from 96% to 79%. 

### Things that helped:
- removing proxy related things (10%)
- removing unused functionality and moving things that are only used for test into the Testable contract, moving some things that are only used in MarketData views there. Checked that all methods used Kwenta code aren't touched.
 
### Things that didn't help (but took a while, see also next section):
- Refactoring the gazzillion getters in settings mixin into a single getter with a struct `config` and passing it around, ended up being worse
- Refactoring the getters used for external views into two structs (position details and market details) - was almost the same, but a bit larger.

### Things that were aweful to deal with: 
Compiler errors relating to structs and ABIEncoderV2 issues. In some cases, the pragma needs to be added into an inheriting contract, but the compiler won't tell you this, and definitely won't tell you which contract.

### Next steps when more functionality will be needed: librarification