### PR TITLE
removes check for faulty setup in shorts integ test

### DIFF
--- a/test/integration/behaviors/short.behavior.js
+++ b/test/integration/behaviors/short.behavior.js
@@ -5,10 +5,7 @@ const {
 } = ethers;
 const { approveIfNeeded } = require('../utils/approve');
 const { assert } = require('../../contracts/common');
-const {
-	toBytes32,
-	constants: { ZERO_BYTES32 },
-} = require('../../../index');
+const { toBytes32 } = require('../../../index');
 const { getLoan, getShortInteractionDelay, setShortInteractionDelay } = require('../utils/loans');
 const { ensureBalance } = require('../utils/balances');
 const { exchangeSynths } = require('../utils/exchanging');
@@ -95,21 +92,14 @@ function itCanOpenAndCloseShort({ ctx }) {
 					});
 
 					before('add the shortable synths if needed', async () => {
-						const synthToTest = await CollateralShort.synthsByKey(shortableSynth);
+						await CollateralShort.connect(owner).addSynths(
+							[toBytes32(`SynthsETH`)],
+							[shortableSynth]
+						);
 
-						if (synthToTest !== ZERO_BYTES32) {
-							await CollateralShort.connect(owner).addSynths(
-								[toBytes32(`SynthsETH`)],
-								[shortableSynth]
-							);
+						await CollateralManager.addSynths([toBytes32(`SynthsETH`)], [shortableSynth]);
 
-							await CollateralManager.addSynths([toBytes32(`SynthsETH`)], [shortableSynth]);
-
-							await CollateralManager.addShortableSynths(
-								[toBytes32(`SynthsETH`)],
-								[shortableSynth]
-							);
-						}
+						await CollateralManager.addShortableSynths([toBytes32(`SynthsETH`)], [shortableSynth]);
 					});
 
 					before('approve the synths for collateral short', async () => {


### PR DESCRIPTION
A slight change of https://github.com/Synthetixio/synthetix/pull/1803 so that the setup makes more sense for the reader / maintainer.

As it is right this check does the setup if the setup is synth is "already setup", and "doesn't do setup if no setup was done", which is weird (and not explained in the comment).