### PR TITLE
DebtRatio aggregator <> CircuitBreaker workaround: add immutable read proxy

### DIFF
--- a/contracts/ImmutableReadProxy.sol
+++ b/contracts/ImmutableReadProxy.sol
@@ -1,0 +1,31 @@
+pragma solidity ^0.5.16;
+
+// solhint-disable payable-fallback
+
+/// a variant of ReadProxy.sol that's not Owned, and so has an immutable target
+/// that can be used e.g. to read a oracle feed, and provide its interface, but from a
+/// different address
+contract ImmutableReadProxy {
+    address public target;
+
+    constructor(address _target) public {
+        target = _target;
+    }
+
+    function() external {
+        // The basics of a proxy read call
+        // Note that msg.sender in the underlying will always be the address of this contract.
+        assembly {
+            calldatacopy(0, 0, calldatasize)
+
+            // Use of staticcall - this will revert if the underlying function mutates state
+            let result := staticcall(gas, sload(target_slot), 0, calldatasize, 0, 0)
+            returndatacopy(0, 0, returndatasize)
+
+            if iszero(result) {
+                revert(0, returndatasize)
+            }
+            return(0, returndatasize)
+        }
+    }
+}

--- a/test/contracts/ReadProxy.js
+++ b/test/contracts/ReadProxy.js
@@ -170,4 +170,53 @@ contract('ReadProxy', async accounts => {
 			);
 		});
 	});
+
+	describe('ImmutableReadProxy forwards views as expected', () => {
+		let mockMutator;
+		beforeEach(async () => {
+			mockMutator = await artifacts.require('MockMutator').new();
+
+			// initialize immutable proxy forwarder
+			forwarder = await artifacts.require('ImmutableReadProxy').new(mockMutator.address);
+		});
+
+		it('When trying to forward to the view, it works as expected', async () => {
+			const response = await proxyThruTo({
+				proxy: forwarder,
+				target: mockMutator,
+				fncName: 'read',
+				args: [],
+				from: account3,
+				call: true,
+			});
+
+			assert.equal(response, '0');
+		});
+
+		it('When trying to forward a call to the mutative function, it reverts', async () => {
+			// forwarder uses staticcall which reverts on any state mutation
+			await assert.revert(
+				proxyThruTo({
+					proxy: forwarder,
+					target: mockMutator,
+					fncName: 'update',
+					args: [],
+					from: account3,
+					call: true,
+				})
+			);
+		});
+		it('When trying to forward a transaction to the mutative function, it reverts', async () => {
+			await assert.revert(
+				proxyThruTo({
+					proxy: forwarder,
+					target: mockMutator,
+					fncName: 'update',
+					args: [],
+					from: account3,
+					call: false, // try as transaction
+				})
+			);
+		});
+	});
 });


### PR DESCRIPTION
Workaround for the DebtRatio arrgegator conflict with the new CricuitBreaker contract.

This adds an `ImmutableReadProxy` contract that is a unowned simplier variant of the `ReadProxy` contract. This contract will be deployed with the `DebtRatio` oracle aggregator as the target. This will enable forwarding all views via this contract, and prevent the address collision in the new CircuitBreaker.