### PR TITLE
Add CONTRACT_NAME constants

### DIFF
--- a/contracts/EmptyFuturesMarketManager.sol
+++ b/contracts/EmptyFuturesMarketManager.sol
@@ -6,6 +6,8 @@ pragma solidity ^0.5.16;
 import "./interfaces/IFuturesMarketManager.sol";
 
 contract EmptyFuturesMarketManager is IFuturesMarketManager {
+    bytes32 public constant CONTRACT_NAME = "EmptyFuturesMarketManager";
+
     function markets(uint index, uint pageSize) external view returns (address[] memory) {
         index;
         pageSize;

--- a/contracts/FuturesMarketManager.sol
+++ b/contracts/FuturesMarketManager.sol
@@ -29,6 +29,8 @@ contract FuturesMarketManager is Owned, MixinResolver, IFuturesMarketManager {
 
     /* ========== ADDRESS RESOLVER CONFIGURATION ========== */
 
+    bytes32 public constant CONTRACT_NAME = "FuturesMarketManager";
+
     bytes32 internal constant SUSD = "sUSD";
     bytes32 internal constant CONTRACT_SYNTHSUSD = "SynthsUSD";
     bytes32 internal constant CONTRACT_FEEPOOL = "FeePool";

--- a/contracts/OneNetAggregatorDebtRatio.sol
+++ b/contracts/OneNetAggregatorDebtRatio.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.5.16;
 import "./BaseOneNetAggregator.sol";
 
 contract OneNetAggregatorDebtRatio is BaseOneNetAggregator {
-    
     bytes32 public constant CONTRACT_NAME = "OneNetAggregatorDebtRatio";
 
     constructor(AddressResolver _resolver) public BaseOneNetAggregator(_resolver) {}

--- a/contracts/OneNetAggregatorDebtRatio.sol
+++ b/contracts/OneNetAggregatorDebtRatio.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.5.16;
 import "./BaseOneNetAggregator.sol";
 
 contract OneNetAggregatorDebtRatio is BaseOneNetAggregator {
+    
+    bytes32 public constant CONTRACT_NAME = "OneNetAggregatorDebtRatio";
+
     constructor(AddressResolver _resolver) public BaseOneNetAggregator(_resolver) {}
 
     function getRoundData(uint80)

--- a/contracts/OneNetAggregatorIssuedSynths.sol
+++ b/contracts/OneNetAggregatorIssuedSynths.sol
@@ -3,10 +3,9 @@ pragma solidity ^0.5.16;
 import "./BaseOneNetAggregator.sol";
 
 contract OneNetAggregatorIssuedSynths is BaseOneNetAggregator {
+    bytes32 public constant CONTRACT_NAME = "OneNetAggregatorIssuedSynths";
 
-bytes32 public constant CONTRACT_NAME = "OneNetAggregatorIssuedSynths";
-
-constructor(AddressResolver _resolver) public BaseOneNetAggregator(_resolver) {}
+    constructor(AddressResolver _resolver) public BaseOneNetAggregator(_resolver) {}
 
     function getRoundData(uint80)
         public

--- a/contracts/OneNetAggregatorIssuedSynths.sol
+++ b/contracts/OneNetAggregatorIssuedSynths.sol
@@ -3,7 +3,10 @@ pragma solidity ^0.5.16;
 import "./BaseOneNetAggregator.sol";
 
 contract OneNetAggregatorIssuedSynths is BaseOneNetAggregator {
-    constructor(AddressResolver _resolver) public BaseOneNetAggregator(_resolver) {}
+
+bytes32 public constant CONTRACT_NAME = "OneNetAggregatorIssuedSynths";
+
+constructor(AddressResolver _resolver) public BaseOneNetAggregator(_resolver) {}
 
     function getRoundData(uint80)
         public

--- a/contracts/SynthetixBridgeToBase.sol
+++ b/contracts/SynthetixBridgeToBase.sol
@@ -11,6 +11,8 @@ import "@eth-optimism/contracts/iOVM/bridge/tokens/iOVM_L1TokenGateway.sol";
 
 contract SynthetixBridgeToBase is BaseSynthetixBridge, ISynthetixBridgeToBase, iOVM_L2DepositedToken {
     /* ========== ADDRESS RESOLVER CONFIGURATION ========== */
+    bytes32 public constant CONTRACT_NAME = "SynthetixBridgeToBase";
+
     bytes32 private constant CONTRACT_BASE_SYNTHETIXBRIDGETOOPTIMISM = "base:SynthetixBridgeToOptimism";
 
     // ========== CONSTRUCTOR ==========

--- a/contracts/SynthetixBridgeToOptimism.sol
+++ b/contracts/SynthetixBridgeToOptimism.sol
@@ -16,6 +16,9 @@ contract SynthetixBridgeToOptimism is BaseSynthetixBridge, ISynthetixBridgeToOpt
     using SafeERC20 for IERC20;
 
     /* ========== ADDRESS RESOLVER CONFIGURATION ========== */
+
+    bytes32 public constant CONTRACT_NAME = "SynthetixBridgeToOptimism";
+
     bytes32 private constant CONTRACT_ISSUER = "Issuer";
     bytes32 private constant CONTRACT_REWARDSDISTRIBUTION = "RewardsDistribution";
     bytes32 private constant CONTRACT_OVM_SYNTHETIXBRIDGETOBASE = "ovm:SynthetixBridgeToBase";

--- a/contracts/SystemStatus.sol
+++ b/contracts/SystemStatus.sol
@@ -17,6 +17,8 @@ contract SystemStatus is Owned, ISystemStatus {
     bytes32 public constant SECTION_SYNTH_EXCHANGE = "SynthExchange";
     bytes32 public constant SECTION_SYNTH = "Synth";
 
+    bytes32 public constant CONTRACT_NAME = "SystemStatus";
+
     Suspension public systemSuspension;
 
     Suspension public issuanceSuspension;


### PR DESCRIPTION
This PR updates the contracts that do not conform to the `bytes32 public constant CONTRACT_NAME` pattern.