### PR TITLE
Feature/next price qol

### DIFF
--- a/contracts/PerpsOrdersV2NextPriceMixin.sol
+++ b/contracts/PerpsOrdersV2NextPriceMixin.sol
@@ -335,7 +335,11 @@ contract PerpsOrdersV2NextPriceMixin is PerpsOrdersV2Base {
     }
 
     /// returns true if order can be executed, false otherwise.
-    function _canExecute(bytes32 marketKey, uint curRoundId, uint targetRoundId) internal view returns (bool) {
+    function _canExecute(
+        bytes32 marketKey,
+        uint curRoundId,
+        uint targetRoundId
+    ) internal view returns (bool) {
         // Order exceeded our target round but order is also not too old.
         return targetRoundId <= curRoundId && !_confirmationWindowOver(marketKey, curRoundId, targetRoundId);
     }

--- a/contracts/PerpsOrdersV2NextPriceMixin.sol
+++ b/contracts/PerpsOrdersV2NextPriceMixin.sol
@@ -39,7 +39,18 @@ contract PerpsOrdersV2NextPriceMixin is PerpsOrdersV2Base {
         bytes32 trackingCode
     );
 
-    event NextPriceOrderRemoved(
+    event NextPriceOrderExecuted(
+        bytes32 indexed marketKey,
+        address indexed account,
+        uint curRoundId,
+        int sizeDelta,
+        uint targetRoundId,
+        uint commitDeposit,
+        uint keeperDeposit,
+        bytes32 trackingCode
+    );
+
+    event NextPriceOrderCancelled(
         bytes32 indexed marketKey,
         address indexed account,
         uint curRoundId,
@@ -201,8 +212,9 @@ contract PerpsOrdersV2NextPriceMixin is PerpsOrdersV2Base {
 
         // remove stored order
         delete nextPriceOrders[marketKey][account];
+
         // emit event
-        emit NextPriceOrderRemoved(
+        emit NextPriceOrderCancelled(
             marketKey,
             account,
             curRoundId,
@@ -267,8 +279,9 @@ contract PerpsOrdersV2NextPriceMixin is PerpsOrdersV2Base {
 
         // remove stored order
         delete nextPriceOrders[marketKey][account];
+
         // emit event
-        emit NextPriceOrderRemoved(
+        emit NextPriceOrderExecuted(
             marketKey,
             account,
             curRoundId,

--- a/contracts/PerpsOrdersV2NextPriceMixin.sol
+++ b/contracts/PerpsOrdersV2NextPriceMixin.sol
@@ -93,8 +93,11 @@ contract PerpsOrdersV2NextPriceMixin is PerpsOrdersV2Base {
     /// given market and trader return whether their order can be executed and/or cancelled.
     function canExecuteOrCancel(bytes32 marketKey, address account) external view returns (bool canExecute, bool canCancel) {
         NextPriceOrder memory order = nextPriceOrders[marketKey][account];
-        uint curRoundId = currentRoundId(marketKey);
+        if (order.sizeDelta == 0) {
+            return (false, false);
+        }
 
+        uint curRoundId = currentRoundId(marketKey);
         canExecute = _canExecute(curRoundId, order.targetRoundId);
         canCancel = _confirmationWindowOver(marketKey, curRoundId, order.targetRoundId);
     }

--- a/test/contracts/PerpsOrdersV2.nextPrice.js
+++ b/test/contracts/PerpsOrdersV2.nextPrice.js
@@ -256,7 +256,7 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 			// check view
 			assert.bnEqual((await perpsOrders.orderFeeNextPrice(marketKey, size))[0], expectedFee);
 
-			// excute the order
+			// execute the order
 			const tx = await perpsOrders.executeNextPriceOrder(marketKey, trader, { from: trader });
 
 			const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, perpsEngine] });
@@ -343,9 +343,9 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 					args: [await feePool.FEE_ADDRESS(), spotFee],
 					log: decodedLogs.slice(-2, -1)[0], // [-2]
 				});
-				// NextPriceOrderRemoved
+				// NextPriceOrderCancelled
 				decodedEventEqual({
-					event: 'NextPriceOrderRemoved',
+					event: 'NextPriceOrderCancelled',
 					emittedFrom: perpsOrders.address,
 					args: [marketKey, trader, roundId, size, roundId.add(toBN(1)), spotFee, keeperFee],
 					log: decodedLogs.slice(-1)[0],
@@ -557,14 +557,14 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 				});
 			});
 
-			// helper function to check excutiion and its results
+			// helper function to check execution and its results
 			// from: which account is requesting the execution
 			// targetPrice: the price that the order should be executed at
 			// feeRate: expected exchange fee rate
 			// spotTradeDetails: trade details of the same trade if it would happen as spot
 			async function checkExecution(from, targetPrice, feeRate, noFeeTradeResults) {
 				const currentMargin = toBN((await getPosition(trader)).margin);
-				// excute the order
+				// execute the order
 				const tx = await perpsOrders.executeNextPriceOrder(marketKey, trader, { from: from });
 
 				// check order is removed now
@@ -638,9 +638,9 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 					log: decodedLogs.slice(-2, -1)[0],
 				});
 
-				// NextPriceOrderRemoved
+				// NextPriceOrderExecuted
 				decodedEventEqual({
-					event: 'NextPriceOrderRemoved',
+					event: 'NextPriceOrderExecuted',
 					emittedFrom: perpsOrders.address,
 					args: [marketKey, trader, roundId, size, roundId.add(toBN(1)), commitFee, keeperFee],
 					log: decodedLogs.slice(-1)[0],

--- a/test/contracts/PerpsOrdersV2.nextPrice.js
+++ b/test/contracts/PerpsOrdersV2.nextPrice.js
@@ -120,6 +120,7 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 
 	describe('when invoking canExecuteOrCancel', () => {
 		it('should return (false, false) when no order is available', async () => {
+			// Check execution/cancellation status.
 			const { canExecute, canCancel } = await perpsOrders.canExecuteOrCancel(marketKey, trader, {
 				from: trader,
 			});
@@ -141,7 +142,7 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 			// Create order.
 			await perpsOrders.submitNextPriceOrder(marketKey, size, { from: trader });
 
-			// targetRoundId is always current_round + 1. round++ does it.
+			// targetRoundId is always currentRound + 1. round++ does it.
 			await setPrice(baseAsset, price);
 
 			// Check execution/cancellation status.
@@ -158,10 +159,10 @@ contract('PerpsOrdersV2 mixin for next price orders', accounts => {
 			// Create order (starting round = 3)
 			await perpsOrders.submitNextPriceOrder(marketKey, size, { from: trader });
 
-			await setPrice(baseAsset, price); // current_round = 4 - 4 < 2
-			await setPrice(baseAsset, price); // current_round = 5 - 4 < 2
-			await setPrice(baseAsset, price); // current_round = 6 - 4 < 2
-			await setPrice(baseAsset, price); // current_round = 7 - 4 > 2 (oops! too old)
+			await setPrice(baseAsset, price); // currentRound = 4 - 4 < 2
+			await setPrice(baseAsset, price); // currentRound = 5 - 4 < 2
+			await setPrice(baseAsset, price); // currentRound = 6 - 4 < 2
+			await setPrice(baseAsset, price); // currentRound = 7 - 4 > 2 (oops! too old)
 
 			// Check execution/cancellation status.
 			const { canExecute, canCancel } = await perpsOrders.canExecuteOrCancel(marketKey, trader, {


### PR DESCRIPTION
Part 1/2 of Next-Price QoL changes. This PR includes:

1. The addition of 2 events `NextPriceOrderCancelled` and `NextPriceOrderExecuted` as well as the removal of `NextPriceOrderRemoved`
2. and also a new `canExecuteOrCancel` view

Both changes were made against `contracts/PerpsOrdersV2NextPriceMixin.sol` with no change to existing functionality. Tests have been updated to reflect event changes and the addition of a new view.

More details can be found as comments in the codebase.