### PR TITLE
feat: Conform SynthetixBridge contracts with Optimism standard bridges

### DIFF
--- a/contracts/SynthetixBridgeToBase.sol
+++ b/contracts/SynthetixBridgeToBase.sol
@@ -54,11 +54,11 @@ contract SynthetixBridgeToBase is BaseSynthetixBridge, ISynthetixBridgeToBase, i
     // Overloaded function name to conform with Optimism's standard bridge interface which can be found here:
     //     - import "@eth-optimism/contracts/L2/messaging/IL2ERC20Bridge.sol"
     function withdrawTo(
-        address _,
+        address _l2Token,
         address to,
         uint amount,
-        uint32 _,
-        bytes calldata _
+        uint32 _l1Gas,
+        bytes calldata _data
     ) external requireInitiationActive {
         _initiateWithdraw(to, amount);
     }

--- a/contracts/SynthetixBridgeToBase.sol
+++ b/contracts/SynthetixBridgeToBase.sol
@@ -51,6 +51,18 @@ contract SynthetixBridgeToBase is BaseSynthetixBridge, ISynthetixBridgeToBase, i
         _initiateWithdraw(to, amount);
     }
 
+    // Overloaded function name to conform with Optimism's standard bridge interface which can be found here:
+    //     - import "@eth-optimism/contracts/L2/messaging/IL2ERC20Bridge.sol"
+    function withdrawTo(
+        address _,
+        address to,
+        uint amount,
+        uint32 _,
+        bytes calldata _
+    ) external requireInitiationActive {
+        _initiateWithdraw(to, amount);
+    }
+
     function _initiateWithdraw(address to, uint amount) private {
         require(synthetix().transferableSynthetix(msg.sender) >= amount, "Not enough transferable SNX");
 

--- a/contracts/SynthetixBridgeToOptimism.sol
+++ b/contracts/SynthetixBridgeToOptimism.sol
@@ -93,12 +93,12 @@ contract SynthetixBridgeToOptimism is BaseSynthetixBridge, ISynthetixBridgeToOpt
     // Overloaded function name to conform with Optimism's standard bridge interface which can be found here:
     //     - import "@eth-optimism/contracts/L1/messaging/IL1StandardBridge.sol";
     function depositERC20To(
-        address _,
-        address _,
+        address _l1Token,
+        address _l2Token,
         address to,
         uint256 amount,
-        uint32 _,
-        bytes calldata _
+        uint32 _l2Gas,
+        bytes calldata _data
     ) external requireInitiationActive {
         _initiateDeposit(to, amount);
     }

--- a/contracts/SynthetixBridgeToOptimism.sol
+++ b/contracts/SynthetixBridgeToOptimism.sol
@@ -90,6 +90,19 @@ contract SynthetixBridgeToOptimism is BaseSynthetixBridge, ISynthetixBridgeToOpt
         _initiateDeposit(to, amount);
     }
 
+    // Overloaded function name to conform with Optimism's standard bridge interface which can be found here:
+    //     - import "@eth-optimism/contracts/L1/messaging/IL1StandardBridge.sol";
+    function depositERC20To(
+        address _,
+        address _,
+        address to,
+        uint256 amount,
+        uint32 _,
+        bytes calldata _
+    ) external requireInitiationActive {
+        _initiateDeposit(to, amount);
+    }
+
     function migrateEscrow(uint256[][] memory entryIDs) public requireInitiationActive requireZeroDebt {
         _migrateEscrow(entryIDs);
     }


### PR DESCRIPTION
Optimism L1 standard bridge interface: https://github.com/ethereum-optimism/optimism/blob/c258acd495f884f10c3da82510a8f378222f4f92/packages/contracts/contracts/L1/messaging/IL1StandardBridge.sol

Optimism L2 standard bridge interface: https://github.com/ethereum-optimism/optimism/blob/c258acd495f884f10c3da82510a8f378222f4f92/packages/contracts/contracts/L2/messaging/IL2ERC20Bridge.sol

Adding these functions to future bridge interface will allow cross-chain Bridges like Across for arbitrary ERC20's to support tokens like SNX that have custom bridges on Optimism

For example, DAI has a custom Optimism bridge that does implement the same interface: https://github.com/makerdao/optimism-dai-bridge/blob/master/contracts/l2/L2DAITokenBridge.sol#L92