### PR TITLE
fix not running fork tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
       image: ubuntu-2204:2022.04.1
       docker_layer_caching: true
     environment:
-      foundry_locked_commit: '3c49efe'
+      foundry_locked_commit: "3c49efe"
     steps:
       - restore_cache:
           keys:
@@ -75,6 +75,7 @@ jobs:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:
@@ -104,6 +105,7 @@ jobs:
         auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_TOKEN
+    resource_class: large
     steps:
       - checkout
       - attach_workspace:
@@ -132,7 +134,7 @@ jobs:
       image: ubuntu-2204:2022.04.1
       docker_layer_caching: true
     environment:
-      foundry_locked_commit: '3c49efe'
+      foundry_locked_commit: "3c49efe"
     resource_class: large
     steps:
       - restore_cache:
@@ -305,7 +307,7 @@ jobs:
       image: ubuntu-2204:2022.04.1
       docker_layer_caching: true
     environment:
-      foundry_locked_commit: '3c49efe'
+      foundry_locked_commit: "3c49efe"
     resource_class: large
     steps:
       - restore_cache:

--- a/.circleci/src/jobs/job-fork-tests-ovm.yml
+++ b/.circleci/src/jobs/job-fork-tests-ovm.yml
@@ -1,5 +1,6 @@
 # Starts a fork of OVM, deploys the latest release, and runs L2 integration tests
 {{> job-header-node.yml}}
+resource_class: large
 steps:
   - checkout
   - attach_workspace:

--- a/.circleci/src/jobs/job-fork-tests.yml
+++ b/.circleci/src/jobs/job-fork-tests.yml
@@ -1,5 +1,6 @@
 # Starts a fork of mainnet, deploys the latest release, and runs L1 integration tests
 {{> job-header-node.yml}}
+resource_class: large
 steps:
   - checkout
   - attach_workspace:

--- a/publish/deployed/local/config.json
+++ b/publish/deployed/local/config.json
@@ -158,10 +158,19 @@
 	"TokenStatesETH": {
 		"deploy": true
 	},
+	"TokenStatesLINK": {
+		"deploy": true
+	},
 	"ProxysETH": {
 		"deploy": true
 	},
+	"ProxysLINK": {
+		"deploy": true
+	},
 	"SynthsETH": {
+		"deploy": true
+	},
+	"SynthsLINK": {
 		"deploy": true
 	},
 	"MockToken": {

--- a/publish/deployed/mainnet-ovm/feeds.json
+++ b/publish/deployed/mainnet-ovm/feeds.json
@@ -59,10 +59,6 @@
 		"asset": "DYDX",
 		"feed": "0xee35A95c9a064491531493D8b380bC40A4CCd0Da"
 	},
-	"DebtRatio": {
-		"asset": "DebtRatio",
-		"feed": "0x94A178f2c480D14F8CdDa908D173d7a73F779cb7"
-	},
 	"BNB": {
 		"asset": "BNB",
 		"feed": "0xD38579f7cBD14c22cF1997575eA8eF7bfe62ca2c"

--- a/publish/deployed/mainnet-ovm/futures-markets.json
+++ b/publish/deployed/mainnet-ovm/futures-markets.json
@@ -182,20 +182,6 @@
 		"paused": false
 	},
 	{
-		"marketKey": "sDebtRatio",
-		"asset": "DebtRatio",
-		"takerFee": "0.0060",
-		"makerFee": "0.0060",
-		"takerFeeNextPrice": "0.0015",
-		"makerFeeNextPrice": "0.0015",
-		"nextPriceConfirmWindow": "2",
-		"maxLeverage": "10",
-		"maxMarketValueUSD": "1000000",
-		"maxFundingRate": "0.1",
-		"skewScaleUSD": "5000000",
-		"paused": true
-	},
-	{
 		"marketKey": "sBNB",
 		"asset": "BNB",
 		"takerFee": "0.0040",

--- a/publish/src/commands/deploy/import-addresses.js
+++ b/publish/src/commands/deploy/import-addresses.js
@@ -113,7 +113,8 @@ module.exports = async ({
 			}
 			if (!continueEvenIfUnsuccessful) {
 				console.log(gray('Stopping.'));
-				process.exit();
+				// avoid silently "successful" test runs that don't run any tests
+				process.exit(1);
 			}
 		}
 	} else {

--- a/publish/src/commands/deploy/index.js
+++ b/publish/src/commands/deploy/index.js
@@ -199,7 +199,7 @@ const deploy = async ({
 
 	const { account } = deployer;
 
-	if (!account) {
+	if (!signer) {
 		signer = deployer.signer;
 	}
 


### PR DESCRIPTION
fix not running fork tests or `job-test-deploy-script` in CI (but not exiting with error, thus having the illusion of successful tests).

Also removes the DebtRatio market (and feed) since new CircuitBreaker isn't able to support it.