### PR TITLE
Debtcache import excluded debt entries

### DIFF
--- a/contracts/BaseDebtCache.sol
+++ b/contracts/BaseDebtCache.sol
@@ -213,24 +213,30 @@ contract BaseDebtCache is Owned, MixinSystemSettings, IDebtCache {
     /// previous instance of the contract
     /// Also, in addition to this method it's possible to use recordExcludedDebtChange since
     /// it's accessible to owner in case additional adjustments are required
-    function importExcludedIssuedDebts(IDebtCache prevDebtCache) external onlyOwner {
+    function importExcludedIssuedDebts(IDebtCache prevDebtCache, IIssuer prevIssuer) external onlyOwner {
         // this can only be run once so that recorded debt deltas aren't accidentally
         // lost or double counted
-        require(excludedDebtImported == false, "import can only be run once");
+        require(!excludedDebtImported, "import can only be run once");
         excludedDebtImported = true;
 
-        bytes32[] memory currencyKeys = issuer().availableCurrencyKeys();
+        // get the currency keys from **previous** issuer, in case current issuer
+        // doesn't have all the synths at this point
+        // warning: if a synth won't be added to the current issuer before the next upgrade of this contract,
+        // its entry will be lost (because it won't be in the prevIssuer for next time).
+        // if for some reason this is a problem, it should be possible to use recordExcludedDebtChange() to amend
+        bytes32[] memory keys = prevIssuer.availableCurrencyKeys();
 
-        // query for previous records
-        uint[] memory prevExcludedDebts = prevDebtCache.excludedIssuedDebts(currencyKeys);
+        require(keys.length > 0, "previous Issuer has no synths");
+
+        // query for previous debt records
+        uint[] memory debts = prevDebtCache.excludedIssuedDebts(keys);
 
         // store the values
-        uint numKeys = currencyKeys.length;
-        for (uint i = 0; i < numKeys; i++) {
-            if (prevExcludedDebts[i] > 0) {
+        for (uint i = 0; i < keys.length; i++) {
+            if (debts[i] > 0) {
                 // adding the values instead of overwriting in case some deltas were recorded in this
                 // contract already (e.g. if the upgrade was not atomic)
-                _excludedIssuedDebt[currencyKeys[i]] = _excludedIssuedDebt[currencyKeys[i]].add(prevExcludedDebts[i]);
+                _excludedIssuedDebt[keys[i]] = _excludedIssuedDebt[keys[i]].add(debts[i]);
             }
         }
     }

--- a/contracts/BaseDebtCache.sol
+++ b/contracts/BaseDebtCache.sol
@@ -32,7 +32,7 @@ contract BaseDebtCache is Owned, MixinSystemSettings, IDebtCache {
     bool internal _cacheInvalid = true;
 
     // flag to ensure importing excluded debt is invoked only once
-    bool public excludedDebtImported = false; // public to avoid needing an event
+    bool public isInitialized = false; // public to avoid needing an event
 
     /* ========== ENCODED NAMES ========== */
 
@@ -216,8 +216,8 @@ contract BaseDebtCache is Owned, MixinSystemSettings, IDebtCache {
     function importExcludedIssuedDebts(IDebtCache prevDebtCache, IIssuer prevIssuer) external onlyOwner {
         // this can only be run once so that recorded debt deltas aren't accidentally
         // lost or double counted
-        require(!excludedDebtImported, "import can only be run once");
-        excludedDebtImported = true;
+        require(!isInitialized, "already initialized");
+        isInitialized = true;
 
         // get the currency keys from **previous** issuer, in case current issuer
         // doesn't have all the synths at this point

--- a/contracts/interfaces/IDebtCache.sol
+++ b/contracts/interfaces/IDebtCache.sol
@@ -13,6 +13,8 @@ interface IDebtCache {
 
     function cacheStale() external view returns (bool);
 
+    function excludedDebtImported() external view returns (bool);
+
     function currentSynthDebts(bytes32[] calldata currencyKeys)
         external
         view
@@ -39,6 +41,8 @@ interface IDebtCache {
             bool isStale
         );
 
+    function excludedIssuedDebts(bytes32[] calldata currencyKeys) external view returns (uint[] memory excludedDebts);
+
     // Mutative functions
 
     function updateCachedSynthDebts(bytes32[] calldata currencyKeys) external;
@@ -56,4 +60,6 @@ interface IDebtCache {
     function recordExcludedDebtChange(bytes32 currencyKey, int256 delta) external;
 
     function updateCachedsUSDDebt(int amount) external;
+
+    function importExcludedIssuedDebts(IDebtCache prevDebtCache) external;
 }

--- a/contracts/interfaces/IDebtCache.sol
+++ b/contracts/interfaces/IDebtCache.sol
@@ -1,5 +1,7 @@
 pragma solidity >=0.4.24;
 
+import "./IIssuer.sol";
+
 interface IDebtCache {
     // Views
 
@@ -61,5 +63,5 @@ interface IDebtCache {
 
     function updateCachedsUSDDebt(int amount) external;
 
-    function importExcludedIssuedDebts(IDebtCache prevDebtCache) external;
+    function importExcludedIssuedDebts(IDebtCache prevDebtCache, IIssuer prevIssuer) external;
 }

--- a/contracts/interfaces/IDebtCache.sol
+++ b/contracts/interfaces/IDebtCache.sol
@@ -15,7 +15,7 @@ interface IDebtCache {
 
     function cacheStale() external view returns (bool);
 
-    function excludedDebtImported() external view returns (bool);
+    function isInitialized() external view returns (bool);
 
     function currentSynthDebts(bytes32[] calldata currencyKeys)
         external

--- a/publish/src/commands/deploy/import-excluded-debt.js
+++ b/publish/src/commands/deploy/import-excluded-debt.js
@@ -14,19 +14,24 @@ module.exports = async ({ deployer, freshDeploy, runStep }) => {
 	}
 
 	const ExistingDebtCache = deployer.getExistingContract({ contract: 'DebtCache' });
+	const ExistingIssuer = deployer.getExistingContract({ contract: 'Issuer' });
 
 	if (ExistingDebtCache.address === DebtCache.address) {
 		console.log(gray(`No excluded debt required to import. Skipping.`));
 		return;
-	} else {
-		console.log(gray(`Existing DebtCache at: ${white(ExistingDebtCache.address)}`));
-		console.log(gray(`New DebtCache at: ${yellow(DebtCache.address)}`));
 	}
+
+	console.log(gray(`Existing DebtCache (source of debts) at: ${white(ExistingDebtCache.address)}`));
+	console.log(
+		gray(`Existing Issuer (source of currencyKeys) at: ${white(ExistingIssuer.address)}`)
+	);
+	console.log(gray(`New DebtCache at: ${yellow(DebtCache.address)}`));
+
 	await runStep({
 		contract: 'DebtCache',
 		target: DebtCache,
 		write: 'importExcludedIssuedDebts',
-		writeArg: [ExistingDebtCache.address],
+		writeArg: [ExistingDebtCache.address, ExistingIssuer.address],
 		comment: `Import excluded-debt records from existing DebtCache`,
 	});
 };

--- a/publish/src/commands/deploy/import-excluded-debt.js
+++ b/publish/src/commands/deploy/import-excluded-debt.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const { white, gray, yellow } = require('chalk');
+
+module.exports = async ({ deployer, freshDeploy, runStep }) => {
+	console.log(gray(`\n------ IMPORT DEBT-CACHE EXCLUDED-DEBT RECORDS ------\n`));
+
+	const { DebtCache } = deployer.deployedContracts;
+
+	// fresh deploys or no new debt cache mean this should be skipped
+	if (freshDeploy) {
+		console.log(gray(`freshDeploy - no excluded debt required to import. Skipping.`));
+		return;
+	}
+
+	const ExistingDebtCache = deployer.getExistingContract({ contract: 'DebtCache' });
+
+	if (ExistingDebtCache.address === DebtCache.address) {
+		console.log(gray(`No excluded debt required to import. Skipping.`));
+		return;
+	} else {
+		console.log(gray(`Existing DebtCache at: ${white(ExistingDebtCache.address)}`));
+		console.log(gray(`New DebtCache at: ${yellow(DebtCache.address)}`));
+	}
+	await runStep({
+		contract: 'DebtCache',
+		target: DebtCache,
+		write: 'importExcludedIssuedDebts',
+		writeArg: [ExistingDebtCache.address],
+		comment: `Import excluded-debt records from existing DebtCache`,
+	});
+};

--- a/publish/src/commands/deploy/index.js
+++ b/publish/src/commands/deploy/index.js
@@ -37,6 +37,7 @@ const generateSolidityOutput = require('./generate-solidity-output');
 const getDeployParameterFactory = require('./get-deploy-parameter-factory');
 const importAddresses = require('./import-addresses');
 const importFeePeriods = require('./import-fee-periods');
+const importExcludedDebt = require('./import-excluded-debt');
 const performSafetyChecks = require('./perform-safety-checks');
 const rebuildResolverCaches = require('./rebuild-resolver-caches');
 const rebuildLegacyResolverCaches = require('./rebuild-legacy-resolver-caches');
@@ -370,6 +371,12 @@ const deploy = async ({
 		systemSuspended,
 		useFork,
 		yes,
+	});
+
+	await importExcludedDebt({
+		deployer,
+		freshDeploy,
+		runStep,
 	});
 
 	await configureStandalonePriceFeeds({

--- a/test/contracts/DebtCache.js
+++ b/test/contracts/DebtCache.js
@@ -875,7 +875,7 @@ contract('DebtCache', async accounts => {
 				await newIssuer.addSynth(sETHContract.address, { from: owner });
 
 				// check uninitialised
-				assert.equal(await newDebtCache.excludedDebtImported(), false);
+				assert.equal(await newDebtCache.isInitialized(), false);
 
 				// import entries
 				await newDebtCache.importExcludedIssuedDebts(debtCache.address, issuer.address, {
@@ -883,7 +883,7 @@ contract('DebtCache', async accounts => {
 				});
 
 				// check initialised
-				assert.equal(await newDebtCache.excludedDebtImported(), true);
+				assert.equal(await newDebtCache.isInitialized(), true);
 
 				// check both entries are updated
 				// sAUD is not in new Issuer, but should be imported
@@ -897,7 +897,7 @@ contract('DebtCache', async accounts => {
 					newDebtCache.importExcludedIssuedDebts(debtCache.address, issuer.address, {
 						from: owner,
 					}),
-					'import can only be run once'
+					'already initialized'
 				);
 			});
 		});


### PR DESCRIPTION
Adds the ability to import excluded debt entries which is needed for upgrading to new DebtCache instance.