### PR TITLE
Feature/sip 279 new funding

### DIFF
--- a/contracts/MixinPerpsV2MarketSettings.sol
+++ b/contracts/MixinPerpsV2MarketSettings.sol
@@ -23,7 +23,7 @@ contract MixinPerpsV2MarketSettings is MixinResolver {
     bytes32 internal constant PARAMETER_DELAYED_ORDER_CONFIRM_WINDOW = "delayedOrderConfirmWindow";
     bytes32 internal constant PARAMETER_MAX_LEVERAGE = "maxLeverage";
     bytes32 internal constant PARAMETER_MAX_MARKET_VALUE = "maxMarketValueUSD";
-    bytes32 internal constant PARAMETER_MAX_FUNDING_RATE = "maxFundingRate";
+    bytes32 internal constant PARAMETER_MAX_FUNDING_VELOCITY = "maxFundingVelocity";
     bytes32 internal constant PARAMETER_MIN_SKEW_SCALE = "skewScaleUSD";
     bytes32 internal constant PARAMETER_MIN_DELAY_TIME_DELTA = "minDelayTimeDelta";
     bytes32 internal constant PARAMETER_MAX_DELAY_TIME_DELTA = "maxDelayTimeDelta";
@@ -98,8 +98,8 @@ contract MixinPerpsV2MarketSettings is MixinResolver {
         return _parameter(_marketKey, PARAMETER_MIN_SKEW_SCALE);
     }
 
-    function _maxFundingRate(bytes32 _marketKey) internal view returns (uint) {
-        return _parameter(_marketKey, PARAMETER_MAX_FUNDING_RATE);
+    function _maxFundingVelocity(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_MAX_FUNDING_VELOCITY);
     }
 
     function _minDelayTimeDelta(bytes32 _marketKey) internal view returns (uint) {

--- a/contracts/PerpsV2Market.sol
+++ b/contracts/PerpsV2Market.sol
@@ -180,7 +180,7 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
 
     /*
      * Same as modifyPosition, but emits an event with the passed tracking code to
-     * allow offchain calculations for fee sharing with originating integrations
+     * allow off-chain calculations for fee sharing with originating integrations
      */
     function modifyPositionWithTracking(int sizeDelta, bytes32 trackingCode) external {
         _modifyPosition(sizeDelta, trackingCode);

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -143,11 +143,7 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
         int pSkew = int(marketState.marketSkew()).divideDecimal(int(skewScaleBaseAsset));
 
         // Ensures the proportionalSkew is between -1 and 1.
-        //  - when pSkew = 1.1 then
-        //   min(1.1, 1) = 1
-        //  - when pSkew = -1.1 then
-        //   max(-0.02, -1) = -1
-        return pSkew > 0 ? _min(pSkew, _UNIT) : _max(pSkew, -_UNIT);
+        return _min(_max(-_UNIT, pSkew), _UNIT);
     }
 
     function _proportionalElapsed() internal view returns (int) {

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -196,23 +196,6 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
         int nextFundingRate = _currentFundingRate(price);
         int avgFundingRate = (int(marketState.fundingRateLastRecomputed()).add(nextFundingRate)).divideDecimal(_UNIT * 2);
         int elapsed = _proportionalElapsed();
-
-//        console.log("---- king shit BEGIN!");
-//
-//        console.log("current funding rate");
-//        console.logInt(marketState.fundingRate());
-//
-//        console.log("next funding rate");
-//        console.logInt(nextFundingRate);
-//
-//        console.log("avg funding rate");
-//        console.logInt(avgFundingRate);
-//
-//        console.log("elapsed");
-//        console.logInt(elapsed);
-//
-//        console.log("---- king shit");
-
         return avgFundingRate.multiplyDecimal(elapsed);
     }
 

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -180,7 +180,7 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
         //  - prev_funding_rate     = 0
         //  - prev_velocity         = 0.0025
         //  - time_delta            = 29,000s
-        //  - max_funding_velocity  = 0.025 (2.5%) aka (max funding velocity)
+        //  - max_funding_velocity  = 0.025 (2.5%)
         //  - skew                  = 300
         //  - price                 = 10,000 ($10k)
         //  - skew_scale_usd        = 10,000,000 (10M)

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -21,6 +21,8 @@ import "./interfaces/ISystemStatus.sol";
 // Internal references
 import "./interfaces/IPerpsV2MarketState.sol";
 
+import "hardhat/console.sol";
+
 interface IPerpsV2MarketManagerInternal {
     function issueSUSD(address account, uint amount) external;
 
@@ -184,7 +186,7 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
         // funding_rate = 0 + 0.0025 * (29,000 / 86,400)
         //              = 0 + 0.0025 * 0.33564815
         //              = 0.00083912
-        int fundingRate = marketState.fundingRate();
+        int fundingRate = marketState.fundingRateLastRecomputed();
         int fundingVelocity = _currentFundingVelocity(price);
         int elapsed = _proportionalElapsed();
         return fundingRate.add(fundingVelocity.multiplyDecimal(elapsed));
@@ -192,8 +194,25 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
 
     function _unrecordedFunding(uint price) internal view returns (int) {
         int nextFundingRate = _currentFundingRate(price);
-        int avgFundingRate = (int(marketState.fundingRate()).add(nextFundingRate)).divideDecimal(_UNIT * 2);
+        int avgFundingRate = (int(marketState.fundingRateLastRecomputed()).add(nextFundingRate)).divideDecimal(_UNIT * 2);
         int elapsed = _proportionalElapsed();
+
+//        console.log("---- king shit BEGIN!");
+//
+//        console.log("current funding rate");
+//        console.logInt(marketState.fundingRate());
+//
+//        console.log("next funding rate");
+//        console.logInt(nextFundingRate);
+//
+//        console.log("avg funding rate");
+//        console.logInt(avgFundingRate);
+//
+//        console.log("elapsed");
+//        console.logInt(elapsed);
+//
+//        console.log("---- king shit");
+
         return avgFundingRate.multiplyDecimal(elapsed);
     }
 

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -151,8 +151,8 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
     }
 
     function _currentFundingVelocity(uint price) internal view returns (int) {
-        int maxFundingRate = int(_maxFundingRate(marketState.marketKey()));
-        return _proportionalSkew(price).multiplyDecimal(maxFundingRate);
+        int maxFundingVelocity = int(_maxFundingVelocity(marketState.marketKey()));
+        return _proportionalSkew(price).multiplyDecimal(maxFundingVelocity);
     }
 
     /*
@@ -164,21 +164,21 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
      * recent skew modification.
      *
      * There is no variance in computation but will be affected based on outside modifications to
-     * the market skew, max funding rate, price, and time delta.
+     * the market skew, max funding velocity, price, and time delta.
      */
     function _currentFundingRate(uint price) internal view returns (int) {
         // calculations:
-        //  - velocity          = proportional_skew * max_funding_rate
+        //  - velocity          = proportional_skew * max_funding_velocity
         //  - proportional_skew = (skew * price) / skew_scale_usd
         //
         // example:
-        //  - prev_funding_rate = 0
-        //  - prev_velocity     = 0.0025
-        //  - time_delta        = 29,000s
-        //  - max_funding_rate  = 0.025 (2.5%) aka (max funding velocity)
-        //  - skew              = 300
-        //  - price             = 10,000 ($10k)
-        //  - skew_scale_usd    = 10,000,000 (10M)
+        //  - prev_funding_rate     = 0
+        //  - prev_velocity         = 0.0025
+        //  - time_delta            = 29,000s
+        //  - max_funding_velocity  = 0.025 (2.5%) aka (max funding velocity)
+        //  - skew                  = 300
+        //  - price                 = 10,000 ($10k)
+        //  - skew_scale_usd        = 10,000,000 (10M)
         //
         // note: prev_velocity just refs to the velocity _before_ modifying the market skew.
         //

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -142,7 +142,8 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
     }
 
     function _proportionalElapsed() internal view returns (int) {
-        return int(block.timestamp.sub(marketState.fundingLastRecomputed())) / 1 days;
+        int delta = int(block.timestamp.sub(marketState.fundingLastRecomputed()));
+        return delta.divideDecimal(1 days);
     }
 
     function _fundingVelocity(uint price) internal view returns (int) {

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -201,7 +201,8 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
 
     function _unrecordedFunding(uint price) internal view returns (int) {
         int nextFundingRate = _currentFundingRate(price);
-        int avgFundingRate = (int(marketState.fundingRateLastRecomputed()).add(nextFundingRate)).divideDecimal(_UNIT * 2);
+        // note the minus sign: funding flows in the opposite direction to the skew.
+        int avgFundingRate = -(int(marketState.fundingRateLastRecomputed()).add(nextFundingRate)).divideDecimal(_UNIT * 2);
         int elapsed = _proportionalElapsed();
         return avgFundingRate.multiplyDecimal(elapsed);
     }
@@ -434,7 +435,7 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
     /// Uses the exchanger to get the dynamic fee (SIP-184) for trading from sUSD to baseAsset
     /// this assumes dynamic fee is symmetric in direction of trade.
     /// @dev this is a pretty expensive action in terms of execution gas as it queries a lot
-    ///   of past rates from oracle. Shoudn't be much of an issue on a rollup though.
+    ///   of past rates from oracle. Shouldn't be much of an issue on a rollup though.
     function _dynamicFeeRate() internal view returns (uint feeRate, bool tooVolatile) {
         return _exchanger().dynamicFeeRateForExchange(sUSD, marketState.baseAsset());
     }

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -21,8 +21,6 @@ import "./interfaces/ISystemStatus.sol";
 // Internal references
 import "./interfaces/IPerpsV2MarketState.sol";
 
-import "hardhat/console.sol";
-
 interface IPerpsV2MarketManagerInternal {
     function issueSUSD(address account, uint amount) external;
 

--- a/contracts/PerpsV2MarketData.sol
+++ b/contracts/PerpsV2MarketData.sol
@@ -56,7 +56,7 @@ contract PerpsV2MarketData {
     }
 
     struct FundingParameters {
-        uint maxFundingRate;
+        uint maxFundingVelocity;
         uint skewScaleUSD;
     }
 
@@ -186,7 +186,7 @@ contract PerpsV2MarketData {
         pure
         returns (FundingParameters memory)
     {
-        return FundingParameters(params.maxFundingRate, params.skewScaleUSD);
+        return FundingParameters(params.maxFundingVelocity, params.skewScaleUSD);
     }
 
     function _marketSizes(IPerpsV2MarketViews market) internal view returns (Sides memory) {

--- a/contracts/PerpsV2MarketProxyable.sol
+++ b/contracts/PerpsV2MarketProxyable.sol
@@ -92,9 +92,11 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
     function _recomputeFunding(uint price) internal returns (uint lastIndex) {
         uint sequenceLengthBefore = marketState.fundingSequenceLength();
 
+        int fundingRate = _currentFundingRate(price);
         int funding = _nextFundingEntry(price);
         marketState.pushFundingSequence(int128(funding));
         marketState.setFundingLastRecomputed(uint32(block.timestamp));
+        marketState.setFundingRate(fundingRate);
 
         emitFundingRecomputed(funding, sequenceLengthBefore, marketState.fundingLastRecomputed());
 

--- a/contracts/PerpsV2MarketProxyable.sol
+++ b/contracts/PerpsV2MarketProxyable.sol
@@ -98,8 +98,7 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
         marketState.setFundingLastRecomputed(uint32(block.timestamp));
         marketState.setFundingRate(int128(fundingRate));
 
-        emitFundingRateRecomputed(fundingRate, block.timestamp);
-        emitFundingRecomputed(funding, sequenceLengthBefore, marketState.fundingLastRecomputed());
+        emitFundingRecomputed(funding, fundingRate, sequenceLengthBefore, marketState.fundingLastRecomputed());
 
         return sequenceLengthBefore;
     }
@@ -301,24 +300,15 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
     }
 
     event FundingRecomputed(int funding, uint index, uint timestamp);
-    bytes32 internal constant FUNDINGRECOMPUTED_SIG = keccak256("FundingRecomputed(int256,uint256,uint256)");
+    bytes32 internal constant FUNDINGRECOMPUTED_SIG = keccak256("FundingRecomputed(int256,int256,uint256,uint256)");
 
     function emitFundingRecomputed(
         int funding,
+        int fundingRate,
         uint index,
         uint timestamp
     ) internal {
-        proxy._emit(abi.encode(funding, index, timestamp), 1, FUNDINGRECOMPUTED_SIG, 0, 0, 0);
-    }
-
-    event FundingRateRecomputed(int fundingRate, uint timestamp);
-    bytes32 internal constant FUNDINGRATERECOMPUTED_SIG = keccak256("FundingRateRecomputed(int256,uint256)");
-
-    function emitFundingRateRecomputed(
-        int funding,
-        uint timestamp
-    ) internal {
-        proxy._emit(abi.encode(funding, timestamp), 1, FUNDINGRATERECOMPUTED_SIG, 0, 0, 0);
+        proxy._emit(abi.encode(funding, fundingRate, index, timestamp), 1, FUNDINGRECOMPUTED_SIG, 0, 0, 0);
     }
 
     event FuturesTracking(bytes32 indexed trackingCode, bytes32 baseAsset, bytes32 marketKey, int sizeDelta, uint fee);

--- a/contracts/PerpsV2MarketProxyable.sol
+++ b/contracts/PerpsV2MarketProxyable.sol
@@ -98,6 +98,7 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
         marketState.setFundingLastRecomputed(uint32(block.timestamp));
         marketState.setFundingRate(int128(fundingRate));
 
+        emitFundingRateRecomputed(fundingRate, block.timestamp);
         emitFundingRecomputed(funding, sequenceLengthBefore, marketState.fundingLastRecomputed());
 
         return sequenceLengthBefore;
@@ -308,6 +309,16 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
         uint timestamp
     ) internal {
         proxy._emit(abi.encode(funding, index, timestamp), 1, FUNDINGRECOMPUTED_SIG, 0, 0, 0);
+    }
+
+    event FundingRateRecomputed(int fundingRate, uint timestamp);
+    bytes32 internal constant FUNDINGRATERECOMPUTED_SIG = keccak256("FundingRateRecomputed(int256,uint256)");
+
+    function emitFundingRateRecomputed(
+        int funding,
+        uint timestamp
+    ) internal {
+        proxy._emit(abi.encode(funding, timestamp), 1, FUNDINGRATERECOMPUTED_SIG, 0, 0, 0);
     }
 
     event FuturesTracking(bytes32 indexed trackingCode, bytes32 baseAsset, bytes32 marketKey, int sizeDelta, uint fee);

--- a/contracts/PerpsV2MarketProxyable.sol
+++ b/contracts/PerpsV2MarketProxyable.sol
@@ -299,7 +299,7 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
         proxy._emit(abi.encode(id, account, liquidator, size, price, fee), 1, POSITIONLIQUIDATED_SIG, 0, 0, 0);
     }
 
-    event FundingRecomputed(int funding, uint index, uint timestamp);
+    event FundingRecomputed(int funding, int fundingRate, uint index, uint timestamp);
     bytes32 internal constant FUNDINGRECOMPUTED_SIG = keccak256("FundingRecomputed(int256,int256,uint256,uint256)");
 
     function emitFundingRecomputed(

--- a/contracts/PerpsV2MarketProxyable.sol
+++ b/contracts/PerpsV2MarketProxyable.sol
@@ -96,7 +96,7 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
         int funding = _nextFundingEntry(price);
         marketState.pushFundingSequence(int128(funding));
         marketState.setFundingLastRecomputed(uint32(block.timestamp));
-        marketState.setFundingRate(fundingRate);
+        marketState.setFundingRate(int128(fundingRate));
 
         emitFundingRecomputed(funding, sequenceLengthBefore, marketState.fundingLastRecomputed());
 

--- a/contracts/PerpsV2MarketProxyable.sol
+++ b/contracts/PerpsV2MarketProxyable.sol
@@ -96,7 +96,7 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
         int funding = _nextFundingEntry(price);
         marketState.pushFundingSequence(int128(funding));
         marketState.setFundingLastRecomputed(uint32(block.timestamp));
-        marketState.setFundingRate(int128(fundingRate));
+        marketState.setFundingRateLastRecomputed(int128(fundingRate));
 
         emitFundingRecomputed(funding, fundingRate, sequenceLengthBefore, marketState.fundingLastRecomputed());
 

--- a/contracts/PerpsV2MarketSettings.sol
+++ b/contracts/PerpsV2MarketSettings.sol
@@ -95,14 +95,14 @@ contract PerpsV2MarketSettings is Owned, MixinPerpsV2MarketSettings, IPerpsV2Mar
     }
 
     /*
-     * The maximum theoretical funding rate per day charged by a market.
+     * The maximum theoretical funding velocity per day charged by a market.
      */
-    function maxFundingRate(bytes32 _marketKey) public view returns (uint) {
-        return _maxFundingRate(_marketKey);
+    function maxFundingVelocity(bytes32 _marketKey) public view returns (uint) {
+        return _maxFundingVelocity(_marketKey);
     }
 
     /*
-     * The skew level at which the max funding rate will be charged.
+     * The skew level at which the max funding velocity will be charged.
      */
     function skewScaleUSD(bytes32 _marketKey) public view returns (uint) {
         return _skewScaleUSD(_marketKey);
@@ -133,7 +133,7 @@ contract PerpsV2MarketSettings is Owned, MixinPerpsV2MarketSettings, IPerpsV2Mar
                 _delayedOrderConfirmWindow(_marketKey),
                 _maxLeverage(_marketKey),
                 _maxMarketValueUSD(_marketKey),
-                _maxFundingRate(_marketKey),
+                _maxFundingVelocity(_marketKey),
                 _skewScaleUSD(_marketKey),
                 _minDelayTimeDelta(_marketKey),
                 _maxDelayTimeDelta(_marketKey)
@@ -234,9 +234,9 @@ contract PerpsV2MarketSettings is Owned, MixinPerpsV2MarketSettings, IPerpsV2Mar
         }
     }
 
-    function setMaxFundingRate(bytes32 _marketKey, uint _maxFundingRate) public onlyOwner {
+    function setMaxFundingVelocity(bytes32 _marketKey, uint _maxFundingVelocity) public onlyOwner {
         _recomputeFunding(_marketKey);
-        _setParameter(_marketKey, PARAMETER_MAX_FUNDING_RATE, _maxFundingRate);
+        _setParameter(_marketKey, PARAMETER_MAX_FUNDING_VELOCITY, _maxFundingVelocity);
     }
 
     function setSkewScaleUSD(bytes32 _marketKey, uint _skewScaleUSD) public onlyOwner {
@@ -259,7 +259,7 @@ contract PerpsV2MarketSettings is Owned, MixinPerpsV2MarketSettings, IPerpsV2Mar
         setMakerFee(_marketKey, _parameters.makerFee);
         setMaxLeverage(_marketKey, _parameters.maxLeverage);
         setMaxMarketValueUSD(_marketKey, _parameters.maxMarketValueUSD);
-        setMaxFundingRate(_marketKey, _parameters.maxFundingRate);
+        setMaxFundingVelocity(_marketKey, _parameters.maxFundingVelocity);
         setSkewScaleUSD(_marketKey, _parameters.skewScaleUSD);
         setTakerFeeDelayedOrder(_marketKey, _parameters.takerFeeDelayedOrder);
         setMakerFeeDelayedOrder(_marketKey, _parameters.makerFeeDelayedOrder);

--- a/contracts/PerpsV2MarketState.sol
+++ b/contracts/PerpsV2MarketState.sol
@@ -48,7 +48,8 @@ contract PerpsV2MarketState is Owned, StateShared, IPerpsV2MarketBaseTypes {
     uint32 public fundingLastRecomputed;
     int128[] public fundingSequence;
 
-    int128 public fundingRate;
+    /* TODO: Add comment */
+    int128 public fundingRate = 0;
 
     /*
      * Each user's position. Multiple positions can always be merged, so each user has

--- a/contracts/PerpsV2MarketState.sol
+++ b/contracts/PerpsV2MarketState.sol
@@ -48,6 +48,8 @@ contract PerpsV2MarketState is Owned, StateShared, IPerpsV2MarketBaseTypes {
     uint32 public fundingLastRecomputed;
     int128[] public fundingSequence;
 
+    int128 public fundingRate;
+
     /*
      * Each user's position. Multiple positions can always be merged, so each user has
      * only have one position at a time.
@@ -129,6 +131,10 @@ contract PerpsV2MarketState is Owned, StateShared, IPerpsV2MarketBaseTypes {
 
     function pushFundingSequence(int128 _fundingSequence) external onlyAssociatedContracts {
         fundingSequence.push(_fundingSequence);
+    }
+
+    function setFundingRate(int128 _fundingRate) external onlyAssociatedContracts {
+        fundingRate = _fundingRate;
     }
 
     /**

--- a/contracts/PerpsV2MarketState.sol
+++ b/contracts/PerpsV2MarketState.sol
@@ -48,8 +48,12 @@ contract PerpsV2MarketState is Owned, StateShared, IPerpsV2MarketBaseTypes {
     uint32 public fundingLastRecomputed;
     int128[] public fundingSequence;
 
-    /* TODO: Add comment */
-    int128 public fundingRate = 0;
+    /*
+     * The funding rate calculated last time funding was recomputed. A market's funding rate floats is not
+     * instantly calculated based on the current market condition. It's affected by time, size, velocity,
+     * skew, etc. and is needed when calculating the next funding rate when markets are modified.
+     */
+    int128 public fundingRateLastRecomputed;
 
     /*
      * Each user's position. Multiple positions can always be merged, so each user has
@@ -77,6 +81,8 @@ contract PerpsV2MarketState is Owned, StateShared, IPerpsV2MarketBaseTypes {
 
         // Initialise the funding sequence with 0 initially accrued, so that the first usable funding index is 1.
         fundingSequence.push(0);
+
+        fundingRateLastRecomputed = 0;
     }
 
     function entryDebtCorrection() external view returns (int128) {
@@ -134,8 +140,9 @@ contract PerpsV2MarketState is Owned, StateShared, IPerpsV2MarketBaseTypes {
         fundingSequence.push(_fundingSequence);
     }
 
-    function setFundingRate(int128 _fundingRate) external onlyAssociatedContracts {
-        fundingRate = _fundingRate;
+    // TODO: Perform this update when maxFundingRate and skewScale are modified.
+    function setFundingRateLastRecomputed(int128 _fundingRateLastRecomputed) external onlyAssociatedContracts {
+        fundingRateLastRecomputed = _fundingRateLastRecomputed;
     }
 
     /**

--- a/contracts/PerpsV2MarketState.sol
+++ b/contracts/PerpsV2MarketState.sol
@@ -140,7 +140,7 @@ contract PerpsV2MarketState is Owned, StateShared, IPerpsV2MarketBaseTypes {
         fundingSequence.push(_fundingSequence);
     }
 
-    // TODO: Perform this update when maxFundingRate and skewScale are modified.
+    // TODO: Perform this update when maxFundingVelocity and skewScale are modified.
     function setFundingRateLastRecomputed(int128 _fundingRateLastRecomputed) external onlyAssociatedContracts {
         fundingRateLastRecomputed = _fundingRateLastRecomputed;
     }

--- a/contracts/PerpsV2MarketState.sol
+++ b/contracts/PerpsV2MarketState.sol
@@ -49,9 +49,8 @@ contract PerpsV2MarketState is Owned, StateShared, IPerpsV2MarketBaseTypes {
     int128[] public fundingSequence;
 
     /*
-     * The funding rate calculated last time funding was recomputed. A market's funding rate floats is not
-     * instantly calculated based on the current market condition. It's affected by time, size, velocity,
-     * skew, etc. and is needed when calculating the next funding rate when markets are modified.
+     * The funding rate last time it was recomputed. The market funding rate floats and requires the previously
+     * calculated funding rate, time, and current market conditions to derive the next.
      */
     int128 public fundingRateLastRecomputed;
 

--- a/contracts/PerpsV2MarketViews.sol
+++ b/contracts/PerpsV2MarketViews.sol
@@ -265,7 +265,7 @@ contract PerpsV2MarketViews is PerpsV2MarketBase, IPerpsV2MarketViews {
         // price = lastPrice + (liquidationMargin - margin) / positionSize - netAccrued
         int fundingPerUnit = _netFundingPerUnit(position.lastFundingIndex, currentPrice);
 
-        // minimum margin beyond which position can be liqudiated
+        // minimum margin beyond which position can be liquidated
         uint liqMargin = _liquidationMargin(positionSize, currentPrice);
 
         // A position can be liquidated whenever:

--- a/contracts/PerpsV2MarketViews.sol
+++ b/contracts/PerpsV2MarketViews.sol
@@ -98,6 +98,15 @@ contract PerpsV2MarketViews is PerpsV2MarketBase, IPerpsV2MarketViews {
     }
 
     /*
+     * Velocity is a measure of how quickly the funding rate increases or decreases. A positive velocity means
+     * funding rate is increasing positively (long skew). A negative velocity means the skew is on shorts.
+     */
+    function currentFundingRateVelocity() external view returns (int) {
+        (uint price, ) = _assetPrice();
+        return _currentFundingVelocity(price);
+    }
+
+    /*
      * The funding per base unit accrued since the funding rate was last recomputed, which has not yet
      * been persisted in the funding sequence.
      */

--- a/contracts/PerpsV2MarketViews.sol
+++ b/contracts/PerpsV2MarketViews.sol
@@ -101,7 +101,7 @@ contract PerpsV2MarketViews is PerpsV2MarketBase, IPerpsV2MarketViews {
      * Velocity is a measure of how quickly the funding rate increases or decreases. A positive velocity means
      * funding rate is increasing positively (long skew). A negative velocity means the skew is on shorts.
      */
-    function currentFundingRateVelocity() external view returns (int) {
+    function currentFundingVelocity() external view returns (int) {
         (uint price, ) = _assetPrice();
         return _currentFundingVelocity(price);
     }

--- a/contracts/interfaces/IPerpsV2MarketSettings.sol
+++ b/contracts/interfaces/IPerpsV2MarketSettings.sol
@@ -11,7 +11,7 @@ interface IPerpsV2MarketSettings {
         uint delayedOrderConfirmWindow;
         uint maxLeverage;
         uint maxMarketValueUSD;
-        uint maxFundingRate;
+        uint maxFundingVelocity;
         uint skewScaleUSD;
         uint minDelayTimeDelta;
         uint maxDelayTimeDelta;
@@ -33,7 +33,7 @@ interface IPerpsV2MarketSettings {
 
     function maxMarketValueUSD(bytes32 _marketKey) external view returns (uint);
 
-    function maxFundingRate(bytes32 _marketKey) external view returns (uint);
+    function maxFundingVelocity(bytes32 _marketKey) external view returns (uint);
 
     function skewScaleUSD(bytes32 _marketKey) external view returns (uint);
 

--- a/contracts/interfaces/IPerpsV2MarketState.sol
+++ b/contracts/interfaces/IPerpsV2MarketState.sol
@@ -45,7 +45,7 @@ interface IPerpsV2MarketState {
 
     function setFundingLastRecomputed(uint32) external;
 
-    function setFundingRate(int _fundingRate) external;
+    function setFundingRate(int128 _fundingRate) external;
 
     function pushFundingSequence(int128) external;
 

--- a/contracts/interfaces/IPerpsV2MarketState.sol
+++ b/contracts/interfaces/IPerpsV2MarketState.sol
@@ -17,6 +17,8 @@ interface IPerpsV2MarketState {
 
     function fundingSequence(uint) external view returns (int128);
 
+    function fundingRate() external view returns (int128);
+
     function positions(address) external view returns (IPerpsV2MarketBaseTypes.Position memory);
 
     function delayedOrders(address) external view returns (IPerpsV2MarketBaseTypes.DelayedOrder memory);
@@ -42,6 +44,8 @@ interface IPerpsV2MarketState {
     function setMarketSkew(int128) external;
 
     function setFundingLastRecomputed(uint32) external;
+
+    function setFundingRate(int _fundingRate) external;
 
     function pushFundingSequence(int128) external;
 

--- a/contracts/interfaces/IPerpsV2MarketState.sol
+++ b/contracts/interfaces/IPerpsV2MarketState.sol
@@ -17,7 +17,7 @@ interface IPerpsV2MarketState {
 
     function fundingSequence(uint) external view returns (int128);
 
-    function fundingRate() external view returns (int128);
+    function fundingRateLastRecomputed() external view returns (int128);
 
     function positions(address) external view returns (IPerpsV2MarketBaseTypes.Position memory);
 
@@ -45,7 +45,7 @@ interface IPerpsV2MarketState {
 
     function setFundingLastRecomputed(uint32) external;
 
-    function setFundingRate(int128 _fundingRate) external;
+    function setFundingRateLastRecomputed(int128 _fundingRateLastRecomputed) external;
 
     function pushFundingSequence(int128) external;
 

--- a/contracts/interfaces/IPerpsV2MarketViews.sol
+++ b/contracts/interfaces/IPerpsV2MarketViews.sol
@@ -38,6 +38,8 @@ interface IPerpsV2MarketViews {
 
     function currentFundingRate() external view returns (int fundingRate);
 
+    function currentFundingRateVelocity() external view returns (int fundingRateVelocity);
+
     function unrecordedFunding() external view returns (int funding, bool invalid);
 
     function fundingSequenceLength() external view returns (uint length);

--- a/contracts/interfaces/IPerpsV2MarketViews.sol
+++ b/contracts/interfaces/IPerpsV2MarketViews.sol
@@ -38,7 +38,7 @@ interface IPerpsV2MarketViews {
 
     function currentFundingRate() external view returns (int fundingRate);
 
-    function currentFundingRateVelocity() external view returns (int fundingRateVelocity);
+    function currentFundingVelocity() external view returns (int fundingRateVelocity);
 
     function unrecordedFunding() external view returns (int funding, bool invalid);
 

--- a/contracts/test-helpers/TestablePerpsV2Market.sol
+++ b/contracts/test-helpers/TestablePerpsV2Market.sol
@@ -23,8 +23,8 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
         return _proportionalSkew(price);
     }
 
-    function maxFundingRate() external view returns (uint) {
-        return _maxFundingRate(marketState.marketKey());
+    function maxFundingVelocity() external view returns (uint) {
+        return _maxFundingVelocity(marketState.marketKey());
     }
 
     /*
@@ -119,6 +119,10 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
     }
 
     function currentFundingRate() external view returns (int fundingRate) {
+        return 0;
+    }
+
+    function currentFundingVelocity() external view returns (int fundingRateVelocity) {
         return 0;
     }
 

--- a/publish/src/commands/deploy/configure-perpsv2.js
+++ b/publish/src/commands/deploy/configure-perpsv2.js
@@ -92,7 +92,7 @@ module.exports = async ({
 			maxDelayTimeDelta,
 			maxLeverage,
 			maxMarketValueUSD,
-			maxFundingRate,
+			maxFundingVelocity,
 			skewScaleUSD,
 			paused,
 		} = market;
@@ -112,7 +112,7 @@ module.exports = async ({
 			maxDelayTimeDelta: maxDelayTimeDelta,
 			maxLeverage: w3utils.toWei(maxLeverage),
 			maxMarketValueUSD: w3utils.toWei(maxMarketValueUSD),
-			maxFundingRate: w3utils.toWei(maxFundingRate),
+			maxFundingVelocity: w3utils.toWei(maxFundingVelocity),
 			skewScaleUSD: w3utils.toWei(skewScaleUSD),
 		};
 

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -17,7 +17,6 @@ const {
 	updateAggregatorRates,
 	onlyGivenAddressCanInvoke,
 } = require('./helpers');
-const { ethers } = require('ethers');
 
 const MockExchanger = artifacts.require('MockExchanger');
 

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -1050,6 +1050,10 @@ contract('PerpsV2Market', accounts => {
 					hash: tx.tx,
 					contracts: [futuresMarketManager, sUSD, futuresMarket],
 				});
+				assert.deepEqual(
+					decodedLogs.map(({ name }) => name),
+					['FundingRecomputed']
+				);
 				assert.equal(decodedLogs.length, 1);
 				assert.equal(decodedLogs[0].name, 'FundingRecomputed');
 
@@ -1228,6 +1232,10 @@ contract('PerpsV2Market', accounts => {
 
 			// The relevant events are properly emitted
 			const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
+			assert.deepEqual(
+				decodedLogs.map(({ name }) => name),
+				['FundingRecomputed', 'Issued', 'PositionModified']
+			);
 			assert.equal(decodedLogs.length, 3);
 			decodedEventEqual({
 				event: 'Issued',
@@ -1257,7 +1265,11 @@ contract('PerpsV2Market', accounts => {
 
 			// The relevant events are properly emitted
 			const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
-			assert.equal(decodedLogs.length, 4); // funding, issued, tracking, pos-modified
+			assert.deepEqual(
+				decodedLogs.map(({ name }) => name),
+				['FundingRecomputed', 'Issued', 'FuturesTracking', 'PositionModified']
+			);
+			assert.equal(decodedLogs.length, 4);
 			decodedEventEqual({
 				event: 'FuturesTracking',
 				emittedFrom: futuresMarket.address,
@@ -1704,7 +1716,10 @@ contract('PerpsV2Market', accounts => {
 					hash: tx.tx,
 					contracts: [futuresMarketManager, sUSD, futuresMarket],
 				});
-
+				assert.deepEqual(
+					decodedLogs.map(({ name }) => name),
+					['FundingRecomputed', 'Issued', 'PositionModified']
+				);
 				assert.equal(decodedLogs.length, 3);
 				const fee = multiplyDecimal(toUnit(1000), takerFee).add(
 					multiplyDecimal(toUnit(2000), makerFee)
@@ -1745,7 +1760,10 @@ contract('PerpsV2Market', accounts => {
 					hash: tx.tx,
 					contracts: [futuresMarketManager, sUSD, futuresMarket],
 				});
-
+				assert.deepEqual(
+					decodedLogs.map(({ name }) => name),
+					['FundingRecomputed', 'Issued', 'FuturesTracking', 'PositionModified']
+				);
 				assert.equal(decodedLogs.length, 4);
 				const fee = multiplyDecimal(toUnit(2000), makerFee);
 
@@ -2097,8 +2115,10 @@ contract('PerpsV2Market', accounts => {
 				await futuresMarket.transferMargin(accessible.neg(), { from: account });
 				accessible = (await futuresMarket.accessibleMargin(account))[0];
 				assert.bnClose(accessible, toBN('0'), toUnit('1'));
+
+				// withdraw large enough margin to trigger leverage > maxLeverage.
 				await assert.revert(
-					futuresMarket.transferMargin(toUnit('-1'), { from: account }),
+					futuresMarket.transferMargin(toUnit('-1.5'), { from: account }),
 					'Insufficient margin'
 				);
 			};
@@ -3594,7 +3614,10 @@ contract('PerpsV2Market', accounts => {
 				assert.bnClose(await sUSD.balanceOf(noBalance), liquidationFee, toUnit('0.001'));
 
 				const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
-
+				assert.deepEqual(
+					decodedLogs.map(({ name }) => name),
+					['FundingRecomputed', 'Issued', 'PositionModified', 'PositionLiquidated']
+				);
 				assert.equal(decodedLogs.length, 4);
 
 				decodedEventEqual({
@@ -3651,7 +3674,10 @@ contract('PerpsV2Market', accounts => {
 				assert.bnClose(await sUSD.balanceOf(noBalance), liquidationFee, toUnit('0.001'));
 
 				const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
-
+				assert.deepEqual(
+					decodedLogs.map(({ name }) => name),
+					['FundingRecomputed', 'Issued', 'PositionModified', 'PositionLiquidated', 'Issued']
+				);
 				assert.equal(decodedLogs.length, 5); // additional sUSD issue event
 
 				const poolFee = remainingMargin.sub(liquidationFee);
@@ -3697,7 +3723,10 @@ contract('PerpsV2Market', accounts => {
 				assert.bnClose(await sUSD.balanceOf(noBalance), liquidationFee, toUnit('0.001'));
 
 				const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
-
+				assert.deepEqual(
+					decodedLogs.map(({ name }) => name),
+					['FundingRecomputed', 'Issued', 'PositionModified', 'PositionLiquidated']
+				);
 				assert.equal(decodedLogs.length, 4);
 				decodedEventEqual({
 					event: 'Issued',
@@ -3752,7 +3781,10 @@ contract('PerpsV2Market', accounts => {
 				assert.bnClose(await sUSD.balanceOf(noBalance), liquidationFee, toUnit('0.001'));
 
 				const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [sUSD, futuresMarket] });
-
+				assert.deepEqual(
+					decodedLogs.map(({ name }) => name),
+					['FundingRecomputed', 'Issued', 'PositionModified', 'PositionLiquidated', 'Issued']
+				);
 				assert.equal(decodedLogs.length, 5); // additional sUSD issue event
 
 				const poolFee = remainingMargin.sub(liquidationFee);

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -216,6 +216,7 @@ contract('PerpsV2Market', accounts => {
 					'setEntryDebtCorrection',
 					'setNextPositionId',
 					'setFundingLastRecomputed',
+					'setFundingRate',
 					'pushFundingSequence',
 					'updateDelayedOrder',
 					'updatePosition',

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -1,4 +1,4 @@
-const { artifacts, contract, web3 } = require('hardhat');
+const { artifacts, contract, web3, ethers } = require('hardhat');
 const { toBytes32 } = require('../..');
 const { toBN } = web3.utils;
 const { currentTime, fastForward, toUnit, multiplyDecimal, divideDecimal } = require('../utils')();
@@ -100,7 +100,7 @@ contract('PerpsV2Market', accounts => {
 	}) {
 		await market.transferMargin(marginDelta, { from: account });
 		await setPrice(await market.baseAsset(), fillPrice);
-		await market.modifyPosition(sizeDelta, {
+		return market.modifyPosition(sizeDelta, {
 			from: account,
 		});
 	}
@@ -2678,7 +2678,33 @@ contract('PerpsV2Market', accounts => {
 		});
 	});
 
-	describe('Funding', () => {
+	describe.only('Funding', () => {
+		// New tests
+
+		describe.only('New funding unit tests', () => {
+			it('A specific complete example');
+
+			it('A balanced market may not always have zero funding');
+
+			it('Should have zero funding when market is empty');
+
+			it('Should continue to increase rate so long as the market is skewed');
+
+			it('Should stop increasing and stay elevated when market is balanced');
+
+			it('Should increase rate in opposite directly when skew flips');
+
+			it('Should proportionally affect funding after altering skewScaleUSD');
+
+			it('Should proportionally affect funding after altering maxFundingRate');
+
+			it('Should cap daily funding rate by maxFundingRate');
+
+			it('Should accrue no funding when position is zero-sized');
+		});
+
+		// Old tests (some may no longer be relevant)
+
 		it('An empty market induces zero funding rate', async () => {
 			assert.bnEqual(await futuresMarket.currentFundingRate(), toUnit(0));
 		});
@@ -3074,10 +3100,6 @@ contract('PerpsV2Market', accounts => {
 					toUnit('0.01')
 				);
 			});
-		});
-
-		it.skip('A zero-size position accrues no funding', async () => {
-			assert.isTrue(false);
 		});
 	});
 

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -2042,33 +2042,12 @@ contract('PerpsV2Market', accounts => {
 		});
 
 		describe('Remaining margin', async () => {
-			let fee, fee2;
-
 			beforeEach(async () => {
 				await setPrice(baseAsset, toUnit('100'));
-				fee = (await futuresMarket.orderFee(toUnit('50')))[0];
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				await futuresMarket.modifyPosition(toUnit('50'), { from: trader });
-				fee2 = (await futuresMarket.orderFee(toUnit('-50')))[0];
 				await futuresMarket.transferMargin(toUnit('5000'), { from: trader2 });
 				await futuresMarket.modifyPosition(toUnit('-50'), { from: trader2 });
-			});
-
-			it('Remaining margin unchanged with no funding or profit', async () => {
-				await fastForward(24 * 60 * 60);
-				// Note that the first guy paid a bit of funding as there was a delay between confirming
-				// the first and second orders
-				assert.bnClose(
-					(await futuresMarket.remainingMargin(trader))[0],
-					toUnit('1000').sub(fee),
-					toUnit('0.1')
-				);
-
-				assert.bnClose(
-					(await futuresMarket.remainingMargin(trader2))[0],
-					toUnit('5000').sub(fee2),
-					toUnit('0.1')
-				);
 			});
 
 			describe.skip('profit and no funding', async () => {

--- a/test/contracts/PerpsV2MarketData.js
+++ b/test/contracts/PerpsV2MarketData.js
@@ -167,7 +167,7 @@ contract('PerpsV2MarketData', accounts => {
 					30, // 30s delay confirm window
 					toWei('5'), // 5x max leverage
 					toWei('1000000'), // 1000000 max total margin
-					toWei('0.2'), // 20% max funding rate
+					toWei('0.2'), // 20% max funding velocity
 					toWei('100000'), // 100000 USD skewScaleUSD
 					60, // 60s minimum delay time in seconds
 					120, // 120s maximum delay time in seconds
@@ -248,7 +248,7 @@ contract('PerpsV2MarketData', accounts => {
 			assert.bnEqual(details.limits.maxLeverage, params.maxLeverage);
 			assert.bnEqual(details.limits.maxMarketValueUSD, params.maxMarketValueUSD);
 
-			assert.bnEqual(details.fundingParameters.maxFundingRate, params.maxFundingRate);
+			assert.bnEqual(details.fundingParameters.maxFundingVelocity, params.maxFundingVelocity);
 			assert.bnEqual(details.fundingParameters.skewScaleUSD, params.skewScaleUSD);
 
 			assert.bnEqual(details.marketSizeDetails.marketSize, await futuresMarket.marketSize());

--- a/test/contracts/PerpsV2MarketManager.js
+++ b/test/contracts/PerpsV2MarketManager.js
@@ -646,7 +646,7 @@ contract('PerpsV2MarketManager', accounts => {
 						30, // 30s delay confirm window
 						toUnit('5'), // 5x max leverage
 						toUnit('1000000'), // 1000000 max total margin
-						toUnit('0.2'), // 20% max funding rate
+						toUnit('0.2'), // 20% max funding velocity
 						toUnit('100000'), // 100000 USD skewScaleUSD
 						60, // 60s minimum delay time in seconds
 						120, // 120s maximum delay time in seconds

--- a/test/contracts/PerpsV2MarketSettings.js
+++ b/test/contracts/PerpsV2MarketSettings.js
@@ -36,7 +36,7 @@ contract('PerpsV2MarketSettings', accounts => {
 	const maxLeverage = toUnit('10');
 	const maxMarketValueUSD = toUnit('100000');
 
-	const maxFundingRate = toUnit('0.1');
+	const maxFundingVelocity = toUnit('0.1');
 	const skewScaleUSD = toUnit('10000');
 
 	before(async () => {
@@ -122,7 +122,7 @@ contract('PerpsV2MarketSettings', accounts => {
 				'setMakerFee',
 				'setMakerFeeDelayedOrder',
 				'setMaxDelayTimeDelta',
-				'setMaxFundingRate',
+				'setMaxFundingVelocity',
 				'setMaxLeverage',
 				'setMaxMarketValueUSD',
 				'setMinDelayTimeDelta',
@@ -149,7 +149,7 @@ contract('PerpsV2MarketSettings', accounts => {
 				nextPriceConfirmWindow,
 				maxLeverage,
 				maxMarketValueUSD,
-				maxFundingRate,
+				maxFundingVelocity,
 				skewScaleUSD,
 			}).map(([key, val]) => {
 				const capKey = key.charAt(0).toUpperCase() + key.slice(1);
@@ -479,10 +479,10 @@ contract('PerpsV2MarketSettings', accounts => {
 		it('should be able to change parameters for both markets independently', async () => {
 			const val1 = toUnit(0.1);
 			const val2 = toUnit(0.5);
-			await futuresMarketSettings.setMaxFundingRate(firstMarketKey, val1, { from: owner });
-			await futuresMarketSettings.setMaxFundingRate(secondMarketKey, val2, { from: owner });
-			assert.bnEqual(await futuresMarketSettings.maxFundingRate(firstMarketKey), val1);
-			assert.bnEqual(await futuresMarketSettings.maxFundingRate(secondMarketKey), val2);
+			await futuresMarketSettings.setMaxFundingVelocity(firstMarketKey, val1, { from: owner });
+			await futuresMarketSettings.setMaxFundingVelocity(secondMarketKey, val2, { from: owner });
+			assert.bnEqual(await futuresMarketSettings.maxFundingVelocity(firstMarketKey), val1);
+			assert.bnEqual(await futuresMarketSettings.maxFundingVelocity(secondMarketKey), val2);
 		});
 	});
 });

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -1672,7 +1672,7 @@ const setupAllContracts = async ({
 						toBN('2'), // 2 rounds next price confirm window
 						toWei('10'), // 10x max leverage
 						toWei('100000'), // 100000 max market debt
-						toWei('0.1'), // 10% max funding rate
+						toWei('0.1'), // 10% max funding velocity
 						toWei('100000'), // 100000 USD skewScaleUSD
 						{ from: owner }
 					),
@@ -1733,7 +1733,7 @@ const setupAllContracts = async ({
 							30, // 30s delay confirm window
 							toWei('10'), // 10x max leverage
 							toWei('100000'), // 100000 max market debt
-							toWei('0.1'), // 10% max funding rate
+							toWei('0.1'), // 10% max funding velocity
 							toWei('100000'), // 100000 USD skewScaleUSD
 							60, // 60s minimum delay time in seconds
 							120, // 120s maximum delay time in seconds

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -347,7 +347,7 @@ const setupContract = async ({
 			toBytes32('sETH' + perpSuffix), // market key
 		],
 		FuturesMarketData: [tryGetAddressOf('AddressResolver')],
-		// Futures V2
+		// Perps V2
 		PerpsV2MarketManager: [owner, tryGetAddressOf('AddressResolver')],
 		PerpsV2MarketSettings: [owner, tryGetAddressOf('AddressResolver')],
 		PerpsV2MarketData: [tryGetAddressOf('AddressResolver')],
@@ -416,7 +416,7 @@ const setupContract = async ({
 				instance.address
 			);
 			if (contract.startsWith('PerpsV2Market') || contract.startsWith('ProxyPerpsV2Market')) {
-				log('Deployed wiht default args:', defaultArgs[contract], 'and args:', args);
+				log('Deployed with default args:', defaultArgs[contract], 'and args:', args);
 			}
 		}
 	} catch (err) {

--- a/test/utils/index.js
+++ b/test/utils/index.js
@@ -370,11 +370,11 @@ module.exports = ({ web3 } = {}) => {
 
 		assert.ok(
 			actual.gte(expected.sub(variance)),
-			`${actual} !~= ${expected} (maxVariance ${variance.toString()}`
+			`${actual} !~= ${expected} (maxVariance ${variance.toString()})`
 		);
 		assert.ok(
 			actual.lte(expected.add(variance)),
-			`${actual} !~= ${expected} (maxVariance ${variance.toString()}`
+			`${actual} !~= ${expected} (maxVariance ${variance.toString()})`
 		);
 	};
 


### PR DESCRIPTION
This PR is the implementation of both the premium/discount pricing function and the new funding rate velocity model described in SIP-279.

Main to-do list:

- [x] Funding rate velocity model
- [ ] Premium/discount pricing function

Smaller to-do list tasks:

- [x] Replace `skewScaleUsd` with `skewScale` (https://github.com/Synthetixio/synthetix/pull/1921)
- [x] Replace `maxMarketValueUSD` with `maxMarketValue`(https://github.com/Synthetixio/synthetix/pull/1921)
- [ ] Reason whether `fundingRateLastRecomputed` should be updated

Technical details:

- `PARAMETER_MAX_FUNDING_RATE` has been replaced with `PARAMETER_MAX_FUNDING_VELOCITY`
- `skewScaleUsd` replaced by just `skewScale` (not usd). Note that an intended byproduct of this is outside prices no longer impact the market skew
- `maxMarketValueUSD` replaced by just `maxMarketValue`
- `currentFundingRate` returns an inverted funding rate (when skewed long it returns negative but positive when skewed short). This is now changed and `currentFundingRate` no longer inverts. Funding entries in the funding sequence remain the same. The inversion happens during the `unrecordedFunding` call
- `FundingRecomputed` event now also includes the `fundingRate`
- A `fundingRateLastRecomputed` is now stored in the market state contract to track the floating funding rate
- A `currentFundingVelocity` is exposed to provide details on the current velocity
- Unlike `maxFundingRate` in V1, the `maxFundingVelocity` is capped. Although it is unlikely this will ever occur, there's code to ensure the proportional skew stays within [-1, 1] to avoid exceeding the max daily funding velocity

Resources:

- https://github.com/davidvuong/perpsv2-funding/blob/master/main.ipynb
- https://blog.synthetix.io/perps-v2-summary/
- https://sips.synthetix.io/sips/sip-279/
