### PR TITLE
SIP-209 Update feeRateForExchange function signature

### DIFF
--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -786,7 +786,7 @@ contract Exchanger is Owned, MixinSystemSettings, IExchanger {
     /// @return The exchange fee rate, and whether the rates are too volatile
     function feeRateForExchange(bytes32 sourceCurrencyKey, bytes32 destinationCurrencyKey) external view returns (uint) {
         (uint feeRate, bool tooVolatile) = _feeRateForExchange(sourceCurrencyKey, destinationCurrencyKey);
-        require(!tooVolatile, "too volatile to trade");
+        require(!tooVolatile, "too volatile");
         return feeRate;
     }
 

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -784,12 +784,10 @@ contract Exchanger is Owned, MixinSystemSettings, IExchanger {
     /// @param sourceCurrencyKey The source currency key
     /// @param destinationCurrencyKey The destination currency key
     /// @return The exchange fee rate, and whether the rates are too volatile
-    function feeRateForExchange(bytes32 sourceCurrencyKey, bytes32 destinationCurrencyKey)
-        external
-        view
-        returns (uint feeRate, bool tooVolatile)
-    {
-        return _feeRateForExchange(sourceCurrencyKey, destinationCurrencyKey);
+    function feeRateForExchange(bytes32 sourceCurrencyKey, bytes32 destinationCurrencyKey) external view returns (uint) {
+        (uint feeRate, bool tooVolatile) = _feeRateForExchange(sourceCurrencyKey, destinationCurrencyKey);
+        require(!tooVolatile, "too volatile to trade");
+        return feeRate;
     }
 
     /// @notice public function to get the dynamic fee rate for a given exchange

--- a/contracts/interfaces/IExchanger.sol
+++ b/contracts/interfaces/IExchanger.sol
@@ -48,10 +48,7 @@ interface IExchanger {
 
     function hasWaitingPeriodOrSettlementOwing(address account, bytes32 currencyKey) external view returns (bool);
 
-    function feeRateForExchange(bytes32 sourceCurrencyKey, bytes32 destinationCurrencyKey)
-        external
-        view
-        returns (uint exchangeFeeRate, bool tooVolatile);
+    function feeRateForExchange(bytes32 sourceCurrencyKey, bytes32 destinationCurrencyKey) external view returns (uint);
 
     function dynamicFeeRateForExchange(bytes32 sourceCurrencyKey, bytes32 destinationCurrencyKey)
         external

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -3,8 +3,8 @@ require('dotenv').config();
 
 const path = require('path');
 
-/// for some weird reason the order of these imports is important:
-/// ./hardhat needs to be imported after hardhat-interact (error otherwise)
+/// the order of these imports is important (due to custom overrides):
+/// ./hardhat needs to be imported after hardhat-interact and after solidity-coverage.
 ///  and hardhat-gas-reporter needs to be imported after ./hardhat (otherwise no gas reports)
 require('hardhat-interact');
 require('solidity-coverage');

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -7,10 +7,10 @@ const path = require('path');
 /// ./hardhat needs to be imported after hardhat-interact (error otherwise)
 ///  and hardhat-gas-reporter needs to be imported after ./hardhat (otherwise no gas reports)
 require('hardhat-interact');
+require('solidity-coverage');
 require('./hardhat');
 require('@nomiclabs/hardhat-truffle5');
 require('@nomiclabs/hardhat-ethers');
-require('solidity-coverage');
 require('hardhat-gas-reporter');
 
 const {

--- a/hardhat/tasks/task-test.js
+++ b/hardhat/tasks/task-test.js
@@ -18,6 +18,13 @@ subtask(TASK_TEST_RUN_MOCHA_TESTS).setAction(async ({ testFiles }, { config }) =
 	return testFailures;
 });
 
+let coverage = false;
+
+task('coverage').setAction(async (taskArguments, hre, runSuper) => {
+	coverage = true;
+	await runSuper(taskArguments);
+});
+
 task('test')
 	.addFlag('optimizer', 'Compile with the optimizer')
 	.addFlag('gas', 'Compile gas usage')
@@ -57,7 +64,7 @@ task('test')
 
 		// When using CircleCI, output the test metadata
 		// See https://circleci.com/docs/2.0/collect-test-data
-		if (isCI) {
+		if (isCI && !coverage) {
 			hre.config.mocha.reporter = 'mocha-junit-reporter';
 			hre.config.mocha.reporterOptions = {
 				mochaFile: '/tmp/junit/test-results.[hash].xml',

--- a/publish/releases.json
+++ b/publish/releases.json
@@ -465,6 +465,11 @@
 			"layer": "both",
 			"sources": ["FeePool"],
 			"released": "both"
+		},
+		{
+			"sip": 209,
+			"layer": "both",
+			"sources": ["Exchanger"]
 		}
 	],
 	"releases": [

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -3709,7 +3709,7 @@ contract('Exchanger (spec tests)', async accounts => {
 					await systemSettings.setExchangeFeeRateForSynths([sUSD], [newFxBIPS], {
 						from: owner,
 					});
-					const sUSDRate = (await exchanger.feeRateForExchange(empty, sUSD))[0];
+					const sUSDRate = await exchanger.feeRateForExchange(empty, sUSD);
 					assert.bnEqual(sUSDRate, newFxBIPS);
 				});
 
@@ -3723,13 +3723,13 @@ contract('Exchanger (spec tests)', async accounts => {
 						}
 					);
 					// Read all rates
-					const sAUDRate = (await exchanger.feeRateForExchange(empty, sAUD))[0];
+					const sAUDRate = await exchanger.feeRateForExchange(empty, sAUD);
 					assert.bnEqual(sAUDRate, newFxBIPS);
-					const sUSDRate = (await exchanger.feeRateForExchange(empty, sUSD))[0];
+					const sUSDRate = await exchanger.feeRateForExchange(empty, sUSD);
 					assert.bnEqual(sUSDRate, newFxBIPS);
-					const sBTCRate = (await exchanger.feeRateForExchange(empty, sBTC))[0];
+					const sBTCRate = await exchanger.feeRateForExchange(empty, sBTC);
 					assert.bnEqual(sBTCRate, newCryptoBIPS);
-					const sETHRate = (await exchanger.feeRateForExchange(empty, sETH))[0];
+					const sETHRate = await exchanger.feeRateForExchange(empty, sETH);
 					assert.bnEqual(sETHRate, newCryptoBIPS);
 				});
 			});

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -462,7 +462,7 @@ contract('Exchanger (spec tests)', async accounts => {
 	const itCalculatesFeeRateForExchange = () => {
 		describe('Given exchangeFeeRates are configured and when calling feeRateForExchange()', () => {
 			it('for two long synths, returns the regular exchange fee', async () => {
-				const actualFeeRate = (await exchanger.feeRateForExchange(sEUR, sBTC))[0];
+				const actualFeeRate = await exchanger.feeRateForExchange(sEUR, sBTC);
 				assert.bnEqual(actualFeeRate, exchangeFeeRate, 'Rate must be the exchange fee rate');
 			});
 		});
@@ -507,7 +507,7 @@ contract('Exchanger (spec tests)', async accounts => {
 						assert.bnEqual(destinationFee, exchangeFeeIncurred(effectiveValue, bipsCrypto));
 					});
 					it('then return the feeRate', async () => {
-						const exchangeFeeRate = (await exchanger.feeRateForExchange(sUSD, sBTC))[0];
+						const exchangeFeeRate = await exchanger.feeRateForExchange(sUSD, sBTC);
 						assert.bnEqual(feeRate, exchangeFeeRate);
 					});
 				});
@@ -536,7 +536,7 @@ contract('Exchanger (spec tests)', async accounts => {
 						assert.bnEqual(destinationFee, exchangeFeeIncurred(effectiveValue, bipsFX));
 					});
 					it('then return the feeRate', async () => {
-						const exchangeFeeRate = (await exchanger.feeRateForExchange(sUSD, sEUR))[0];
+						const exchangeFeeRate = await exchanger.feeRateForExchange(sUSD, sEUR);
 						assert.bnEqual(feeRate, exchangeFeeRate);
 					});
 				});
@@ -585,28 +585,28 @@ contract('Exchanger (spec tests)', async accounts => {
 					const maxDynamicFeeRate = toBN(EXCHANGE_MAX_DYNAMIC_FEE);
 
 					it('initial fee is correct', async () => {
-						assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sBTC), [bipsCrypto, false]);
+						assert.bnEqual(await exchanger.feeRateForExchange(sUSD, sBTC), bipsCrypto);
 						assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sUSD, sBTC), [0, false]);
 					});
 
-					describe('fee is caluclated correctly when rates spike or drop', () => {
+					describe('fee is calculated correctly when rates spike or drop', () => {
 						it('.3% spike is below threshold', async () => {
 							await updateRates([sETH], [toUnit(100.3)]);
 							// spike
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sETH), [bipsCrypto, false]);
+							assert.bnEqual(await exchanger.feeRateForExchange(sUSD, sETH), bipsCrypto);
 							assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sUSD, sETH), [0, false]);
 							// control
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sBTC), [bipsCrypto, false]);
+							assert.bnEqual(await exchanger.feeRateForExchange(sUSD, sBTC), bipsCrypto);
 							assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sBTC, sBTC), [0, false]);
 						});
 
 						it('.3% drop is below threshold', async () => {
 							await updateRates([sETH], [toUnit(99.7)]);
 							// spike
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sETH), [bipsCrypto, false]);
+							assert.bnEqual(await exchanger.feeRateForExchange(sUSD, sETH), bipsCrypto);
 							assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sUSD, sETH), [0, false]);
 							// control
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sBTC), [bipsCrypto, false]);
+							assert.bnEqual(await exchanger.feeRateForExchange(sUSD, sBTC), bipsCrypto);
 							assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sBTC, sBTC), [0, false]);
 						});
 
@@ -614,91 +614,81 @@ contract('Exchanger (spec tests)', async accounts => {
 							await updateRates([sETH], [toUnit(101)]);
 							// price diff ratio (1%)- threshold
 							const expectedDynamicFee = toUnit(0.01).sub(threshold);
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sETH), [
-								bipsCrypto.add(expectedDynamicFee),
-								false,
-							]);
+							assert.bnEqual(
+								await exchanger.feeRateForExchange(sUSD, sETH),
+								bipsCrypto.add(expectedDynamicFee)
+							);
 							assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sUSD, sETH), [
 								expectedDynamicFee,
 								false,
 							]);
 							// control
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sBTC), [bipsCrypto, false]);
+							assert.bnEqual(await exchanger.feeRateForExchange(sUSD, sBTC), bipsCrypto);
 						});
 
 						it('1% drop result in correct dynamic fee', async () => {
 							await updateRates([sETH], [toUnit(99)]);
 							// price diff ratio (1%)- threshold
 							const expectedDynamicFee = toUnit(0.01).sub(threshold);
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sETH), [
-								bipsCrypto.add(expectedDynamicFee),
-								false,
-							]);
+							assert.bnEqual(
+								await exchanger.feeRateForExchange(sUSD, sETH),
+								bipsCrypto.add(expectedDynamicFee)
+							);
 							assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sUSD, sETH), [
 								expectedDynamicFee,
 								false,
 							]);
 							// control
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sBTC), [bipsCrypto, false]);
+							assert.bnEqual(await exchanger.feeRateForExchange(sUSD, sBTC), bipsCrypto);
 						});
 
 						it('5% spike result in correct dynamic fee', async () => {
 							await updateRates([sETH], [toUnit(105)]);
 							// price diff ratio (5%)- threshold
 							const expectedDynamicFee = toUnit(0.05).sub(threshold);
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sETH), [
-								bipsCrypto.add(expectedDynamicFee),
-								false,
-							]);
+							assert.bnEqual(
+								await exchanger.feeRateForExchange(sUSD, sETH),
+								bipsCrypto.add(expectedDynamicFee)
+							);
 							assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sUSD, sETH), [
 								expectedDynamicFee,
 								false,
 							]);
 							// control
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sBTC), [bipsCrypto, false]);
+							assert.bnEqual(await exchanger.feeRateForExchange(sUSD, sBTC), bipsCrypto);
 						});
 
 						it('5% drop result in correct dynamic fee', async () => {
 							await updateRates([sETH], [toUnit(95)]);
 							// price diff ratio (5%)- threshold
 							const expectedDynamicFee = toUnit(0.05).sub(threshold);
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sETH), [
-								bipsCrypto.add(expectedDynamicFee),
-								false,
-							]);
+							assert.bnEqual(
+								await exchanger.feeRateForExchange(sUSD, sETH),
+								bipsCrypto.add(expectedDynamicFee)
+							);
 							assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sUSD, sETH), [
 								expectedDynamicFee,
 								false,
 							]);
 							// control
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sBTC), [bipsCrypto, false]);
+							assert.bnEqual(await exchanger.feeRateForExchange(sUSD, sBTC), bipsCrypto);
 						});
 
 						it('10% spike is over the max and is too volatile', async () => {
 							await updateRates([sETH], [toUnit(110)]);
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sETH), [
-								bipsCrypto.add(maxDynamicFeeRate),
-								true,
-							]);
+							await assert.revert(exchanger.feeRateForExchange(sUSD, sETH), 'too volatile');
 							assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sUSD, sETH), [
 								maxDynamicFeeRate,
 								true,
 							]);
-							// view reverts
-							await assert.revert(
-								exchanger.getAmountsForExchange(toUnit('1'), sUSD, sETH),
-								'too volatile'
-							);
+
 							// control
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sBTC), [bipsCrypto, false]);
+							assert.bnEqual(await exchanger.feeRateForExchange(sUSD, sBTC), bipsCrypto);
 						});
 
 						it('10% drop result in correct dynamic fee', async () => {
 							await updateRates([sETH], [toUnit(90)]);
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sETH), [
-								bipsCrypto.add(maxDynamicFeeRate),
-								true,
-							]);
+							await assert.revert(exchanger.feeRateForExchange(sUSD, sETH), 'too volatile');
 							assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sUSD, sETH), [
 								maxDynamicFeeRate,
 								true,
@@ -709,7 +699,7 @@ contract('Exchanger (spec tests)', async accounts => {
 								'too volatile'
 							);
 							// control
-							assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sBTC), [bipsCrypto, false]);
+							assert.bnEqual(await exchanger.feeRateForExchange(sUSD, sBTC), bipsCrypto);
 						});
 
 						it('trading between two spiked rates is correctly calculated ', async () => {
@@ -718,19 +708,19 @@ contract('Exchanger (spec tests)', async accounts => {
 							const expectedDynamicFee = toUnit(0.02)
 								.sub(threshold)
 								.mul(toBN(2));
-							assert.deepEqual(await exchanger.feeRateForExchange(sBTC, sETH), [
-								bipsCrypto.add(expectedDynamicFee),
-								false,
-							]);
+							assert.bnEqual(
+								await exchanger.feeRateForExchange(sBTC, sETH),
+								bipsCrypto.add(expectedDynamicFee)
+							);
 							assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sBTC, sETH), [
 								expectedDynamicFee,
 								false,
 							]);
 							// reverse direction is the same
-							assert.deepEqual(await exchanger.feeRateForExchange(sETH, sBTC), [
-								bipsCrypto.add(expectedDynamicFee),
-								false,
-							]);
+							assert.bnEqual(
+								await exchanger.feeRateForExchange(sETH, sBTC),
+								bipsCrypto.add(expectedDynamicFee)
+							);
 							assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sETH, sBTC), [
 								expectedDynamicFee,
 								false,
@@ -740,19 +730,13 @@ contract('Exchanger (spec tests)', async accounts => {
 						it('trading between two spiked respects max fee and volatility flag', async () => {
 							// spike each 3% so that total dynamic fee is 6% which is more than the max
 							await updateRates([sETH, sBTC], [toUnit(103), toUnit(5150)]);
-							assert.deepEqual(await exchanger.feeRateForExchange(sBTC, sETH), [
-								bipsCrypto.add(maxDynamicFeeRate),
-								true,
-							]);
+							await assert.revert(exchanger.feeRateForExchange(sBTC, sETH), 'too volatile');
 							assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sBTC, sETH), [
 								maxDynamicFeeRate,
 								true,
 							]);
 							// reverse direction is the same
-							assert.deepEqual(await exchanger.feeRateForExchange(sETH, sBTC), [
-								bipsCrypto.add(maxDynamicFeeRate),
-								true,
-							]);
+							await assert.revert(exchanger.feeRateForExchange(sETH, sBTC), 'too volatile');
 							assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sETH, sBTC), [
 								maxDynamicFeeRate,
 								true,
@@ -810,10 +794,10 @@ contract('Exchanger (spec tests)', async accounts => {
 						await updateRates([sETH], [toUnit(105)]);
 						// (price diff ratio (5%)- threshold)
 						let expectedDynamicFee = toUnit(0.05).sub(threshold);
-						assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sETH), [
-							bipsCrypto.add(expectedDynamicFee),
-							false,
-						]);
+						assert.bnEqual(
+							await exchanger.feeRateForExchange(sUSD, sETH),
+							bipsCrypto.add(expectedDynamicFee)
+						);
 						assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sUSD, sETH), [
 							expectedDynamicFee,
 							false,
@@ -824,10 +808,10 @@ contract('Exchanger (spec tests)', async accounts => {
 						// next round
 						await updateRates([sETH], [toUnit(105)]);
 						expectedDynamicFee = multiplyDecimal(expectedDynamicFee, decay);
-						assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sETH), [
-							bipsCrypto.add(expectedDynamicFee),
-							false,
-						]);
+						assert.bnEqual(
+							await exchanger.feeRateForExchange(sUSD, sETH),
+							bipsCrypto.add(expectedDynamicFee)
+						);
 						assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sUSD, sETH), [
 							expectedDynamicFee,
 							false,
@@ -836,10 +820,10 @@ contract('Exchanger (spec tests)', async accounts => {
 						// another round
 						await updateRates([sETH], [toUnit(105)]);
 						expectedDynamicFee = multiplyDecimal(expectedDynamicFee, decay);
-						assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sETH), [
-							bipsCrypto.add(expectedDynamicFee),
-							false,
-						]);
+						assert.bnEqual(
+							await exchanger.feeRateForExchange(sUSD, sETH),
+							bipsCrypto.add(expectedDynamicFee)
+						);
 						assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sUSD, sETH), [
 							expectedDynamicFee,
 							false,
@@ -849,7 +833,7 @@ contract('Exchanger (spec tests)', async accounts => {
 						for (let i = 0; i < EXCHANGE_DYNAMIC_FEE_ROUNDS - 3; i++) {
 							await updateRates([sETH], [toUnit(105)]);
 						}
-						assert.deepEqual(await exchanger.feeRateForExchange(sUSD, sETH), [bipsCrypto, false]);
+						assert.bnEqual(await exchanger.feeRateForExchange(sUSD, sETH), bipsCrypto);
 						assert.deepEqual(await exchanger.dynamicFeeRateForExchange(sUSD, sETH), [0, false]);
 					});
 				});

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -546,7 +546,7 @@ const setupContract = async ({
 						instance,
 						mock,
 						fncName: 'feeRateForExchange',
-						returns: [toWei('0.0030'), '0'],
+						returns: [toWei('0.0030')],
 					}),
 				]);
 			} else if (mock === 'Issuer') {

--- a/test/publish/index.js
+++ b/test/publish/index.js
@@ -309,7 +309,7 @@ describe('publish scripts', () => {
 						assert.strictEqual(
 							(
 								await Exchanger.feeRateForExchange(toBytes32('(ignored)'), toBytes32(synth.name))
-							)[0].toString(),
+							).toString(),
 							rate
 						);
 					}
@@ -466,7 +466,7 @@ describe('publish scripts', () => {
 							assert.strictEqual(
 								(
 									await Exchanger.feeRateForExchange(toBytes32('(ignored)'), toBytes32('sUSD'))
-								)[0].toString(),
+								).toString(),
 								newRateForsUSD
 							);
 						});


### PR DESCRIPTION
The `exchangeRatesForExchange` function signature changed in the Alsephina release, this SIP proposes that the old function signature remains the same to prevent integrations that rely on the function from breaking.