### PR TITLE
fix kovan futures: add axs feed, remove luna mkt

### DIFF
--- a/publish/deployed/kovan-ovm/feeds.json
+++ b/publish/deployed/kovan-ovm/feeds.json
@@ -54,5 +54,9 @@
 	"EUR": {
 		"asset": "EUR",
 		"feed": "0x7e3786902Bf8EBC196d9a5f06Da4d1Bc0E62D432"
+	},
+	"AXS": {
+		"asset": "AXS",
+		"feed": "0xB0924e98CAFC880ed81F6A4cA63FD61006D1f8A0"
 	}
 }

--- a/publish/deployed/kovan-ovm/futures-markets.json
+++ b/publish/deployed/kovan-ovm/futures-markets.json
@@ -182,20 +182,6 @@
 		"paused": false
 	},
 	{
-		"marketKey": "sLUNA",
-		"asset": "LUNA",
-		"takerFee": "0.0025",
-		"makerFee": "0.002",
-		"takerFeeNextPrice": "0.001",
-		"makerFeeNextPrice": "0.0",
-		"nextPriceConfirmWindow": "2",
-		"maxLeverage": "10",
-		"maxMarketValueUSD": "2000000",
-		"maxFundingRate": "0.1",
-		"skewScaleUSD": "300000000",
-		"paused": false
-	},
-	{
 		"marketKey": "sEUR",
 		"asset": "EUR",
 		"takerFee": "0.0015",


### PR DESCRIPTION
Futures summary views were broken because feeds were not added for AXS and LUNA.

Changes in config:
- add feed for AXS into feeds json
- remove LUNA from markets json

Changes on chain:
- add feed for AXS to rates contract
- remove LUNA market from futures manager