### PR TITLE
Improving fork logic for issuance

### DIFF
--- a/contracts/Issuer.sol
+++ b/contracts/Issuer.sol
@@ -197,15 +197,13 @@ contract Issuer is Owned, MixinSystemSettings, IIssuer {
     }
 
     function _sharesForDebt(uint debtAmount) internal view returns (uint) {
-        (, int256 rawRatio, , , ) =
-            AggregatorV2V3Interface(requireAndGetAddress(CONTRACT_EXT_AGGREGATOR_DEBT_RATIO)).latestRoundData();
+        int256 rawRatio = AggregatorV2V3Interface(requireAndGetAddress(CONTRACT_EXT_AGGREGATOR_DEBT_RATIO)).latestAnswer();
 
         return rawRatio == 0 ? 0 : debtAmount.divideDecimalRoundPrecise(uint(rawRatio));
     }
 
     function _debtForShares(uint sharesAmount) internal view returns (uint) {
-        (, int256 rawRatio, , , ) =
-            AggregatorV2V3Interface(requireAndGetAddress(CONTRACT_EXT_AGGREGATOR_DEBT_RATIO)).latestRoundData();
+        int256 rawRatio = AggregatorV2V3Interface(requireAndGetAddress(CONTRACT_EXT_AGGREGATOR_DEBT_RATIO)).latestAnswer();
 
         return sharesAmount.multiplyDecimalRoundPrecise(uint(rawRatio));
     }
@@ -683,8 +681,10 @@ contract Issuer is Owned, MixinSystemSettings, IIssuer {
         }
     }
 
-    function setLastDebtRatio(uint256 ratio) external onlyOwner {
-        lastDebtRatio = ratio;
+    function updateLastDebtRatio() external onlyOwner {
+        int256 rawRatio = AggregatorV2V3Interface(requireAndGetAddress(CONTRACT_EXT_AGGREGATOR_DEBT_RATIO)).latestAnswer();
+
+        lastDebtRatio = uint(rawRatio);
     }
 
     /* ========== INTERNAL FUNCTIONS ========== */
@@ -842,8 +842,7 @@ contract Issuer is Owned, MixinSystemSettings, IIssuer {
     }
 
     function _verifyCircuitBreaker() internal returns (bool) {
-        (, int256 rawRatio, , , ) =
-            AggregatorV2V3Interface(requireAndGetAddress(CONTRACT_EXT_AGGREGATOR_DEBT_RATIO)).latestRoundData();
+        int256 rawRatio = AggregatorV2V3Interface(requireAndGetAddress(CONTRACT_EXT_AGGREGATOR_DEBT_RATIO)).latestAnswer();
 
         uint deviation = _calculateDeviation(lastDebtRatio, uint(rawRatio));
 

--- a/contracts/test-helpers/MockAggregatorV2V3.sol
+++ b/contracts/test-helpers/MockAggregatorV2V3.sol
@@ -111,11 +111,15 @@ contract MockAggregatorV2V3 is AggregatorV2V3Interface {
         return roundId;
     }
 
+    function latestAnswer() public view returns (int256) {
+        return getAnswer(roundId);
+    }
+
     function decimals() external view returns (uint8) {
         return keyDecimals;
     }
 
-    function getAnswer(uint256 _roundId) external view returns (int256) {
+    function getAnswer(uint256 _roundId) public view returns (int256) {
         Entry memory entry = entries[_roundId];
         return entry.answer;
     }

--- a/test/contracts/Issuer.js
+++ b/test/contracts/Issuer.js
@@ -160,7 +160,7 @@ contract('Issuer (via Synthetix)', async accounts => {
 				'removeSynth',
 				'removeSynths',
 				'setCurrentPeriodId',
-				'setLastDebtRatio',
+				'updateLastDebtRatio',
 			],
 		});
 	});
@@ -254,10 +254,10 @@ contract('Issuer (via Synthetix)', async accounts => {
 				reason: 'Must be fee pool',
 			});
 		});
-		it('setLastDebtRatio() cannot be invoked directly by a user', async () => {
+		it('updateLastDebtRatio() cannot be invoked directly by a user', async () => {
 			await onlyGivenAddressCanInvoke({
-				fnc: issuer.setLastDebtRatio,
-				args: [1234],
+				fnc: issuer.updateLastDebtRatio,
+				args: [],
 				accounts,
 				address: owner,
 				reason: 'Only the contract owner may perform this action',

--- a/test/integration/utils/issuance.js
+++ b/test/integration/utils/issuance.js
@@ -1,18 +1,32 @@
 const ethers = require('ethers');
 const { resumeIssuance } = require('./status');
-const { setSystemSetting } = require('./settings');
+const { getMockAggregatorContract } = require('../../utils/index')();
+const { toBytes32 } = require('../../..');
 
 async function ensureIssuance({ ctx }) {
 	if (ctx.fork) {
 		// Ensure issuance is not suspended for any reason
 		await resumeIssuance({ ctx });
+
 		// Note: if issuance has been suspended for some time, the circuit breaker could kick in for issuance,
-		// so up the ratio here
-		await setSystemSetting({
-			ctx,
-			settingName: 'priceDeviationThresholdFactor',
-			newValue: ethers.utils.parseEther('10'),
-		});
+		// so refresh the lastDebtRatio by reading what's on mainnet
+
+		const { AddressResolver } = ctx.contracts;
+
+		const AggregatorDebtRatio = new ethers.Contract(
+			await AddressResolver.getAddress(toBytes32('ext:AggregatorDebtRatio')),
+			getMockAggregatorContract().abi,
+			ctx.provider
+		);
+
+		const currentRatio = await AggregatorDebtRatio.latestAnswer();
+
+		let { Issuer } = ctx.contracts;
+
+		Issuer = Issuer.connect(ctx.users.owner);
+
+		const tx = await Issuer.setLastDebtRatio(currentRatio);
+		await tx.wait();
 	}
 }
 

--- a/test/integration/utils/issuance.js
+++ b/test/integration/utils/issuance.js
@@ -25,7 +25,9 @@ async function ensureIssuance({ ctx }) {
 
 		Issuer = Issuer.connect(ctx.users.owner);
 
+		// TODO - once Issuer changes in an upcoming SIP, the below should change to updateLastDebtRatio()
 		const tx = await Issuer.setLastDebtRatio(currentRatio);
+
 		await tx.wait();
 	}
 }

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -528,8 +528,7 @@ module.exports = ({ web3 } = {}) => {
 		return latestSolTimestamp > earliestCompiledTimestamp;
 	};
 
-	// create a factory to deploy mock price aggregators
-	const createMockAggregatorFactory = async account => {
+	const getMockAggregatorContract = () => {
 		const { compiled } = loadCompiledFiles({ buildPath });
 		const {
 			abi,
@@ -537,6 +536,12 @@ module.exports = ({ web3 } = {}) => {
 				bytecode: { object: bytecode },
 			},
 		} = compiled['MockAggregatorV2V3'];
+		return { abi, bytecode };
+	};
+
+	// create a factory to deploy mock price aggregators
+	const createMockAggregatorFactory = async account => {
+		const { abi, bytecode } = getMockAggregatorContract();
 		return new ethers.ContractFactory(abi, bytecode, account);
 	};
 
@@ -620,6 +625,7 @@ module.exports = ({ web3 } = {}) => {
 		loadLocalUsers,
 		isCompileRequired,
 		createMockAggregatorFactory,
+		getMockAggregatorContract,
 
 		setupProvider,
 		getContract,


### PR DESCRIPTION
* Improving fork logic for issuance to actually update the `setLastDebtRatio` owner function
* Cleanup logic in `Issuer` to only fetch answer not the whole round
* Change `setLastDebtRatio` to `updateDebtRatio` - fetching the latest on-chain from the aggregator (needs to be done after rebuildCache so can't be in constructor)
* Updating deploy script to invoke `updateDebtRatio` function as needed