### PR TITLE
SIP-236: fix exchange before reclaim risk

### DIFF
--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -457,13 +457,7 @@ contract Exchanger is Owned, MixinSystemSettings, IExchanger {
             entry.roundIdForDest
         );
 
-        _ensureCanExchangeAtRound(
-            sourceCurrencyKey,
-            sourceAmountAfterSettlement,
-            destinationCurrencyKey,
-            entry.roundIdForSrc,
-            entry.roundIdForDest
-        );
+        _ensureCanExchangeAtRound(sourceCurrencyKey, destinationCurrencyKey, entry.roundIdForSrc, entry.roundIdForDest);
 
         // SIP-65: Decentralized Circuit Breaker
         // mutative call to suspend system if the rate is invalid
@@ -644,13 +638,11 @@ contract Exchanger is Owned, MixinSystemSettings, IExchanger {
 
     function _ensureCanExchangeAtRound(
         bytes32 sourceCurrencyKey,
-        uint sourceAmount,
         bytes32 destinationCurrencyKey,
         uint roundIdForSrc,
         uint roundIdForDest
     ) internal view {
         require(sourceCurrencyKey != destinationCurrencyKey, "Can't be same synth");
-        require(sourceAmount > 0, "Zero amount");
 
         bytes32[] memory synthKeys = new bytes32[](2);
         synthKeys[0] = sourceCurrencyKey;

--- a/contracts/Exchanger.sol
+++ b/contracts/Exchanger.sol
@@ -433,6 +433,8 @@ contract Exchanger is Owned, MixinSystemSettings, IExchanger {
             IVirtualSynth vSynth
         )
     {
+        require(sourceAmount > 0, "Zero amount");
+
         // Using struct to resolve stack too deep error
         IExchanger.ExchangeEntry memory entry;
 

--- a/contracts/ExchangerWithFeeRecAlternatives.sol
+++ b/contracts/ExchangerWithFeeRecAlternatives.sol
@@ -186,7 +186,7 @@ contract ExchangerWithFeeRecAlternatives is MinimalProxyFactory, Exchanger {
         } else {
             // Otherwise, convert source to sUSD value
             (uint amountReceivedInUSD, uint sUsdFee, , , , ) =
-                _getAmountsForAtomicExchangeMinusFees(sourceAmount, sourceCurrencyKey, sUSD);
+                _getAmountsForAtomicExchangeMinusFees(sourceAmountAfterSettlement, sourceCurrencyKey, sUSD);
             sourceSusdValue = amountReceivedInUSD.add(sUsdFee);
         }
 

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -3389,7 +3389,11 @@ contract('Exchanger (spec tests)', async accounts => {
 								describe('exchanges for sAUD -> sEUR', () => {
 									beforeEach('exchange', async () => {
 										expectedReceiveAmount = (
-											await exchanger.getAmountsForAtomicExchange(adjustedTransferBalance, sAUD, sEUR)
+											await exchanger.getAmountsForAtomicExchange(
+												adjustedTransferBalance,
+												sAUD,
+												sEUR
+											)
 										)[0];
 
 										await synthetix.exchangeAtomically(sAUD, balanceBefore, sEUR, toBytes32(), 0, {

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -1215,6 +1215,35 @@ contract('Exchanger (spec tests)', async accounts => {
 														newRate: divideDecimal(1, 4),
 													});
 												});
+
+												describe.only('when full exchange() is invoked before settle', () => {
+													let expectedAmountReceived;
+													beforeEach(async () => {
+														expectedAmountReceived = (
+															await exchanger.getAmountsForExchange(
+																srcBalanceBeforeExchange.sub(expectedSettlement.reclaimAmount),
+																sEUR,
+																sBTC
+															)
+														)[0];
+
+														await synthetix.exchange(
+															sEUR,
+															await sEURContract.balanceOf(account1),
+															sBTC,
+															{
+																from: account1,
+															}
+														);
+													});
+													it('then exchanges with settled amount', async () => {
+														assert.bnEqual(
+															await sBTCContract.balanceOf(account1),
+															expectedAmountReceived
+														);
+													});
+												});
+
 												describe('when settle() is invoked', () => {
 													let transaction;
 													beforeEach(async () => {

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -1450,7 +1450,7 @@ contract('Exchanger (spec tests)', async accounts => {
 													await fastForward(60);
 												});
 
-												describe.only('when full exchange() is invoked before settle', () => {
+												describe('when full exchange() is invoked before settle', () => {
 													let expectedAmountReceived;
 													beforeEach(async () => {
 														const srcBalanceBeforeExchange = await sEURContract.balanceOf(account1);

--- a/test/contracts/Exchanger.spec.js
+++ b/test/contracts/Exchanger.spec.js
@@ -3348,7 +3348,7 @@ contract('Exchanger (spec tests)', async accounts => {
 						});
 					});
 
-					function settlementCase(newPrice) {
+					const settlementCase = newPrice => {
 						describe(`price of sAUD changes to ${newPrice} immediately after trade`, () => {
 							let balanceBefore;
 							let adjustedTransferBalance;
@@ -3376,7 +3376,7 @@ contract('Exchanger (spec tests)', async accounts => {
 								);
 							});
 
-							beforeEach('change', async () => {
+							beforeEach(`AUD price changes to ${newPrice}`, async () => {
 								await fastForward(5);
 								await updateRates([sAUD], [newPrice]);
 							});
@@ -3412,7 +3412,7 @@ contract('Exchanger (spec tests)', async accounts => {
 								});
 							});
 						});
-					}
+					};
 
 					settlementCase(toUnit('0.7'));
 					settlementCase(toUnit('0.8'));


### PR DESCRIPTION
`Exchanger.exchange` does not use the post-reclaim amount to calculate the amount of exchange for the
user trade. This leads to the user being left with more of their source token then they should
have had.

this PR resolves this problem by ensuring amounts used for exchange are
calculated for the amount after fee reclamation has occured. It also adds associated tests.

SIP to be assigned pending