### PR TITLE
Fix remaining liquidation tests affected by p/d pricing

### DIFF
--- a/contracts/test-helpers/TestablePerpsV2Market.sol
+++ b/contracts/test-helpers/TestablePerpsV2Market.sol
@@ -115,9 +115,15 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
         return (fillPrice, invalid);
     }
 
-    /* @dev Given the size and baseBase (e.g. current off-chain price), return the expected fillPrice */
+    /* @dev Given the size and basePrice (e.g. current off-chain price), return the expected fillPrice */
     function fillPriceWithBasePrice(int size, uint basePrice) external view returns (uint price) {
         return _fillPrice(size, basePrice);
+    }
+
+    /* @dev Given an account, find the associated position and return the netFundingPerUnit. */
+    function netFundingPerUnit(address account) external view returns (int) {
+        Position memory position = marketState.positions(account);
+        return _netFundingPerUnit(position.lastFundingIndex);
     }
 
     function marketSizes() external view returns (uint long, uint short) {

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -3963,7 +3963,7 @@ contract('PerpsV2Market', accounts => {
 			}) => {
 				const defaultLiquidationBufferRatio = toUnit('0.0025');
 				const defaultLiquidationFeeRatio = toUnit('0.0035');
-				const defaultLiquidationMinFee = toUnit('20'); // 20 USD
+				const defaultLiquidationMinFee = toUnit('20'); // 20 sUSD
 
 				const liqMinFee = minFee || defaultLiquidationMinFee;
 				const liqFeeRatio = feeRatio || defaultLiquidationFeeRatio;
@@ -3971,7 +3971,7 @@ contract('PerpsV2Market', accounts => {
 
 				// How is the liquidation price calculated?
 				//
-				// liqFee    = max(Math.abs(size) * price * liquidationFeeRatio, minFee)
+				// liqFee    = max(abs(size) * price * liquidationFeeRatio, minFee)
 				// liqMargin = abs(pos.size) * price * liquidationBufferRatio + liqFee
 				// liqPrice  = pos.lastPrice + (liqMargin - (pos.margin - fees)) / pos.size - fundingPerUnit
 
@@ -4424,7 +4424,7 @@ contract('PerpsV2Market', accounts => {
 				// liquidated longs). However, the long positions are actually underwater and the negative
 				// contribution is not removed until liquidation
 				//
-				// marketDebt is impacted by funding (priceWithFunding) and debtCorrection, which affects marketDebt
+				// marketDebt is impacted by funding (priceWithFunding) and debtCorrection, which affects marketDebt,
 				// is also affected by p/d as lastPrice stored on the position is the fillPrice (impacted by sizeDelta).
 				//
 				// nextFundingEntry = lastFundingEntry + unrecordedFunding


### PR DESCRIPTION
This resolves the remaining skipped liquidation related unit tests for Perps V2 after the introduction of the p/d pricing function (denoted, `fillPrice`) in a prior PR (https://github.com/Synthetixio/synthetix/pull/1921) as part of the implementation for SIP 279.