### PR TITLE
Fix Exchanger Unit Tests

### DIFF
--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -2903,7 +2903,7 @@ contract('Exchanger (spec tests)', async accounts => {
 								amountIn,
 								sETH,
 								toBytes32(),
-								toUnit('.4975'),
+								toUnit('.495'),
 								{
 									from: account1,
 								}


### PR DESCRIPTION
There was an interaction between the changes in #1667 and #1749 which led to a unit test failure. With the PR for SIP-222, the relevant exchange fees were doubled, which resulted in a smaller amount of sETH being provided in the failing test.