### PR TITLE
adding debt-ratio futures market

### DIFF
--- a/publish/assets.json
+++ b/publish/assets.json
@@ -452,5 +452,11 @@
 		"category": "crypto",
 		"sign": "",
 		"description": "Axie Infinity"
+	},
+	"DebtRatio": {
+		"asset": "DebtRatio",
+		"category": "crypto",
+		"sign": "",
+		"description": "Synthetix Aggregator Debt Ratio"
 	}
 }

--- a/publish/deployed/mainnet-ovm/feeds.json
+++ b/publish/deployed/mainnet-ovm/feeds.json
@@ -58,5 +58,9 @@
 	"DYDX": {
 		"asset": "DYDX",
 		"feed": "0xee35A95c9a064491531493D8b380bC40A4CCd0Da"
+	},
+	"DebtRatio": {
+		"asset": "DebtRatio",
+		"feed": "0x94A178f2c480D14F8CdDa908D173d7a73F779cb7"
 	}
 }

--- a/publish/deployed/mainnet-ovm/futures-markets.json
+++ b/publish/deployed/mainnet-ovm/futures-markets.json
@@ -180,5 +180,19 @@
 		"maxFundingRate": "0.1",
 		"skewScaleUSD": "10000000",
 		"paused": false
+	},
+	{
+		"marketKey": "sDebtRatio",
+		"asset": "DebtRatio",
+		"takerFee": "0.0060",
+		"makerFee": "0.0060",
+		"takerFeeNextPrice": "0.0015",
+		"makerFeeNextPrice": "0.0015",
+		"nextPriceConfirmWindow": "2",
+		"maxLeverage": "10",
+		"maxMarketValueUSD": "1000000",
+		"maxFundingRate": "0.1",
+		"skewScaleUSD": "5000000",
+		"paused": true
 	}
 ]


### PR DESCRIPTION
Adding the configs for https://sips.synthetix.io/sips/sip-257/

Didn't add testnet feed and config, since it doesn't look like they exist yet.