### PR TITLE
Feature/shortcut methods

### DIFF
--- a/contracts/PerpsOrdersV2Base.sol
+++ b/contracts/PerpsOrdersV2Base.sol
@@ -282,6 +282,6 @@ contract PerpsOrdersV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2 {
 
     function _closePosition(bytes32 marketKey, bytes32 trackingCode) internal {
         int size = stateContract().position(marketKey, msg.sender).size;
-        _trade(marketKey, - size, trackingCode);
+        _trade(marketKey, -size, trackingCode);
     }
 }

--- a/contracts/PerpsOrdersV2Base.sol
+++ b/contracts/PerpsOrdersV2Base.sol
@@ -258,13 +258,23 @@ contract PerpsOrdersV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2 {
     }
 
     /// Shortcut method to transfer margin and trade in a single tx.
-    function transferAndTrade(bytes32 marketKey, int marginDelta, int sizeDelta, bytes32 trackingCode) external {
+    function transferAndTrade(
+        bytes32 marketKey,
+        int marginDelta,
+        int sizeDelta,
+        bytes32 trackingCode
+    ) external {
         _engineInternal().transferMargin(marketKey, msg.sender, marginDelta);
         _trade(marketKey, sizeDelta, trackingCode);
     }
 
     /// Shortcut method to trade and transfer margin in a single tx (inverse of transferAndTrade).
-    function tradeAndTransfer(bytes32 marketKey, int marginDelta, int sizeDelta, bytes32 trackingCode) external {
+    function tradeAndTransfer(
+        bytes32 marketKey,
+        int marginDelta,
+        int sizeDelta,
+        bytes32 trackingCode
+    ) external {
         _trade(marketKey, sizeDelta, trackingCode);
         _engineInternal().transferMargin(marketKey, msg.sender, marginDelta);
     }

--- a/contracts/PerpsOrdersV2Base.sol
+++ b/contracts/PerpsOrdersV2Base.sol
@@ -178,11 +178,6 @@ contract PerpsOrdersV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2 {
         return int(targetPrice).sub(int(currentPrice));
     }
 
-    /// helper for building an ExecutionOptions that only includes feeRate, and defaults ot 0 for other fields
-    function _defaultExecutionOptions(uint _rate) internal pure returns (ExecutionOptions memory) {
-        return ExecutionOptions({feeRate: _rate, priceDelta: 0, trackingCode: bytes32(0)});
-    }
-
     /// calculate fee amount using current asset price and given rate and order size
     function _feeAmountCurrentPrice(
         bytes32 marketKey,

--- a/contracts/PerpsOrdersV2Base.sol
+++ b/contracts/PerpsOrdersV2Base.sol
@@ -206,7 +206,7 @@ contract PerpsOrdersV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2 {
      * Reverts on deposit if the caller lacks a sufficient sUSD balance.
      * Reverts on withdrawal if the amount to be withdrawn would expose an open position to liquidation.
      */
-    function transferMargin(bytes32 marketKey, int marginDelta) external {
+    function transferMargin(bytes32 marketKey, int marginDelta) public {
         _engineInternal().transferMargin(marketKey, msg.sender, marginDelta);
     }
 
@@ -214,7 +214,7 @@ contract PerpsOrdersV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2 {
      * Withdraws all accessible margin in a position. This will leave some remaining margin
      * in the account if the caller has a position open. Equivalent to `transferMargin(-withdrawableMargin(sender))`.
      */
-    function withdrawMaxMargin(bytes32 marketKey) external {
+    function withdrawMaxMargin(bytes32 marketKey) public {
         address account = msg.sender;
         uint withdrawable = engineContract().withdrawableMargin(marketKey, account);
         _engineInternal().transferMargin(marketKey, account, -int(withdrawable));
@@ -259,7 +259,7 @@ contract PerpsOrdersV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2 {
         int sizeDelta,
         bytes32 trackingCode
     ) external {
-        _engineInternal().transferMargin(marketKey, msg.sender, marginDelta);
+        transferMargin(marketKey, marginDelta);
         _trade(marketKey, sizeDelta, trackingCode);
     }
 
@@ -271,7 +271,13 @@ contract PerpsOrdersV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2 {
         bytes32 trackingCode
     ) external {
         _trade(marketKey, sizeDelta, trackingCode);
-        _engineInternal().transferMargin(marketKey, msg.sender, marginDelta);
+        transferMargin(marketKey, marginDelta);
+    }
+
+    /// Shortcut method to close an open position and withdraw all margin.
+    function closeAndWithdraw(bytes32 marketKey, bytes32 trackingCode) external {
+        _closePosition(marketKey, trackingCode);
+        withdrawMaxMargin(marketKey);
     }
 
     /* ========== INTERNAL MUTATIVE ========== */

--- a/contracts/PerpsOrdersV2Base.sol
+++ b/contracts/PerpsOrdersV2Base.sol
@@ -174,8 +174,13 @@ contract PerpsOrdersV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2 {
     /// helper for getting `int priceDelta` for the `engine.trade()` interface for making a trade at price different
     /// from current asset price (e.g. orders such as next price, limit, but also orders with slippage)
     function _priceDeltaFromCurrent(bytes32 marketKey, uint targetPrice) internal view returns (int) {
-        (uint currentPrice,) = engineContract().assetPrice(marketKey);
+        (uint currentPrice, ) = engineContract().assetPrice(marketKey);
         return int(targetPrice).sub(int(currentPrice));
+    }
+
+    /// helper for building an ExecutionOptions that only includes feeRate, and defaults ot 0 for other fields
+    function _defaultExecutionOptions(uint _rate) internal pure returns (ExecutionOptions memory) {
+        return ExecutionOptions({feeRate: _rate, priceDelta: 0, trackingCode: bytes32(0)});
     }
 
     /// calculate fee amount using current asset price and given rate and order size
@@ -217,7 +222,7 @@ contract PerpsOrdersV2Base is PerpsConfigGettersV2Mixin, IPerpsTypesV2 {
     function withdrawMaxMargin(bytes32 marketKey) external {
         address account = msg.sender;
         uint withdrawable = engineContract().withdrawableMargin(marketKey, account);
-        _engineInternal().transferMargin(marketKey, account, - int(withdrawable));
+        _engineInternal().transferMargin(marketKey, account, -int(withdrawable));
     }
 
     /*

--- a/contracts/interfaces/IPerpsInterfacesV2.sol
+++ b/contracts/interfaces/IPerpsInterfacesV2.sol
@@ -287,6 +287,8 @@ interface IPerpsOrdersV2 {
         bytes32 trackingCode
     ) external;
 
+    function closeAndWithdraw(bytes32 marketKey, bytes32 trackingCode) external;
+
     function tradeWithTracking(
         bytes32 marketKey,
         int sizeDelta,

--- a/contracts/interfaces/IPerpsInterfacesV2.sol
+++ b/contracts/interfaces/IPerpsInterfacesV2.sol
@@ -273,9 +273,19 @@ interface IPerpsOrdersV2 {
 
     function trade(bytes32 marketKey, int sizeDelta) external;
 
-    function transferAndTrade(bytes32 marketKey, int marginDelta, int sizeDelta, bytes32 trackingCode) external;
+    function transferAndTrade(
+        bytes32 marketKey,
+        int marginDelta,
+        int sizeDelta,
+        bytes32 trackingCode
+    ) external;
 
-    function tradeAndTransfer(bytes32 marketKey, int marginDelta, int sizeDelta, bytes32 trackingCode) external;
+    function tradeAndTransfer(
+        bytes32 marketKey,
+        int marginDelta,
+        int sizeDelta,
+        bytes32 trackingCode
+    ) external;
 
     function tradeWithTracking(
         bytes32 marketKey,

--- a/contracts/interfaces/IPerpsInterfacesV2.sol
+++ b/contracts/interfaces/IPerpsInterfacesV2.sol
@@ -273,6 +273,10 @@ interface IPerpsOrdersV2 {
 
     function trade(bytes32 marketKey, int sizeDelta) external;
 
+    function transferAndTrade(bytes32 marketKey, int marginDelta, int sizeDelta, bytes32 trackingCode) external;
+
+    function tradeAndTransfer(bytes32 marketKey, int marginDelta, int sizeDelta, bytes32 trackingCode) external;
+
     function tradeWithTracking(
         bytes32 marketKey,
         int sizeDelta,

--- a/test/contracts/PerpsOrdersV2.js
+++ b/test/contracts/PerpsOrdersV2.js
@@ -648,7 +648,9 @@ contract('PerpsOrdersV2', accounts => {
 				// 1000 margin, size 5.
 				const [fee1] = await executeTransferAndTradeWithFee(margin, size); // 1000 margin, size 5.
 
-				const originalPositionId = (await perpsOrders.positionSummary(marketKey, trader)).position.id
+				const { id: originalPositionId } = (
+					await perpsOrders.positionSummary(marketKey, trader)
+				).position;
 
 				// Increase margin by 1000 (2x), no change in size.
 				//
@@ -718,6 +720,7 @@ contract('PerpsOrdersV2', accounts => {
 
 		describe('on tradeAndTransfer', () => {
 			it('should succeed on valid invocation params');
+			it('should succeed when closing and withdrawing all remaining margin');
 			it('should succeed when transferring zero margin');
 			it('should revert when no position is available');
 			it('should revert when transfer amount exceeds remaining');

--- a/test/contracts/PerpsOrdersV2.js
+++ b/test/contracts/PerpsOrdersV2.js
@@ -616,7 +616,7 @@ contract('PerpsOrdersV2', accounts => {
 	describe('trading using shortcut methods', () => {
 		describe('on transferAndTrade', () => {
 			const executeTransferAndTradeWithFee = async (margin, size) => {
-				const fee = (await perpsEngine.orderFee(marketKey, size, [baseFee, 0, toBytes32('')])).fee;
+				const fee = (await perpsOrders.orderFee(marketKey, size, [baseFee, 0, toBytes32('')])).fee;
 				const tx = await perpsOrders.transferAndTrade(marketKey, margin, size, toBytes32(''), {
 					from: trader,
 				});

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -342,7 +342,7 @@ module.exports = ({ web3 } = {}) => {
 	 *  Convenience method to assert that two BN.js instances are equal.
 	 *  @param actualBN The BN.js instance you received
 	 *  @param expectedBN The BN.js amount you expected to receive
-	 *  @param context The description to log if we fail the assertion
+	 *  @param [context] Optional description to log if we fail the assertion
 	 */
 	const assertBNEqual = (actualBN, expectedBN, context) => {
 		assert.strictEqual(actualBN.toString(), expectedBN.toString(), context);
@@ -352,16 +352,17 @@ module.exports = ({ web3 } = {}) => {
 	 *  Convenience method to assert that two BN.js instances are NOT equal.
 	 *  @param actualBN The BN.js instance you received
 	 *  @param expectedBN The BN.js amount you expected NOT to receive
-	 *  @param context The description to log if we fail the assertion
+	 *  @param [context] Optional description to log if we fail the assertion
 	 */
-	const assertBNNotEqual = (actualBN, expectedBN) => {
+	const assertBNNotEqual = (actualBN, expectedBN, context) => {
 		assert.notStrictEqual(actualBN.toString(), expectedBN.toString(), context);
 	};
 
 	/**
-	 *  Convenience method to assert that two BN.js instances are within 100 units of each other.
+	 *  Convenience method to assert that two BN.js instances are within 10 units of each other.
 	 *  @param actualBN The BN.js instance you received
-	 *  @param expectedBN The BN.js amount you expected to receive, allowing a variance of +/- 100 units
+	 *  @param expectedBN The BN.js amount you expected to receive, allowing a variance of +/- 10 units
+	 *  @param [varianceParam=10] Optional max variance param used to define range
 	 */
 	const assertBNClose = (actualBN, expectedBN, varianceParam = '10') => {
 		const actual = toBN(actualBN);
@@ -370,11 +371,11 @@ module.exports = ({ web3 } = {}) => {
 
 		assert.ok(
 			actual.gte(expected.sub(variance)),
-			`${actual} !~= ${expected} (maxVariance ${variance.toString()}`
+			`${actual} !~= ${expected} (maxVariance ${variance.toString()})`
 		);
 		assert.ok(
 			actual.lte(expected.add(variance)),
-			`${actual} !~= ${expected} (maxVariance ${variance.toString()}`
+			`${actual} !~= ${expected} (maxVariance ${variance.toString()})`
 		);
 	};
 
@@ -493,7 +494,7 @@ module.exports = ({ web3 } = {}) => {
 	 * Convenience method to assert that the return of the given block when invoked or promise causes a
 	 * revert to occur, with an optional revert message.
 	 * @param blockOrPromise The JS block (i.e. function that when invoked returns a promise) or a promise itself
-	 * @param reason Optional reason string to search for in revert message
+	 * @param [reason] Optional reason string to search for in revert message
 	 */
 	const assertRevert = async (blockOrPromise, reason) => {
 		let errorCaught = false;

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -342,7 +342,7 @@ module.exports = ({ web3 } = {}) => {
 	 *  Convenience method to assert that two BN.js instances are equal.
 	 *  @param actualBN The BN.js instance you received
 	 *  @param expectedBN The BN.js amount you expected to receive
-	 *  @param context The description to log if we fail the assertion
+	 *  @param [context] Optional description to log if we fail the assertion
 	 */
 	const assertBNEqual = (actualBN, expectedBN, context) => {
 		assert.strictEqual(actualBN.toString(), expectedBN.toString(), context);

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -342,7 +342,7 @@ module.exports = ({ web3 } = {}) => {
 	 *  Convenience method to assert that two BN.js instances are equal.
 	 *  @param actualBN The BN.js instance you received
 	 *  @param expectedBN The BN.js amount you expected to receive
-	 *  @param [context] Optional description to log if we fail the assertion
+	 *  @param context The description to log if we fail the assertion
 	 */
 	const assertBNEqual = (actualBN, expectedBN, context) => {
 		assert.strictEqual(actualBN.toString(), expectedBN.toString(), context);
@@ -352,7 +352,7 @@ module.exports = ({ web3 } = {}) => {
 	 *  Convenience method to assert that two BN.js instances are NOT equal.
 	 *  @param actualBN The BN.js instance you received
 	 *  @param expectedBN The BN.js amount you expected NOT to receive
-	 *  @param [context] Optional description to log if we fail the assertion
+	 *  @param context The description to log if we fail the assertion
 	 */
 	const assertBNNotEqual = (actualBN, expectedBN, context) => {
 		assert.notStrictEqual(actualBN.toString(), expectedBN.toString(), context);


### PR DESCRIPTION
This PR adds additional convenience methods to the `contracts/PerpsOrdersV2Base.sol` contract. The intent is to reduce the number of transactions traders are required to sign and submit to improve usability when interacting with contracts through dApps like Kwenta.

The methods added are:

- `transferAndTrade`
- `tradeAndTransfer`
- `closeAndWithdraw`

You can find more details on specifics in comments within the codebase.