### PR TITLE
ci: use node@LTS(16.15)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
   job-audit:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-sec-tools:16.14-ubuntu
+      - image: synthetixio/docker-sec-tools:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -33,7 +33,7 @@ jobs:
   job-compile:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-node:16.14-ubuntu
+      - image: synthetixio/docker-node:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -45,7 +45,7 @@ jobs:
   job-fork-tests-ovm:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-node:16.14-ubuntu
+      - image: synthetixio/docker-node:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -74,7 +74,7 @@ jobs:
   job-fork-tests:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-node:16.14-ubuntu
+      - image: synthetixio/docker-node:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -152,7 +152,7 @@ jobs:
   job-lint:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-node:16.14-ubuntu
+      - image: synthetixio/docker-node:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -164,7 +164,7 @@ jobs:
   job-pack-browser:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-node:16.14-ubuntu
+      - image: synthetixio/docker-node:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -178,7 +178,7 @@ jobs:
   job-prepare:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-node:16.14-ubuntu
+      - image: synthetixio/docker-node:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -208,7 +208,7 @@ jobs:
   job-simulate-release:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-node:16.14-ubuntu
+      - image: synthetixio/docker-node:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -235,7 +235,7 @@ jobs:
   job-static-analysis:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-node:16.14-ubuntu
+      - image: synthetixio/docker-node:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -255,7 +255,7 @@ jobs:
   job-test-deploy-script:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-node:16.14-ubuntu
+      - image: synthetixio/docker-node:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -281,7 +281,7 @@ jobs:
   job-unit-tests-coverage-report:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-sec-tools:16.14-ubuntu
+      - image: synthetixio/docker-sec-tools:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -297,7 +297,7 @@ jobs:
   job-unit-tests-coverage:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-node:16.14-ubuntu
+      - image: synthetixio/docker-node:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -327,7 +327,7 @@ jobs:
   job-unit-tests-gas-report:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-node:16.14-ubuntu
+      - image: synthetixio/docker-node:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -348,7 +348,7 @@ jobs:
   job-unit-tests:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-node:16.14-ubuntu
+      - image: synthetixio/docker-node:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -384,7 +384,7 @@ jobs:
   job-validate-deployments:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-node:16.14-ubuntu
+      - image: synthetixio/docker-node:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
@@ -403,7 +403,7 @@ jobs:
   job-validate-etherscan:
     working_directory: ~/repo
     docker:
-      - image: synthetixio/docker-node:16.14-ubuntu
+      - image: synthetixio/docker-node:16.15-ubuntu
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN

--- a/.circleci/src/snippets/job-header-node.yml
+++ b/.circleci/src/snippets/job-header-node.yml
@@ -1,6 +1,6 @@
 working_directory: ~/repo
 docker:
-  - image: synthetixio/docker-node:16.14-ubuntu
+  - image: synthetixio/docker-node:16.15-ubuntu
     auth:
       username: $DOCKERHUB_USERNAME
       password: $DOCKERHUB_TOKEN

--- a/.circleci/src/snippets/job-header-sec-tools.yml
+++ b/.circleci/src/snippets/job-header-sec-tools.yml
@@ -1,6 +1,6 @@
 working_directory: ~/repo
 docker:
-  - image: synthetixio/docker-sec-tools:16.14-ubuntu
+  - image: synthetixio/docker-sec-tools:16.15-ubuntu
     auth:
       username: $DOCKERHUB_USERNAME
       password: $DOCKERHUB_TOKEN

--- a/.github/workflows/slither-analysis.yml
+++ b/.github/workflows/slither-analysis.yml
@@ -30,12 +30,16 @@ jobs:
         id: npm-cache-dir
         run: echo "::set-output name=dir::$(npm config get cache)"
 
+      - name: Get node version
+        id: node-version
+        run: echo "::set-output name=version::$(node --version)"
+
       - uses: actions/cache@c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d # pin@v3.0.4
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-ubuntu-16_15-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-ubuntu-${{ steps.node-version.outputs.version }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-ubuntu-16_15-
+            ${{ runner.os }}-ubuntu-${{ steps.node-version.outputs.version }}-
 
       - name: Install dependencies
         run: npm ci --prefer-offline

--- a/.github/workflows/slither-analysis.yml
+++ b/.github/workflows/slither-analysis.yml
@@ -21,16 +21,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # pin@v2
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # pin@v3.0.2
 
       - name: Set npm cache directory
         run: npm config set cache .npm-cache --global
         continue-on-error: true
 
-      - uses: actions/cache@136d96b4aee02b1f0de3ba493b1d47135042d9c0 # pin@v3
       - name: Get npm cache directory
         id: npm-cache-dir
         run: echo "::set-output name=dir::$(npm config get cache)"
+
+      - uses: actions/cache@c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d # pin@v3.0.4
         with:
           path: |
             .npm-cache

--- a/.github/workflows/slither-analysis.yml
+++ b/.github/workflows/slither-analysis.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: ghcr.io/synthetixio/docker-sec-tools/ubuntu:16.14
+      image: ghcr.io/synthetixio/docker-sec-tools/ubuntu:16.15
       credentials:
         username: synthetixio
         password: ${{ secrets.GH_PACKAGES_READ_ONLY }}

--- a/.github/workflows/slither-analysis.yml
+++ b/.github/workflows/slither-analysis.yml
@@ -28,6 +28,9 @@ jobs:
         continue-on-error: true
 
       - uses: actions/cache@136d96b4aee02b1f0de3ba493b1d47135042d9c0 # pin@v3
+      - name: Get npm cache directory
+        id: npm-cache-dir
+        run: echo "::set-output name=dir::$(npm config get cache)"
         with:
           path: |
             .npm-cache

--- a/.github/workflows/slither-analysis.yml
+++ b/.github/workflows/slither-analysis.yml
@@ -31,19 +31,13 @@ jobs:
         run: echo "::set-output name=dir::$(npm config get cache)"
 
       - uses: actions/cache@c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d # pin@v3.0.4
-        id: cache-npm
-        env:
-          cache-name: cache-node-modules
         with:
           path: ${{ steps.npm-cache-dir.outputs.dir }}
-          key: ${{ runner.os }}-ubuntu-16_15-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          key: ${{ runner.os }}-ubuntu-16_15-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-ubuntu-16_15-${{ env.cache-name }}-
             ${{ runner.os }}-ubuntu-16_15-
 
       - name: Install dependencies
-        # run only if cache is not present
-        if: ${{ steps.cache-npm.outputs.cache-hit == 'false' }}
         run: npm ci --prefer-offline
 
       - name: Run slither

--- a/.github/workflows/slither-analysis.yml
+++ b/.github/workflows/slither-analysis.yml
@@ -25,23 +25,25 @@ jobs:
 
       - name: Set npm cache directory
         run: npm config set cache .npm-cache --global
-        continue-on-error: true
 
       - name: Get npm cache directory
         id: npm-cache-dir
         run: echo "::set-output name=dir::$(npm config get cache)"
 
       - uses: actions/cache@c3f1317a9e7b1ef106c153ac8c0f00fed3ddbc0d # pin@v3.0.4
+        id: cache-npm
+        env:
+          cache-name: cache-node-modules
         with:
-          path: |
-            .npm-cache
-            node_modules
-          key: ${{ runner.os }}-ubuntu-${{ hashFiles('**/package-lock.json') }}
+          path: ${{ steps.npm-cache-dir.outputs.dir }}
+          key: ${{ runner.os }}-ubuntu-16_15-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            ${{ runner.os }}-ubuntu-
-        continue-on-error: true
+            ${{ runner.os }}-ubuntu-16_15-${{ env.cache-name }}-
+            ${{ runner.os }}-ubuntu-16_15-
 
       - name: Install dependencies
+        # run only if cache is not present
+        if: ${{ steps.cache-npm.outputs.cache-hit == 'false' }}
         run: npm ci --prefer-offline
 
       - name: Run slither


### PR DESCRIPTION
changes:
- use node@lts (16.15)
- fix failing pipeline (slither)
- improve caching to work cross-platform
- consider node version while creating cache dir

Signed-off-by: Jakub Mucha <jakub.mucha@icloud.com>