### PR TITLE
Make very minor copy changes to require err msgs

### DIFF
--- a/contracts/PerpsEngineV2Base.sol
+++ b/contracts/PerpsEngineV2Base.sol
@@ -145,7 +145,7 @@ contract PerpsEngineV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2, IPerpsEn
             // market was previously initialized, ensure it was initialized to the same baseAsset
             // this behavior is important in order to allow manager to add previously removed markets
             // or for adding markets to a new manager that will call this method.
-            require(market.baseAsset == baseAsset, "initialized with different asset");
+            require(market.baseAsset == baseAsset, "Initialized with different asset");
         }
     }
 
@@ -389,7 +389,7 @@ contract PerpsEngineV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2, IPerpsEn
         uint price
     ) internal {
         // prevent creating empty positions
-        require(lockAmount != 0 || burnAmount != 0 || transferAmount != 0, "zero modification amounts");
+        require(lockAmount != 0 || burnAmount != 0 || transferAmount != 0, "Zero modification amounts");
         // this ensures position is initialized so that it has the correct id (instead of zero) for events
         Position memory oldPosition = _stateMutative().positionWithInit(marketKey, account);
 
@@ -398,7 +398,7 @@ contract PerpsEngineV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2, IPerpsEn
         // but the old + delta - burn must be positive. If it's negative we're either unlocking
         // too much, or burning too much.
         int newLocked = int(oldPosition.lockedMargin).add(lockAmount).sub(int(burnAmount));
-        require(newLocked >= 0, "new locked margin negative");
+        require(newLocked >= 0, "New locked margin negative");
 
         // adding the unlocked margin to the margin delta
         // subtraction because lockedDelta is w.r.t to locked margin, so is negative w.r.t to margin
@@ -551,7 +551,7 @@ contract PerpsEngineV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2, IPerpsEn
 
     function _marketScalars(bytes32 marketKey) internal view returns (MarketScalars memory market) {
         market = _stateViews().marketScalars(marketKey);
-        require(market.baseAsset != bytes32(0), "market not initialised");
+        require(market.baseAsset != bytes32(0), "Market not initialised");
         return market;
     }
 
@@ -568,9 +568,9 @@ contract PerpsEngineV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2, IPerpsEn
             return 0;
         }
         // marketSize is in baseAsset units so we need to convert from USD units
-        require(price > 0, "price can't be zero");
+        require(price > 0, "Price can't be zero");
         uint skewScaleBaseAsset = _skewScaleUSD(marketKey).divideDecimal(price);
-        require(skewScaleBaseAsset != 0, "skewScale is zero"); // don't divide by zero
+        require(skewScaleBaseAsset != 0, "Skew scale is zero"); // don't divide by zero
         return skew.divideDecimal(int(skewScaleBaseAsset));
     }
 
@@ -627,7 +627,7 @@ contract PerpsEngineV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2, IPerpsEn
 
         The last term: sum( margin-deposit - q * ( last-price + initial-funding ) ) being the position debt correction
             that is tracked with each position change using this method.
-        
+
         The first term ( skew * (price + funding) ) and total debt calculation using current skew, price, and funding
         is calculated globally in _marketDebt().
 

--- a/contracts/PerpsManagerV2.sol
+++ b/contracts/PerpsManagerV2.sol
@@ -160,7 +160,7 @@ contract PerpsManagerV2 is PerpsManagerV2ConfigSettersMixin, IPerpsManagerV2, IP
     /// Note: checks V1 markets and ensures that it doesn't add a colliding marketKey
     function addMarkets(bytes32[] calldata marketKeys, bytes32[] calldata assets) external onlyOwner {
         uint numOfMarkets = marketKeys.length;
-        require(marketKeys.length == assets.length, "length of marketKeys != assets");
+        require(marketKeys.length == assets.length, "Length of marketKeys != assets");
         IFuturesMarketManager futuresManager = IFuturesMarketManager(address(_futuresManager()));
         // iterate and add
         IPerpsEngineV2Internal engineMutative = _perpsEngineV2Mutative();

--- a/contracts/PerpsManagerV2ConfigSettersMixin.sol
+++ b/contracts/PerpsManagerV2ConfigSettersMixin.sol
@@ -129,12 +129,12 @@ contract PerpsManagerV2ConfigSettersMixin is Owned, PerpsConfigGettersV2Mixin, I
     }
 
     function setBaseFee(bytes32 marketKey, uint _baseFee) public onlyOwner {
-        require(_baseFee <= 1e18, "base fee greater than 1");
+        require(_baseFee <= 1e18, "Base fee greater than 1");
         _setParameter(marketKey, PARAMETER_BASE_FEE, _baseFee);
     }
 
     function setBaseFeeNextPrice(bytes32 marketKey, uint _baseFeeNextPrice) public onlyOwner {
-        require(_baseFeeNextPrice <= 1e18, "base fee greater than 1");
+        require(_baseFeeNextPrice <= 1e18, "Base fee greater than 1");
         _setParameter(marketKey, PARAMETER_BASE_FEE_NEXT_PRICE, _baseFeeNextPrice);
     }
 
@@ -162,7 +162,7 @@ contract PerpsManagerV2ConfigSettersMixin is Owned, PerpsConfigGettersV2Mixin, I
     }
 
     function setSkewScaleUSD(bytes32 marketKey, uint _skewScaleUSD) public onlyOwner {
-        require(_skewScaleUSD > 0, "cannot set skew scale 0");
+        require(_skewScaleUSD > 0, "Cannot set skew scale 0");
         _recomputeFunding(marketKey);
         _setParameter(marketKey, PARAMETER_MIN_SKEW_SCALE, _skewScaleUSD);
     }
@@ -187,7 +187,7 @@ contract PerpsManagerV2ConfigSettersMixin is Owned, PerpsConfigGettersV2Mixin, I
     }
 
     function setMinKeeperFee(uint _sUSD) external onlyOwner {
-        require(_sUSD <= _minInitialMargin(), "min margin < liquidation fee");
+        require(_sUSD <= _minInitialMargin(), "Min margin < liquidation fee");
         _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_KEEPER_FEE, _sUSD);
         emit MinKeeperFeeUpdated(_sUSD);
     }
@@ -203,7 +203,7 @@ contract PerpsManagerV2ConfigSettersMixin is Owned, PerpsConfigGettersV2Mixin, I
     }
 
     function setMinInitialMargin(uint _minMargin) external onlyOwner {
-        require(_minKeeperFee() <= _minMargin, "min margin < liquidation fee");
+        require(_minKeeperFee() <= _minMargin, "Min margin < liquidation fee");
         _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_INITIAL_MARGIN, _minMargin);
         emit MinInitialMarginUpdated(_minMargin);
     }

--- a/contracts/PerpsStorageV2.sol
+++ b/contracts/PerpsStorageV2.sol
@@ -33,7 +33,7 @@ contract PerpsStorageV2 is IPerpsStorageV2External, IPerpsStorageV2Internal, IPe
     /* ========== MODIFIERS ========== */
 
     modifier withMarket(bytes32 marketKey) {
-        require(marketScalars[marketKey].baseAsset != bytes32(0), "market not initialised");
+        require(marketScalars[marketKey].baseAsset != bytes32(0), "Market not initialised");
         _;
     }
 
@@ -56,15 +56,15 @@ contract PerpsStorageV2 is IPerpsStorageV2External, IPerpsStorageV2Internal, IPe
 
     function initMarket(bytes32 marketKey, bytes32 baseAsset) external onlyAssociatedContract {
         // validate input
-        require(marketKey != bytes32(0), "market key cannot be empty");
-        require(baseAsset != bytes32(0), "asset key cannot be empty");
+        require(marketKey != bytes32(0), "Market key cannot be empty");
+        require(baseAsset != bytes32(0), "Asset key cannot be empty");
         // load market
         MarketScalars storage market = marketScalars[marketKey];
         // check is not initialized already (can only be initialized once)
         // (it should be ok to re-initialize if no positions were created yet, but
         // this would only be needed if baseAsset was incorrectly set the first time, so is
         // an edge case that doesn't justify any added side effects concerns for a less strict check)
-        require(market.baseAsset == bytes32(0), "already initialized");
+        require(market.baseAsset == bytes32(0), "Already initialized");
         // set asset
         market.baseAsset = baseAsset;
         // event
@@ -122,7 +122,7 @@ contract PerpsStorageV2 is IPerpsStorageV2External, IPerpsStorageV2Internal, IPe
         // load the storage
         Position storage position = _positions[marketKey][account];
         // ensure is initialized
-        require(position.id != 0, "position not initialized");
+        require(position.id != 0, "Position not initialized");
         // update values according to inputs
         position.margin = newMargin;
         position.lockedMargin = newLocked;

--- a/test/contracts/PerpsEngineV2.js
+++ b/test/contracts/PerpsEngineV2.js
@@ -403,10 +403,10 @@ contract('PerpsEngineV2', accounts => {
 					from: mockOrders,
 				});
 				// but after that the market is still broken due to skewScale being 0
-				await assert.revert(instance.proportionalSkew(newKey), 'skewScale is zero');
+				await assert.revert(instance.proportionalSkew(newKey), 'Skew scale is zero');
 				await assert.revert(
 					instance.trade(newKey, trader, toUnit('1'), defaultExecOptions, { from: mockOrders }),
-					'skewScale is zero'
+					'Skew scale is zero'
 				);
 			});
 
@@ -433,7 +433,7 @@ contract('PerpsEngineV2', accounts => {
 			});
 
 			it('uninitialized market fails baseAsset check', async () => {
-				await assert.revert(instance.assetPrice(toBytes32('pNew')), 'market not initialised');
+				await assert.revert(instance.assetPrice(toBytes32('pNew')), 'Market not initialised');
 			});
 		});
 
@@ -564,19 +564,19 @@ contract('PerpsEngineV2', accounts => {
 			// cannot init to another asset
 			await assert.revert(
 				instance.ensureInitialized(marketKey, toBytes32('other asset'), { from: mockManager }),
-				'initialized with different asset'
+				'Initialized with different asset'
 			);
 
 			// cannot init to empty marketKey
 			await assert.revert(
 				instance.ensureInitialized(toBytes32(''), toBytes32('new'), { from: mockManager }),
-				'market key cannot be empty'
+				'Market key cannot be empty'
 			);
 
 			// cannot init to empty asset
 			await assert.revert(
 				instance.ensureInitialized(toBytes32('pNew'), toBytes32(''), { from: mockManager }),
-				'asset key cannot be empty'
+				'Asset key cannot be empty'
 			);
 		});
 	});
@@ -905,12 +905,12 @@ contract('PerpsEngineV2', accounts => {
 			it('reverts as for zero amounts', async () => {
 				await assert.revert(
 					instance.modifyLockedMargin(marketKey, trader, toBN(0), toBN(0), { from: mockOrders }),
-					'zero modification amounts'
+					'Zero modification amounts'
 				);
 			});
 
 			it('reverts for negative locked', async () => {
-				const revertMsg = 'new locked margin negative';
+				const revertMsg = 'New locked margin negative';
 				await assert.revert(
 					instance.modifyLockedMargin(marketKey, trader, toBN(0), toBN('1'), {
 						from: mockOrders,
@@ -970,7 +970,7 @@ contract('PerpsEngineV2', accounts => {
 				// cannot burn more than locked
 				await assert.revert(
 					instance.modifyLockedMargin(marketKey, trader, 0, toBN('20'), { from: mockOrders }),
-					'new locked margin negative'
+					'New locked margin negative'
 				);
 				// can burn locked
 				await instance.modifyLockedMargin(marketKey, trader, 0, locked, { from: mockOrders });
@@ -988,7 +988,7 @@ contract('PerpsEngineV2', accounts => {
 				// cannot unlock more than locked
 				await assert.revert(
 					instance.modifyLockedMargin(marketKey, trader, toBN('-11'), 0, { from: mockOrders }),
-					'new locked margin negative'
+					'New locked margin negative'
 				);
 				// can burn locked
 				await instance.modifyLockedMargin(marketKey, trader, locked.neg(), 0, { from: mockOrders });
@@ -2708,7 +2708,7 @@ contract('PerpsEngineV2', accounts => {
 				marginDelta: toUnit(1000),
 			});
 			await setPrice(baseAsset, toUnit('0'));
-			await assert.revert(instance.proportionalSkew(marketKey), "price can't be zero");
+			await assert.revert(instance.proportionalSkew(marketKey), "Price can't be zero");
 		});
 
 		describe('last funding entry', () => {

--- a/test/contracts/PerpsManagerV2.configSetters.js
+++ b/test/contracts/PerpsManagerV2.configSetters.js
@@ -65,7 +65,7 @@ contract('PerpsManagerV2 ConfigSettersMixin', accounts => {
 					perpsManager.setBaseFee(marketKey, toUnit('1').add(new BN(1)), {
 						from: owner,
 					}),
-					'base fee greater than 1'
+					'Base fee greater than 1'
 				);
 			});
 
@@ -74,7 +74,7 @@ contract('PerpsManagerV2 ConfigSettersMixin', accounts => {
 					perpsManager.setBaseFeeNextPrice(marketKey, toUnit('1').add(new BN(1)), {
 						from: owner,
 					}),
-					'base fee greater than 1'
+					'Base fee greater than 1'
 				);
 			});
 
@@ -83,7 +83,7 @@ contract('PerpsManagerV2 ConfigSettersMixin', accounts => {
 					perpsManager.setSkewScaleUSD(marketKey, 0, {
 						from: owner,
 					}),
-					'cannot set skew scale 0'
+					'Cannot set skew scale 0'
 				);
 			});
 		});
@@ -234,7 +234,7 @@ contract('PerpsManagerV2 ConfigSettersMixin', accounts => {
 				perpsManager.setMinKeeperFee(minInitialMargin.add(new BN(1)), {
 					from: owner,
 				}),
-				'min margin < liquidation fee'
+				'Min margin < liquidation fee'
 			);
 
 			const currentLiquidationFee = await perpsManager.minKeeperFee.call();
@@ -242,7 +242,7 @@ contract('PerpsManagerV2 ConfigSettersMixin', accounts => {
 				perpsManager.setMinInitialMargin(currentLiquidationFee.sub(new BN(1)), {
 					from: owner,
 				}),
-				'min margin < liquidation fee'
+				'Min margin < liquidation fee'
 			);
 		});
 

--- a/test/contracts/PerpsManagerV2.js
+++ b/test/contracts/PerpsManagerV2.js
@@ -144,7 +144,7 @@ contract('PerpsManagerV2', accounts => {
 		it('Must provide same length of keys', async () => {
 			await assert.revert(
 				perpsManager.addMarkets(marketKeys, [baseAssets[0]], { from: owner }),
-				'length of marketKeys'
+				'Length of marketKeys'
 			);
 		});
 
@@ -152,7 +152,7 @@ contract('PerpsManagerV2', accounts => {
 			// check it's not known to storage
 			assert.equal((await perpsStorage.marketScalars(marketKey)).baseAsset, toBytes32(''));
 			// engine doesn't know about it
-			await assert.revert(perpsEngine.marketSummary(marketKey), 'market not initialised');
+			await assert.revert(perpsEngine.marketSummary(marketKey), 'Market not initialised');
 			// not approved for trading
 			assert.isFalse(await perpsManager.approvedRouterAndMarket(perpsOrders.address, marketKey));
 

--- a/test/contracts/PerpsOrdersV2.nextPrice.js
+++ b/test/contracts/PerpsOrdersV2.nextPrice.js
@@ -167,7 +167,7 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 			it('zero size', async () => {
 				await assert.revert(
 					perpsOrders.submitNextPriceOrder(marketKey, 0, { from: trader }),
-					'order would fail as spot'
+					'Order would fail as spot'
 				);
 			});
 
@@ -175,14 +175,14 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 				await perpsOrders.withdrawAllMargin(marketKey, { from: trader });
 				await assert.revert(
 					perpsOrders.submitNextPriceOrder(marketKey, size, { from: trader }),
-					'order would fail as spot'
+					'Order would fail as spot'
 				);
 			});
 
 			it('too much leverage', async () => {
 				await assert.revert(
 					perpsOrders.submitNextPriceOrder(marketKey, size.mul(toBN(10)), { from: trader }),
-					'order would fail as spot'
+					'Order would fail as spot'
 				);
 			});
 
@@ -190,7 +190,7 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 				await perpsOrders.submitNextPriceOrder(marketKey, size, { from: trader });
 				await assert.revert(
 					perpsOrders.submitNextPriceOrder(marketKey, size, { from: trader }),
-					'previous order exists'
+					'Previous order exists'
 				);
 			});
 
@@ -277,12 +277,12 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 			// account owner
 			await assert.revert(
 				perpsOrders.cancelNextPriceOrder(marketKey, trader, { from: trader }),
-				'no previous order'
+				'No previous order'
 			);
 			// keeper
 			await assert.revert(
 				perpsOrders.cancelNextPriceOrder(marketKey, trader, { from: trader2 }),
-				'no previous order'
+				'No previous order'
 			);
 		});
 
@@ -432,28 +432,28 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 					// same round
 					await assert.revert(
 						perpsOrders.cancelNextPriceOrder(marketKey, trader, { from: trader2 }),
-						'cannot be cancelled by keeper yet'
+						'Cannot be cancelled by keeper yet'
 					);
 
 					// target round
 					await setPrice(baseAsset, price);
 					await assert.revert(
 						perpsOrders.cancelNextPriceOrder(marketKey, trader, { from: trader2 }),
-						'cannot be cancelled by keeper yet'
+						'Cannot be cancelled by keeper yet'
 					);
 
 					// next round after target round
 					await setPrice(baseAsset, price);
 					await assert.revert(
 						perpsOrders.cancelNextPriceOrder(marketKey, trader, { from: trader2 }),
-						'cannot be cancelled by keeper yet'
+						'Cannot be cancelled by keeper yet'
 					);
 
 					// next one after that (for 2 roundId)
 					await setPrice(baseAsset, price);
 					await assert.revert(
 						perpsOrders.cancelNextPriceOrder(marketKey, trader, { from: trader2 }),
-						'cannot be cancelled by keeper yet'
+						'Cannot be cancelled by keeper yet'
 					);
 
 					// ok now
@@ -469,12 +469,12 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 			// account owner
 			await assert.revert(
 				perpsOrders.executeNextPriceOrder(marketKey, trader, { from: trader }),
-				'no previous order'
+				'No previous order'
 			);
 			// keeper
 			await assert.revert(
 				perpsOrders.executeNextPriceOrder(marketKey, trader, { from: trader2 }),
-				'no previous order'
+				'No previous order'
 			);
 		});
 
@@ -495,12 +495,12 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 					// account owner
 					await assert.revert(
 						perpsOrders.executeNextPriceOrder(marketKey, trader, { from: trader }),
-						'target roundId not reached'
+						'Target roundId not reached'
 					);
 					// keeper
 					await assert.revert(
 						perpsOrders.executeNextPriceOrder(marketKey, trader, { from: trader2 }),
-						'target roundId not reached'
+						'Target roundId not reached'
 					);
 				});
 
@@ -515,12 +515,12 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 					// account owner
 					await assert.revert(
 						perpsOrders.executeNextPriceOrder(marketKey, trader, { from: trader }),
-						'order too old, use cancel'
+						'Order too old, use cancel'
 					);
 					// keeper
 					await assert.revert(
 						perpsOrders.executeNextPriceOrder(marketKey, trader, { from: trader2 }),
-						'order too old, use cancel'
+						'Order too old, use cancel'
 					);
 				});
 

--- a/test/contracts/PerpsStorageV2.js
+++ b/test/contracts/PerpsStorageV2.js
@@ -81,7 +81,7 @@ contract('PerpsStorageV2', async accounts => {
 		});
 
 		it('withMarket: all fail for storage owner if market is not initialized', async () => {
-			const revertMsg = 'market not initialised';
+			const revertMsg = 'Market not initialised';
 			await assert.revert(
 				instance.positionWithInit(marketKey, user1, { from: writeAccount }),
 				revertMsg
@@ -119,15 +119,15 @@ contract('PerpsStorageV2', async accounts => {
 		it('reverts for bad input', async () => {
 			await assert.revert(
 				instance.initMarket(emptyBytes32, baseAsset, { from: writeAccount }),
-				'market key cannot be empty'
+				'Market key cannot be empty'
 			);
 			await assert.revert(
 				instance.initMarket(marketKey, emptyBytes32, { from: writeAccount }),
-				'asset key cannot be empty'
+				'Asset key cannot be empty'
 			);
 			await assert.revert(
 				instance.initMarket(marketKey, baseAsset, { from: writeAccount }),
-				'already initialized'
+				'Already initialized'
 			);
 		});
 
@@ -258,7 +258,7 @@ contract('PerpsStorageV2', async accounts => {
 					instance.storePosition(marketKey, user1, margin, lockedMargin, size, lastPrice, {
 						from: writeAccount,
 					}),
-					'position not initialized'
+					'Position not initialized'
 				);
 			});
 


### PR DESCRIPTION
Most require error messages are in sentence case.

This also removes trailing white spaces on some files. Rather than adding 20 suggestion comments in PR #1859, I did it all in one easy to approve/merge commit.