### PR TITLE
SIP 279 Slippage Protection

### DIFF
--- a/contracts/PerpsV2Market.sol
+++ b/contracts/PerpsV2Market.sol
@@ -182,11 +182,19 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
      * Same as modifyPosition, but emits an event with the passed tracking code to
      * allow off-chain calculations for fee sharing with originating integrations
      */
-    function modifyPositionWithTracking(int sizeDelta, uint slippage, bytes32 trackingCode) external {
+    function modifyPositionWithTracking(
+        int sizeDelta,
+        uint slippage,
+        bytes32 trackingCode
+    ) external {
         _modifyPosition(sizeDelta, slippage, trackingCode);
     }
 
-    function _modifyPosition(int sizeDelta, uint slippage, bytes32 trackingCode) internal onlyProxy {
+    function _modifyPosition(
+        int sizeDelta,
+        uint slippage,
+        bytes32 trackingCode
+    ) internal onlyProxy {
         uint price = _assetPriceRequireSystemChecks();
         _recomputeFunding();
         _trade(

--- a/contracts/PerpsV2Market.sol
+++ b/contracts/PerpsV2Market.sol
@@ -174,19 +174,19 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
      * Adjust the sender's position size.
      * Reverts if the resulting position is too large, outside the max leverage, or is liquidating.
      */
-    function modifyPosition(int sizeDelta) external {
-        _modifyPosition(sizeDelta, bytes32(0));
+    function modifyPosition(int sizeDelta, uint slippage) external {
+        _modifyPosition(sizeDelta, slippage, bytes32(0));
     }
 
     /*
      * Same as modifyPosition, but emits an event with the passed tracking code to
      * allow off-chain calculations for fee sharing with originating integrations
      */
-    function modifyPositionWithTracking(int sizeDelta, bytes32 trackingCode) external {
-        _modifyPosition(sizeDelta, trackingCode);
+    function modifyPositionWithTracking(int sizeDelta, uint slippage, bytes32 trackingCode) external {
+        _modifyPosition(sizeDelta, slippage, trackingCode);
     }
 
-    function _modifyPosition(int sizeDelta, bytes32 trackingCode) internal onlyProxy {
+    function _modifyPosition(int sizeDelta, uint slippage, bytes32 trackingCode) internal onlyProxy {
         uint price = _assetPriceRequireSystemChecks();
         _recomputeFunding();
         _trade(
@@ -196,6 +196,7 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
                 price: price,
                 takerFee: _takerFee(_marketKey()),
                 makerFee: _makerFee(_marketKey()),
+                slippage: slippage,
                 trackingCode: trackingCode
             })
         );
@@ -225,6 +226,7 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
                 price: price,
                 takerFee: _takerFee(_marketKey()),
                 makerFee: _makerFee(_marketKey()),
+                slippage: 0, // zero here because we don't care when closing a position.
                 trackingCode: trackingCode
             })
         );

--- a/contracts/PerpsV2Market.sol
+++ b/contracts/PerpsV2Market.sol
@@ -104,7 +104,7 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
         // This is because this method is used by system settings when changing funding related
         // parameters, so needs to function even when system / market is paused. E.g. to facilitate
         // market migration.
-        (uint _, bool invalid) = _assetPrice();
+        (, bool invalid) = _assetPrice();
         // A check for a valid price is still in place, to ensure that a system settings action
         // doesn't take place when the price is invalid (e.g. some oracle issue).
         require(!invalid, "Invalid price");

--- a/contracts/PerpsV2Market.sol
+++ b/contracts/PerpsV2Market.sol
@@ -187,7 +187,7 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
     }
 
     function _modifyPosition(int sizeDelta, bytes32 trackingCode) internal onlyProxy {
-        uint price = _fillPrice(sizeDelta, _assetPriceRequireSystemChecks());
+        uint price = _assetPriceRequireSystemChecks();
         _recomputeFunding();
         _trade(
             messageSender,
@@ -216,7 +216,7 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
     function _closePosition(bytes32 trackingCode) internal onlyProxy {
         int size = marketState.positions(messageSender).size;
         _revertIfError(size == 0, Status.NoPositionOpen);
-        uint price = _fillPrice(-size, _assetPriceRequireSystemChecks());
+        uint price = _assetPriceRequireSystemChecks();
         _recomputeFunding();
         _trade(
             messageSender,

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -71,6 +71,7 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
         uint price;
         uint takerFee;
         uint makerFee;
+        uint slippage;
         bytes32 trackingCode; // optional tracking code for volume source fee sharing
     }
 
@@ -95,6 +96,7 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
         _errorMessages[uint8(Status.NilOrder)] = "Cannot submit empty order";
         _errorMessages[uint8(Status.NoPositionOpen)] = "No position open";
         _errorMessages[uint8(Status.PriceTooVolatile)] = "Price too volatile";
+        _errorMessages[uint8(Status.SlippageToleranceExceeded)] = "Price exceeded slippage tolerance";
     }
 
     /* ---------- External Contracts ---------- */
@@ -575,7 +577,11 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
      * percentage of the fillPrice. So assuming no dynamic fees and this is a taker trade with a 0.0045
      * fee on a 10k USD sized trade then the slippagePrice would be 100 + 10000 * 0.0045 = 145.
      */
-    function _maxSlippagePrice(uint price, uint slippage, uint orderFee) internal pure returns (uint) {
+    function _maxSlippagePrice(
+        uint price,
+        uint slippage,
+        uint orderFee
+    ) internal pure returns (uint) {
         // No slippage is specified, use the orderFee as the upper bound.
         if (slippage == 0) {
             return price.add(orderFee);

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -567,11 +567,21 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
     }
 
     /*
-     * @dev Given the current price (not fillPrice) and slippage, determine the upper bound the fillPrice
-     * is allowed, for a trade to execute successfully.
+     * @dev Given the current oracle price (not fillPrice) and slippage, return the max slippage
+     * price which is a price that is inclusive of the slippage tolerance.
      *
-     * For instance, if price is 100 and slippage is 0.01 then maxSlippagePrice is 101. The fillPrice must be
-     * below 101 for the trade to succeed.
+     * For instance, if price ETH is $1000 and slippage is 1% then maxSlippagePrice is $1010. The fillPrice
+     * on the trade must be below $1010 for the trade to succeed.
+     *
+     * For clarity when slippage is:
+     *  0.1   then 10%
+     *  0.01  then 1%
+     *  0.001 then 0.1%
+     *
+     * When price is $1000 and slippage is:
+     *  0.1   then price * (1 + 0.1)   = 1100
+     *  0.01  then price * (1 + 0.01)  = 1010
+     *  0.001 then price * (1 + 0.001) = 1001
      *
      * When slippage is not specified (i.e. 0) then we derive the price by looking at the orderFee as a
      * percentage of the fillPrice. So assuming no dynamic fees and this is a taker trade with a 0.0045

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -592,7 +592,10 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
         uint slippage,
         uint orderFee
     ) internal pure returns (uint) {
-        // No slippage is specified, use the orderFee as the upper bound.
+        // No slippage is specified, use the orderFee for the upper bound.
+        //
+        // note: We look at orderFee (not maker/taker fee) because orderFee considers the case when a
+        // trade with large enough size can flip the skew.
         if (slippage == 0) {
             return price.add(orderFee);
         }

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -580,7 +580,7 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
         if (slippage == 0) {
             return price.add(orderFee);
         }
-        return multipleDecimal(price, uint(_UNIT).add(slippage));
+        return price.multiplyDecimal(uint(_UNIT).add(slippage));
     }
 
     /*

--- a/contracts/PerpsV2MarketDelayedOrders.sol
+++ b/contracts/PerpsV2MarketDelayedOrders.sol
@@ -127,7 +127,6 @@ contract PerpsV2MarketDelayedOrders is IPerpsV2MarketDelayedOrders, PerpsV2Marke
 
         // price depends on whether the delay or price update has reached/occurred first
         uint currentPrice = _assetPriceRequireSystemChecks();
-        currentPrice = _fillPrice(order.sizeDelta, _assetPriceRequireSystemChecks());
 
         _executeDelayedOrder(
             account,

--- a/contracts/PerpsV2MarketDelayedOrders.sol
+++ b/contracts/PerpsV2MarketDelayedOrders.sol
@@ -41,26 +41,28 @@ contract PerpsV2MarketDelayedOrders is IPerpsV2MarketDelayedOrders, PerpsV2Marke
      * Reverts if the desiredTimeDelta is < minimum required delay.
      *
      * @param sizeDelta size in baseAsset (notional terms) of the order, similar to `modifyPosition` interface
+     * @param slippage is a percentage tolerance on fillPrice to be check upon execution
      * @param desiredTimeDelta maximum time in seconds to wait before filling this order
      */
-    function submitDelayedOrder(int sizeDelta, uint desiredTimeDelta) external onlyProxy {
+    function submitDelayedOrder(int sizeDelta, uint slippage, uint desiredTimeDelta) external onlyProxy {
         // @dev market key is obtained here and not in internal function to prevent stack too deep there
         // bytes32 marketKey = _marketKey();
 
-        _submitDelayedOrder(_marketKey(), sizeDelta, desiredTimeDelta, bytes32(0), false);
+        _submitDelayedOrder(_marketKey(), sizeDelta, slippage, desiredTimeDelta, bytes32(0), false);
     }
 
     /// same as submitDelayedOrder but emits an event with the tracking code
     /// to allow volume source fee sharing for integrations
     function submitDelayedOrderWithTracking(
         int sizeDelta,
+        uint slippage,
         uint desiredTimeDelta,
         bytes32 trackingCode
     ) external onlyProxy {
         // @dev market key is obtained here and not in internal function to prevent stack too deep there
         // bytes32 marketKey = _marketKey();
 
-        _submitDelayedOrder(_marketKey(), sizeDelta, desiredTimeDelta, trackingCode, false);
+        _submitDelayedOrder(_marketKey(), sizeDelta, slippage, desiredTimeDelta, trackingCode, false);
     }
 
     /**
@@ -127,7 +129,6 @@ contract PerpsV2MarketDelayedOrders is IPerpsV2MarketDelayedOrders, PerpsV2Marke
 
         // price depends on whether the delay or price update has reached/occurred first
         uint currentPrice = _assetPriceRequireSystemChecks();
-
         _executeDelayedOrder(
             account,
             order,

--- a/contracts/PerpsV2MarketDelayedOrders.sol
+++ b/contracts/PerpsV2MarketDelayedOrders.sol
@@ -44,7 +44,11 @@ contract PerpsV2MarketDelayedOrders is IPerpsV2MarketDelayedOrders, PerpsV2Marke
      * @param slippage is a percentage tolerance on fillPrice to be check upon execution
      * @param desiredTimeDelta maximum time in seconds to wait before filling this order
      */
-    function submitDelayedOrder(int sizeDelta, uint slippage, uint desiredTimeDelta) external onlyProxy {
+    function submitDelayedOrder(
+        int sizeDelta,
+        uint slippage,
+        uint desiredTimeDelta
+    ) external onlyProxy {
         // @dev market key is obtained here and not in internal function to prevent stack too deep there
         // bytes32 marketKey = _marketKey();
 

--- a/contracts/PerpsV2MarketDelayedOrdersBase.sol
+++ b/contracts/PerpsV2MarketDelayedOrdersBase.sol
@@ -183,11 +183,14 @@ contract PerpsV2MarketDelayedOrdersBase is PerpsV2MarketProxyable {
 
         uint fundingIndex = _recomputeFunding();
 
+        // we need to grab the fillPrice for events and margin updates (but this is also calc in _trade).
+        uint fillPrice = _fillPrice(order.sizeDelta, currentPrice);
+
         // refund the commitFee (and possibly the keeperFee) to the margin before executing the order
         // if the order later fails this is reverted of course
-        _updatePositionMargin(account, position, currentPrice, int(toRefund));
+        _updatePositionMargin(account, position, fillPrice, int(toRefund));
         // emit event for modifying the position (refunding fee/s)
-        emitPositionModified(position.id, account, position.margin, position.size, 0, currentPrice, fundingIndex, 0);
+        emitPositionModified(position.id, account, position.margin, position.size, 0, fillPrice, fundingIndex, 0);
 
         // execute or revert
         _trade(

--- a/contracts/PerpsV2MarketDelayedOrdersBase.sol
+++ b/contracts/PerpsV2MarketDelayedOrdersBase.sol
@@ -104,7 +104,6 @@ contract PerpsV2MarketDelayedOrdersBase is PerpsV2MarketProxyable {
             messageSender,
             order.isOffchain,
             order.sizeDelta,
-            order.slippage,
             order.targetRoundId,
             order.executableAtTime,
             order.commitDeposit,
@@ -159,7 +158,6 @@ contract PerpsV2MarketDelayedOrdersBase is PerpsV2MarketProxyable {
             account,
             currentRoundId,
             order.sizeDelta,
-            order.slippage,
             order.targetRoundId,
             order.commitDeposit,
             order.keeperDeposit,
@@ -220,7 +218,6 @@ contract PerpsV2MarketDelayedOrdersBase is PerpsV2MarketProxyable {
             account,
             currentRoundId,
             order.sizeDelta,
-            order.slippage,
             order.targetRoundId,
             order.commitDeposit,
             order.keeperDeposit,
@@ -254,7 +251,6 @@ contract PerpsV2MarketDelayedOrdersBase is PerpsV2MarketProxyable {
         address indexed account,
         bool isOffchain,
         int sizeDelta,
-        uint slippage,
         uint targetRoundId,
         uint executableAtTime,
         uint commitDeposit,
@@ -262,13 +258,12 @@ contract PerpsV2MarketDelayedOrdersBase is PerpsV2MarketProxyable {
         bytes32 trackingCode
     );
     bytes32 internal constant DELAYEDORDERSUBMITTED_SIG =
-        keccak256("DelayedOrderSubmitted(address,bool,int256,uint256,uint256,uint256,uint256,uint256,bytes32)");
+        keccak256("DelayedOrderSubmitted(address,bool,int256,uint256,uint256,uint256,uint256,bytes32)");
 
     function emitDelayedOrderSubmitted(
         address account,
         bool isOffchain,
         int sizeDelta,
-        uint slippage,
         uint targetRoundId,
         uint executableAtTime,
         uint commitDeposit,
@@ -276,7 +271,7 @@ contract PerpsV2MarketDelayedOrdersBase is PerpsV2MarketProxyable {
         bytes32 trackingCode
     ) internal {
         proxy._emit(
-            abi.encode(isOffchain, sizeDelta, slippage, targetRoundId, executableAtTime, commitDeposit, keeperDeposit, trackingCode),
+            abi.encode(isOffchain, sizeDelta, targetRoundId, executableAtTime, commitDeposit, keeperDeposit, trackingCode),
             2,
             DELAYEDORDERSUBMITTED_SIG,
             addressToBytes32(account),
@@ -289,27 +284,25 @@ contract PerpsV2MarketDelayedOrdersBase is PerpsV2MarketProxyable {
         address indexed account,
         uint currentRoundId,
         int sizeDelta,
-        uint slippage,
         uint targetRoundId,
         uint commitDeposit,
         uint keeperDeposit,
         bytes32 trackingCode
     );
     bytes32 internal constant DELAYEDORDERREMOVED_SIG =
-        keccak256("DelayedOrderRemoved(address,uint256,int256,uint256,uint256,uint256,uint256,bytes32)");
+        keccak256("DelayedOrderRemoved(address,uint256,int256,uint256,uint256,uint256,bytes32)");
 
     function emitDelayedOrderRemoved(
         address account,
         uint currentRoundId,
         int sizeDelta,
-        uint slippage,
         uint targetRoundId,
         uint commitDeposit,
         uint keeperDeposit,
         bytes32 trackingCode
     ) internal {
         proxy._emit(
-            abi.encode(currentRoundId, sizeDelta, slippage, targetRoundId, commitDeposit, keeperDeposit, trackingCode),
+            abi.encode(currentRoundId, sizeDelta, targetRoundId, commitDeposit, keeperDeposit, trackingCode),
             2,
             DELAYEDORDERREMOVED_SIG,
             addressToBytes32(account),

--- a/contracts/PerpsV2MarketDelayedOrdersOffchain.sol
+++ b/contracts/PerpsV2MarketDelayedOrdersOffchain.sol
@@ -118,7 +118,6 @@ contract PerpsV2MarketDelayedOrdersOffchain is IPerpsV2MarketOffchainOrders, Per
         uint minAge = _offchainDelayedOrderMinAge(_marketKey());
 
         (uint currentPrice, uint executionTimestamp) = _offchainAssetPriceRequireSystemChecks(maxAge);
-        uint fillPrice = _fillPrice(order.sizeDelta, currentPrice);
 
         require((executionTimestamp > order.intentionTime), "price not updated");
         require((executionTimestamp - order.intentionTime > minAge), "too early");
@@ -127,7 +126,7 @@ contract PerpsV2MarketDelayedOrdersOffchain is IPerpsV2MarketOffchainOrders, Per
         _executeDelayedOrder(
             account,
             order,
-            fillPrice,
+            currentPrice,
             0,
             _takerFeeOffchainDelayedOrder(_marketKey()),
             _makerFeeOffchainDelayedOrder(_marketKey())

--- a/contracts/PerpsV2MarketDelayedOrdersOffchain.sol
+++ b/contracts/PerpsV2MarketDelayedOrdersOffchain.sol
@@ -49,20 +49,21 @@ contract PerpsV2MarketDelayedOrdersOffchain is IPerpsV2MarketOffchainOrders, Per
      * Reverts if the desiredTimeDelta is < minimum required delay.
      *
      * @param sizeDelta size in baseAsset (notional terms) of the order, similar to `modifyPosition` interface
+     * @param slippage is a percentage tolerance on fillPrice to be check upon execution
      */
-    function submitOffchainDelayedOrder(int sizeDelta) external onlyProxy {
+    function submitOffchainDelayedOrder(int sizeDelta, uint slippage) external onlyProxy {
         // @dev market key is obtained here and not in internal function to prevent stack too deep there
         // bytes32 marketKey = _marketKey();
 
         // enforcing desiredTimeDelta to 0 to use default (not needed for offchain delayed order)
-        _submitDelayedOrder(_marketKey(), sizeDelta, 0, bytes32(0), true);
+        _submitDelayedOrder(_marketKey(), sizeDelta, slippage, 0, bytes32(0), true);
     }
 
-    function submitOffchainDelayedOrderWithTracking(int sizeDelta, bytes32 trackingCode) external onlyProxy {
+    function submitOffchainDelayedOrderWithTracking(int sizeDelta, uint slippage, bytes32 trackingCode) external onlyProxy {
         // @dev market key is obtained here and not in internal function to prevent stack too deep there
         // bytes32 marketKey = _marketKey();
 
-        _submitDelayedOrder(_marketKey(), sizeDelta, 0, trackingCode, true);
+        _submitDelayedOrder(_marketKey(), sizeDelta, slippage, 0, trackingCode, true);
     }
 
     /**

--- a/contracts/PerpsV2MarketDelayedOrdersOffchain.sol
+++ b/contracts/PerpsV2MarketDelayedOrdersOffchain.sol
@@ -59,7 +59,11 @@ contract PerpsV2MarketDelayedOrdersOffchain is IPerpsV2MarketOffchainOrders, Per
         _submitDelayedOrder(_marketKey(), sizeDelta, slippage, 0, bytes32(0), true);
     }
 
-    function submitOffchainDelayedOrderWithTracking(int sizeDelta, uint slippage, bytes32 trackingCode) external onlyProxy {
+    function submitOffchainDelayedOrderWithTracking(
+        int sizeDelta,
+        uint slippage,
+        bytes32 trackingCode
+    ) external onlyProxy {
         // @dev market key is obtained here and not in internal function to prevent stack too deep there
         // bytes32 marketKey = _marketKey();
 

--- a/contracts/PerpsV2MarketProxyable.sol
+++ b/contracts/PerpsV2MarketProxyable.sol
@@ -156,6 +156,9 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
     }
 
     function _trade(address sender, TradeParams memory params) internal {
+        // update the price of the intended trade to account to the affect to skew.
+        params.price = _fillPrice(params.sizeDelta, params.price);
+
         Position memory position = marketState.positions(sender);
         Position memory oldPosition =
             Position({

--- a/contracts/PerpsV2MarketProxyable.sol
+++ b/contracts/PerpsV2MarketProxyable.sol
@@ -89,6 +89,20 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
         return price;
     }
 
+    /*
+     * @dev Checks if the fillPrice does not exceed slippage tolerance.
+     */
+    function _assertPriceSlippage(
+        uint price,
+        uint fillPrice,
+        uint slippage,
+        uint orderFee
+    ) internal view returns (uint) {
+        uint maxSlippagePrice = _maxSlippagePrice(price, slippage, orderFee);
+        _revertIfError(fillPrice > maxSlippagePrice, Status.SlippageToleranceExceeded);
+        return maxSlippagePrice;
+    }
+
     function _recomputeFunding() internal returns (uint lastIndex) {
         uint sequenceLengthBefore = marketState.fundingSequenceLength();
 
@@ -156,8 +170,10 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
     }
 
     function _trade(address sender, TradeParams memory params) internal {
+        // track the original price as its needed to calculate if slippage is acceptable.
+        uint price = params.price;
         // update the price of the intended trade to account to the affect to skew.
-        params.price = _fillPrice(params.sizeDelta, params.price);
+        params.price = _fillPrice(params.sizeDelta, price);
 
         Position memory position = marketState.positions(sender);
         Position memory oldPosition =
@@ -172,6 +188,8 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
         // Compute the new position after performing the trade
         (Position memory newPosition, uint fee, Status status) = _postTradeDetails(oldPosition, params);
         _revertIfError(status);
+
+        _assertPriceSlippage(price, params.price, params.slippage, fee);
 
         // Update the aggregated market size and skew with the new order size
         marketState.setMarketSkew(int128(int(marketState.marketSkew()).add(newPosition.size).sub(oldPosition.size)));

--- a/contracts/PerpsV2MarketState.sol
+++ b/contracts/PerpsV2MarketState.sol
@@ -171,6 +171,7 @@ contract PerpsV2MarketState is Owned, StateShared, IPerpsV2MarketBaseTypes {
      * @dev Only the associated contract may call this.
      * @param account The account whose value to set.
      * @param sizeDelta Difference in position to pass to modifyPosition
+     * @param slippage Slippage tolerance as a percentage used on fillPrice at execution
      * @param targetRoundId Price oracle roundId using which price this order needs to executed
      * @param commitDeposit The commitDeposit paid upon submitting that needs to be refunded if order succeeds
      * @param keeperDeposit The keeperDeposit paid upon submitting that needs to be paid / refunded on tx confirmation
@@ -182,6 +183,7 @@ contract PerpsV2MarketState is Owned, StateShared, IPerpsV2MarketBaseTypes {
         address account,
         bool isOffchain,
         int128 sizeDelta,
+        uint128 slippage,
         uint128 targetRoundId,
         uint128 commitDeposit,
         uint128 keeperDeposit,
@@ -192,6 +194,7 @@ contract PerpsV2MarketState is Owned, StateShared, IPerpsV2MarketBaseTypes {
         delayedOrders[account] = DelayedOrder(
             isOffchain,
             sizeDelta,
+            slippage,
             targetRoundId,
             commitDeposit,
             keeperDeposit,

--- a/contracts/PerpsV2MarketViews.sol
+++ b/contracts/PerpsV2MarketViews.sol
@@ -247,7 +247,6 @@ contract PerpsV2MarketViews is PerpsV2MarketBase, IPerpsV2MarketViews {
     {
         bool invalid;
         (price, invalid) = _assetPrice();
-        uint fillPrice = _fillPrice(sizeDelta, price);
 
         if (invalid) {
             return (0, 0, 0, 0, 0, Status.InvalidPrice);
@@ -256,7 +255,7 @@ contract PerpsV2MarketViews is PerpsV2MarketBase, IPerpsV2MarketViews {
         TradeParams memory params =
             TradeParams({
                 sizeDelta: sizeDelta,
-                price: fillPrice,
+                price: _fillPrice(sizeDelta, price),
                 takerFee: _takerFee(_marketKey()),
                 makerFee: _makerFee(_marketKey()),
                 trackingCode: bytes32(0)

--- a/contracts/PerpsV2MarketViews.sol
+++ b/contracts/PerpsV2MarketViews.sol
@@ -225,6 +225,7 @@ contract PerpsV2MarketViews is PerpsV2MarketBase, IPerpsV2MarketViews {
                 price: _fillPrice(sizeDelta, price),
                 takerFee: _takerFee(_marketKey()),
                 makerFee: _makerFee(_marketKey()),
+                slippage: 0, // slippage is not needed to calculate order fees.
                 trackingCode: bytes32(0)
             });
         return (_orderFee(params, dynamicFeeRate), isInvalid || tooVolatile);
@@ -232,6 +233,8 @@ contract PerpsV2MarketViews is PerpsV2MarketBase, IPerpsV2MarketViews {
 
     /*
      * Returns all new position details if a given order from `sender` was confirmed at the current price.
+     *
+     * note: We do not check for slippage during this trade simulation.
      */
     function postTradeDetails(int sizeDelta, address sender)
         external
@@ -255,9 +258,10 @@ contract PerpsV2MarketViews is PerpsV2MarketBase, IPerpsV2MarketViews {
         TradeParams memory params =
             TradeParams({
                 sizeDelta: sizeDelta,
-                price: _fillPrice(sizeDelta, price),
+                price: _fillPrice(sizeDelta, price), // we use fillPrice here as we're not actually calling _trade.
                 takerFee: _takerFee(_marketKey()),
                 makerFee: _makerFee(_marketKey()),
+                slippage: 0,
                 trackingCode: bytes32(0)
             });
         (Position memory newPosition, uint fee_, Status status_) = _postTradeDetails(marketState.positions(sender), params);

--- a/contracts/interfaces/IPerpsV2Market.sol
+++ b/contracts/interfaces/IPerpsV2Market.sol
@@ -13,9 +13,9 @@ interface IPerpsV2Market {
 
     function withdrawAllMargin() external;
 
-    function modifyPosition(int sizeDelta) external;
+    function modifyPosition(int sizeDelta, uint slippage) external;
 
-    function modifyPositionWithTracking(int sizeDelta, bytes32 trackingCode) external;
+    function modifyPositionWithTracking(int sizeDelta, uint slippage, bytes32 trackingCode) external;
 
     function closePosition() external;
 

--- a/contracts/interfaces/IPerpsV2Market.sol
+++ b/contracts/interfaces/IPerpsV2Market.sol
@@ -15,7 +15,11 @@ interface IPerpsV2Market {
 
     function modifyPosition(int sizeDelta, uint slippage) external;
 
-    function modifyPositionWithTracking(int sizeDelta, uint slippage, bytes32 trackingCode) external;
+    function modifyPositionWithTracking(
+        int sizeDelta,
+        uint slippage,
+        bytes32 trackingCode
+    ) external;
 
     function closePosition() external;
 

--- a/contracts/interfaces/IPerpsV2MarketBaseTypes.sol
+++ b/contracts/interfaces/IPerpsV2MarketBaseTypes.sol
@@ -15,7 +15,8 @@ interface IPerpsV2MarketBaseTypes {
         NotPermitted,
         NilOrder,
         NoPositionOpen,
-        PriceTooVolatile
+        PriceTooVolatile,
+        SlippageToleranceExceeded
     }
 
     // If margin/size are positive, the position is long; if negative then it is short.
@@ -31,6 +32,7 @@ interface IPerpsV2MarketBaseTypes {
     struct DelayedOrder {
         bool isOffchain; // flag indicating the delayed order is offchain
         int128 sizeDelta; // difference in position to pass to modifyPosition
+        uint128 slippage; // slippage tolerance as a percentage used on fillPrice at execution
         uint128 targetRoundId; // price oracle roundId using which price this order needs to executed
         uint128 commitDeposit; // the commitDeposit paid upon submitting that needs to be refunded if order succeeds
         uint128 keeperDeposit; // the keeperDeposit paid upon submitting that needs to be paid / refunded on tx confirmation

--- a/contracts/interfaces/IPerpsV2MarketDelayedOrders.sol
+++ b/contracts/interfaces/IPerpsV2MarketDelayedOrders.sol
@@ -1,10 +1,11 @@
 pragma solidity ^0.5.16;
 
 interface IPerpsV2MarketDelayedOrders {
-    function submitDelayedOrder(int sizeDelta, uint desiredTimeDelta) external;
+    function submitDelayedOrder(int sizeDelta, uint slippage, uint desiredTimeDelta) external;
 
     function submitDelayedOrderWithTracking(
         int sizeDelta,
+        uint slippage,
         uint desiredTimeDelta,
         bytes32 trackingCode
     ) external;

--- a/contracts/interfaces/IPerpsV2MarketDelayedOrders.sol
+++ b/contracts/interfaces/IPerpsV2MarketDelayedOrders.sol
@@ -1,7 +1,11 @@
 pragma solidity ^0.5.16;
 
 interface IPerpsV2MarketDelayedOrders {
-    function submitDelayedOrder(int sizeDelta, uint slippage, uint desiredTimeDelta) external;
+    function submitDelayedOrder(
+        int sizeDelta,
+        uint slippage,
+        uint desiredTimeDelta
+    ) external;
 
     function submitDelayedOrderWithTracking(
         int sizeDelta,

--- a/contracts/interfaces/IPerpsV2MarketOffchainOrders.sol
+++ b/contracts/interfaces/IPerpsV2MarketOffchainOrders.sol
@@ -2,9 +2,9 @@ pragma solidity ^0.5.16;
 pragma experimental ABIEncoderV2;
 
 interface IPerpsV2MarketOffchainOrders {
-    function submitOffchainDelayedOrder(int sizeDelta) external;
+    function submitOffchainDelayedOrder(int sizeDelta, uint slippage) external;
 
-    function submitOffchainDelayedOrderWithTracking(int sizeDelta, bytes32 trackingCode) external;
+    function submitOffchainDelayedOrderWithTracking(int sizeDelta, uint slippage, bytes32 trackingCode) external;
 
     function cancelOffchainDelayedOrder(address account) external;
 

--- a/contracts/interfaces/IPerpsV2MarketOffchainOrders.sol
+++ b/contracts/interfaces/IPerpsV2MarketOffchainOrders.sol
@@ -4,7 +4,11 @@ pragma experimental ABIEncoderV2;
 interface IPerpsV2MarketOffchainOrders {
     function submitOffchainDelayedOrder(int sizeDelta, uint slippage) external;
 
-    function submitOffchainDelayedOrderWithTracking(int sizeDelta, uint slippage, bytes32 trackingCode) external;
+    function submitOffchainDelayedOrderWithTracking(
+        int sizeDelta,
+        uint slippage,
+        bytes32 trackingCode
+    ) external;
 
     function cancelOffchainDelayedOrder(address account) external;
 

--- a/contracts/interfaces/IPerpsV2MarketState.sol
+++ b/contracts/interfaces/IPerpsV2MarketState.sol
@@ -62,6 +62,7 @@ interface IPerpsV2MarketState {
         address account,
         bool isOffchain,
         int128 sizeDelta,
+        uint128 slippage,
         uint128 targetRoundId,
         uint128 commitDeposit,
         uint128 keeperDeposit,

--- a/contracts/interfaces/IPerpsV2MarketViews.sol
+++ b/contracts/interfaces/IPerpsV2MarketViews.sol
@@ -64,7 +64,11 @@ interface IPerpsV2MarketViews {
 
     function orderFee(int sizeDelta) external view returns (uint fee, bool invalid);
 
-    function postTradeDetails(int sizeDelta, address sender)
+    function postTradeDetails(
+        int sizeDelta,
+        uint tradePrice,
+        address sender
+    )
         external
         view
         returns (

--- a/contracts/test-helpers/TestablePerpsV2Market.sol
+++ b/contracts/test-helpers/TestablePerpsV2Market.sol
@@ -209,10 +209,11 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
         return DelayedOrder(false, 0, 0, 0, 0, 0, 0, 0, bytes32(0));
     }
 
-    function submitDelayedOrder(int sizeDelta, uint desiredTimeDelta) external {}
+    function submitDelayedOrder(int sizeDelta, uint slippage, uint desiredTimeDelta) external {}
 
     function submitDelayedOrderWithTracking(
         int sizeDelta,
+        uint slippage,
         uint desiredTimeDelta,
         bytes32 trackingCode
     ) external {}
@@ -223,9 +224,9 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
 
     /* ---------- Offchain Delayed Orders ---------- */
 
-    function submitOffchainDelayedOrder(int sizeDelta) external {}
+    function submitOffchainDelayedOrder(int sizeDelta, uint slippage) external {}
 
-    function submitOffchainDelayedOrderWithTracking(int sizeDelta, bytes32 trackingCode) external {}
+    function submitOffchainDelayedOrderWithTracking(int sizeDelta, uint slippage, bytes32 trackingCode) external {}
 
     function cancelOffchainDelayedOrder(address account) external {}
 

--- a/contracts/test-helpers/TestablePerpsV2Market.sol
+++ b/contracts/test-helpers/TestablePerpsV2Market.sol
@@ -39,7 +39,7 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
             bool invalid
         )
     {
-        (uint _, bool invalid) = _assetPrice();
+        (, bool invalid) = _assetPrice();
         int sizeLimit = int(_maxMarketValue(_marketKey()));
         (uint longSize, uint shortSize) = _marketSizes();
         long = uint(sizeLimit.sub(_min(int(longSize), sizeLimit)));
@@ -188,7 +188,11 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
         return (0, false);
     }
 
-    function postTradeDetails(int sizeDelta, address sender)
+    function postTradeDetails(
+        int sizeDelta,
+        uint tradePrice,
+        address sender
+    )
         external
         view
         returns (

--- a/contracts/test-helpers/TestablePerpsV2Market.sol
+++ b/contracts/test-helpers/TestablePerpsV2Market.sol
@@ -206,7 +206,7 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
     /* ---------- Delayed Orders ---------- */
 
     function delayedOrders(address account) external view returns (DelayedOrder memory) {
-        return DelayedOrder(false, 0, 0, 0, 0, 0, 0, bytes32(0));
+        return DelayedOrder(false, 0, 0, 0, 0, 0, 0, 0, bytes32(0));
     }
 
     function submitDelayedOrder(int sizeDelta, uint desiredTimeDelta) external {}

--- a/contracts/test-helpers/TestablePerpsV2Market.sol
+++ b/contracts/test-helpers/TestablePerpsV2Market.sol
@@ -209,7 +209,11 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
         return DelayedOrder(false, 0, 0, 0, 0, 0, 0, 0, bytes32(0));
     }
 
-    function submitDelayedOrder(int sizeDelta, uint slippage, uint desiredTimeDelta) external {}
+    function submitDelayedOrder(
+        int sizeDelta,
+        uint slippage,
+        uint desiredTimeDelta
+    ) external {}
 
     function submitDelayedOrderWithTracking(
         int sizeDelta,
@@ -226,7 +230,11 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
 
     function submitOffchainDelayedOrder(int sizeDelta, uint slippage) external {}
 
-    function submitOffchainDelayedOrderWithTracking(int sizeDelta, uint slippage, bytes32 trackingCode) external {}
+    function submitOffchainDelayedOrderWithTracking(
+        int sizeDelta,
+        uint slippage,
+        bytes32 trackingCode
+    ) external {}
 
     function cancelOffchainDelayedOrder(address account) external {}
 

--- a/contracts/test-helpers/TestablePerpsV2Market.sol
+++ b/contracts/test-helpers/TestablePerpsV2Market.sol
@@ -115,9 +115,15 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
         return (fillPrice, invalid);
     }
 
-    /* @dev Given the size and baseBase (e.g. current off-chain price), return the expected fillPrice */
+    /* @dev Given the size and basePrice (e.g. current off-chain price), return the expected fillPrice */
     function fillPriceWithBasePrice(int size, uint basePrice) external view returns (uint price) {
         return _fillPrice(size, basePrice);
+    }
+
+    /* @dev Given an account, find the associated position and return the netFundingPerUnit. */
+    function netFundingPerUnit(address account) external view returns (int) {
+        Position memory position = marketState.positions(account);
+        return _netFundingPerUnit(position.lastFundingIndex);
     }
 
     function marketSizes() external view returns (uint long, uint short) {

--- a/test/contracts/PerpsV2Market.delayedOrder.js
+++ b/test/contracts/PerpsV2Market.delayedOrder.js
@@ -34,6 +34,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 	const takerFeeDelayedOrder = toUnit('0.0005');
 	const makerFeeDelayedOrder = toUnit('0.0001');
 	const initialPrice = toUnit('100');
+	const slippage = toUnit('0.5'); // 50% slippage tolerance acceptable.
 
 	async function setPrice(asset, price, resetCircuitBreaker = true) {
 		await updateAggregatorRates(
@@ -114,7 +115,9 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 			const roundId = await exchangeRates.getCurrentRoundId(baseAsset);
 			const spotFee = (await futuresMarket.orderFee(size))[0];
 			const keeperFee = await futuresMarketSettings.minKeeperFee();
-			const tx = await futuresMarket.submitDelayedOrder(size, desiredTimeDelta, { from: trader });
+			const tx = await futuresMarket.submitDelayedOrder(size, slippage, desiredTimeDelta, {
+				from: trader,
+			});
 			const txBlock = await ethers.provider.getBlock(tx.receipt.blockNumber);
 
 			const order = await futuresMarketState.delayedOrders(trader);
@@ -160,7 +163,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 
 		it('set desiredTimeDelta to minDelayTimeDelta when delta is 0', async () => {
 			// setup
-			const tx = await futuresMarket.submitDelayedOrder(size, 0, { from: trader });
+			const tx = await futuresMarket.submitDelayedOrder(size, slippage, 0, { from: trader });
 			const txBlock = await ethers.provider.getBlock(tx.receipt.blockNumber);
 
 			const order = await futuresMarketState.delayedOrders(trader);
@@ -170,7 +173,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 		describe('cannot submit an order when', () => {
 			it('zero size', async () => {
 				await assert.revert(
-					futuresMarket.submitDelayedOrder(0, desiredTimeDelta, { from: trader }),
+					futuresMarket.submitDelayedOrder(0, slippage, desiredTimeDelta, { from: trader }),
 					'Cannot submit empty order'
 				);
 			});
@@ -178,22 +181,24 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 			it('not enough margin', async () => {
 				await futuresMarket.withdrawAllMargin({ from: trader });
 				await assert.revert(
-					futuresMarket.submitDelayedOrder(size, desiredTimeDelta, { from: trader }),
+					futuresMarket.submitDelayedOrder(size, slippage, desiredTimeDelta, { from: trader }),
 					'Insufficient margin'
 				);
 			});
 
 			it('too much leverage', async () => {
 				await assert.revert(
-					futuresMarket.submitDelayedOrder(size.mul(toBN(10)), desiredTimeDelta, { from: trader }),
+					futuresMarket.submitDelayedOrder(size.mul(toBN(10)), slippage, desiredTimeDelta, {
+						from: trader,
+					}),
 					'Max leverage exceeded'
 				);
 			});
 
 			it('previous order exists', async () => {
-				await futuresMarket.submitDelayedOrder(size, desiredTimeDelta, { from: trader });
+				await futuresMarket.submitDelayedOrder(size, slippage, desiredTimeDelta, { from: trader });
 				await assert.revert(
-					futuresMarket.submitDelayedOrder(size, desiredTimeDelta, { from: trader }),
+					futuresMarket.submitDelayedOrder(size, slippage, desiredTimeDelta, { from: trader }),
 					'previous order exists'
 				);
 			});
@@ -201,7 +206,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 			it('if futures markets are suspended', async () => {
 				await systemStatus.suspendFutures(toUnit(0), { from: owner });
 				await assert.revert(
-					futuresMarket.submitDelayedOrder(size, desiredTimeDelta, { from: trader }),
+					futuresMarket.submitDelayedOrder(size, slippage, desiredTimeDelta, { from: trader }),
 					'Futures markets are suspended'
 				);
 			});
@@ -209,18 +214,18 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 			it('if market is suspended', async () => {
 				await systemStatus.suspendFuturesMarket(marketKey, toUnit(0), { from: owner });
 				await assert.revert(
-					futuresMarket.submitDelayedOrder(size, desiredTimeDelta, { from: trader }),
+					futuresMarket.submitDelayedOrder(size, slippage, desiredTimeDelta, { from: trader }),
 					'Market suspended'
 				);
 			});
 
 			it('if desiredTimeDelta is below the minimum delay or negative', async () => {
 				await assert.revert(
-					futuresMarket.submitDelayedOrder(0, 1, { from: trader }),
+					futuresMarket.submitDelayedOrder(0, slippage, 1, { from: trader }),
 					'delay out of bounds'
 				);
 				try {
-					await futuresMarket.submitDelayedOrder(0, -1, { from: trader });
+					await futuresMarket.submitDelayedOrder(0, slippage, -1, { from: trader });
 				} catch (err) {
 					const { reason, code, argument } = err;
 					assert.deepEqual(
@@ -236,7 +241,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 
 			it('if desiredTimeDelta is above the maximum delay', async () => {
 				await assert.revert(
-					futuresMarket.submitDelayedOrder(0, 1000000, { from: trader }),
+					futuresMarket.submitDelayedOrder(0, slippage, 1000000, { from: trader }),
 					'delay out of bounds'
 				);
 			});
@@ -254,6 +259,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 
 			const tx = await futuresMarket.submitDelayedOrderWithTracking(
 				size,
+				slippage,
 				desiredTimeDelta,
 				trackingCode,
 				{
@@ -296,9 +302,15 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 
 		it('executing an order emits the tracking event', async () => {
 			// setup
-			await futuresMarket.submitDelayedOrderWithTracking(size, desiredTimeDelta, trackingCode, {
-				from: trader,
-			});
+			await futuresMarket.submitDelayedOrderWithTracking(
+				size,
+				slippage,
+				desiredTimeDelta,
+				trackingCode,
+				{
+					from: trader,
+				}
+			);
 
 			// go to next round
 			await setPrice(baseAsset, price);
@@ -398,7 +410,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 				// transfer more margin
 				await futuresMarket.transferMargin(margin, { from: trader });
 				// and can submit new order
-				await futuresMarket.submitDelayedOrder(size, desiredTimeDelta, { from: trader });
+				await futuresMarket.submitDelayedOrder(size, slippage, desiredTimeDelta, { from: trader });
 				const newOrder = await futuresMarketState.delayedOrders(trader);
 				assert.bnEqual(newOrder.sizeDelta, size);
 			}
@@ -407,7 +419,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 				roundId = await exchangeRates.getCurrentRoundId(baseAsset);
 				spotFee = (await futuresMarket.orderFee(size))[0];
 				keeperFee = await futuresMarketSettings.minKeeperFee();
-				await futuresMarket.submitDelayedOrder(size, desiredTimeDelta, { from: trader });
+				await futuresMarket.submitDelayedOrder(size, slippage, desiredTimeDelta, { from: trader });
 			});
 
 			it('cannot cancel if futures markets are suspended', async () => {
@@ -575,7 +587,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 				// commitFee is the fee that would be charged for a spot trade when order is submitted
 				commitFee = (await futuresMarket.orderFee(size))[0];
 
-				await futuresMarket.submitDelayedOrder(size, desiredTimeDelta, { from: trader });
+				await futuresMarket.submitDelayedOrder(size, slippage, desiredTimeDelta, { from: trader });
 			});
 
 			describe('execution reverts', () => {
@@ -736,7 +748,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 				// transfer more margin
 				await futuresMarket.transferMargin(margin, { from: trader });
 				// and can submit new order
-				await futuresMarket.submitDelayedOrder(size, desiredTimeDelta, { from: trader });
+				await futuresMarket.submitDelayedOrder(size, slippage, desiredTimeDelta, { from: trader });
 				const newOrder = await futuresMarketState.delayedOrders(trader);
 				assert.bnEqual(newOrder.sizeDelta, size);
 			}
@@ -799,7 +811,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 						beforeEach(async () => {
 							// skew the other way
 							await futuresMarket.transferMargin(margin.mul(toBN(2)), { from: trader3 });
-							await futuresMarket.modifyPosition(size.mul(toBN(-2)), { from: trader3 });
+							await futuresMarket.modifyPosition(size.mul(toBN(-2)), slippage, { from: trader3 });
 							// go to next round
 							await setPrice(baseAsset, targetPrice);
 							targetFillPrice = (await futuresMarket.fillPrice(size))[0];
@@ -884,7 +896,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 							// will affect the p/d on fillPrice. since this existing trade is short, the execution
 							// of the delay order contracts the skew hence targetFillPrice will be a discount on price.
 							await futuresMarket.transferMargin(margin.mul(toBN(2)), { from: trader3 });
-							await futuresMarket.modifyPosition(size.mul(toBN(-2)), { from: trader3 });
+							await futuresMarket.modifyPosition(size.mul(toBN(-2)), slippage, { from: trader3 });
 
 							spotTradeDetails = await futuresMarket.postTradeDetails(size, trader);
 
@@ -929,7 +941,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 
 				// submit an order
-				await futuresMarket.submitDelayedOrder(size, desiredTimeDelta, { from: trader });
+				await futuresMarket.submitDelayedOrder(size, slippage, desiredTimeDelta, { from: trader });
 
 				// spike the price
 				await setPrice(baseAsset, spikedPrice);
@@ -944,7 +956,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 				await futuresMarket.cancelDelayedOrder(trader, { from: trader });
 
 				await assert.revert(
-					futuresMarket.submitDelayedOrder(size, desiredTimeDelta, { from: trader }),
+					futuresMarket.submitDelayedOrder(size, slippage, desiredTimeDelta, { from: trader }),
 					'Price too volatile'
 				);
 			});

--- a/test/contracts/PerpsV2Market.delayedOrder.js
+++ b/test/contracts/PerpsV2Market.delayedOrder.js
@@ -34,7 +34,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 	const takerFeeDelayedOrder = toUnit('0.0005');
 	const makerFeeDelayedOrder = toUnit('0.0001');
 	const initialPrice = toUnit('100');
-	const slippage = toUnit('0.5'); // 50% slippage tolerance acceptable.
+	const slippage = toUnit('0.5'); // 500bps (high bps to avoid affecting unrelated tests)
 
 	async function setPrice(asset, price, resetCircuitBreaker = true) {
 		await updateAggregatorRates(

--- a/test/contracts/PerpsV2Market.delayedOrder.js
+++ b/test/contracts/PerpsV2Market.delayedOrder.js
@@ -773,7 +773,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 					// fast-forward to the order's executableAtTime
 					//
 					// note that we do NOT update the price (to ensure target round is never reached)
-					spotTradeDetails = await futuresMarket.postTradeDetails(size, trader);
+					spotTradeDetails = await futuresMarket.postTradeDetails(size, toUnit('0'), trader);
 					await fastForward(desiredTimeDelta);
 
 					// check we can execute.
@@ -790,7 +790,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 							// go to next round
 							await setPrice(baseAsset, targetPrice);
 							targetFillPrice = (await futuresMarket.fillPrice(size))[0];
-							spotTradeDetails = await futuresMarket.postTradeDetails(size, trader);
+							spotTradeDetails = await futuresMarket.postTradeDetails(size, toUnit('0'), trader);
 						});
 
 						it('from account owner', async () => {
@@ -815,7 +815,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 							// go to next round
 							await setPrice(baseAsset, targetPrice);
 							targetFillPrice = (await futuresMarket.fillPrice(size))[0];
-							spotTradeDetails = await futuresMarket.postTradeDetails(size, trader);
+							spotTradeDetails = await futuresMarket.postTradeDetails(size, toUnit('0'), trader);
 						});
 
 						it('from account owner', async () => {
@@ -860,7 +860,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 						await setPrice(baseAsset, price);
 
 						// latest price = the price we use.
-						spotTradeDetails = await futuresMarket.postTradeDetails(size, trader);
+						spotTradeDetails = await futuresMarket.postTradeDetails(size, toUnit('0'), trader);
 					});
 
 					describe('taker trade', () => {
@@ -898,7 +898,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 							await futuresMarket.transferMargin(margin.mul(toBN(2)), { from: trader3 });
 							await futuresMarket.modifyPosition(size.mul(toBN(-2)), slippage, { from: trader3 });
 
-							spotTradeDetails = await futuresMarket.postTradeDetails(size, trader);
+							spotTradeDetails = await futuresMarket.postTradeDetails(size, toUnit('0'), trader);
 
 							// go to next round
 							await setPrice(baseAsset, price);

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -1363,6 +1363,14 @@ contract('PerpsV2Market', accounts => {
 	});
 
 	describe('Modifying positions', () => {
+		describe('Slippage', () => {
+			it('should succeed with a reasonable slippage');
+			it('should fail when the fillPrice exceeds the slippage tolerance');
+			it('should default to the makerFee as slippage when nothing is provided');
+			it('should default to the takerFee as slippage when nothing is provided');
+			it('should fail when no slippage is provided and fillPrice exceeds default tolerance');
+		});
+
 		it('can modify a position', async () => {
 			const margin = toUnit('1000');
 			await futuresMarket.transferMargin(margin, { from: trader });

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -3963,7 +3963,7 @@ contract('PerpsV2Market', accounts => {
 			}) => {
 				const defaultLiquidationBufferRatio = toUnit('0.0025');
 				const defaultLiquidationFeeRatio = toUnit('0.0035');
-				const defaultLiquidationMinFee = toUnit('20'); // 20 USD
+				const defaultLiquidationMinFee = toUnit('20'); // 20 sUSD
 
 				const liqMinFee = minFee || defaultLiquidationMinFee;
 				const liqFeeRatio = feeRatio || defaultLiquidationFeeRatio;
@@ -3971,7 +3971,7 @@ contract('PerpsV2Market', accounts => {
 
 				// How is the liquidation price calculated?
 				//
-				// liqFee    = max(Math.abs(size) * price * liquidationFeeRatio, minFee)
+				// liqFee    = max(abs(size) * price * liquidationFeeRatio, minFee)
 				// liqMargin = abs(pos.size) * price * liquidationBufferRatio + liqFee
 				// liqPrice  = pos.lastPrice + (liqMargin - (pos.margin - fees)) / pos.size - fundingPerUnit
 
@@ -4424,7 +4424,7 @@ contract('PerpsV2Market', accounts => {
 				// liquidated longs). However, the long positions are actually underwater and the negative
 				// contribution is not removed until liquidation
 				//
-				// marketDebt is impacted by funding (priceWithFunding) and debtCorrection, which affects marketDebt
+				// marketDebt is impacted by funding (priceWithFunding) and debtCorrection, which affects marketDebt,
 				// is also affected by p/d as lastPrice stored on the position is the fillPrice (impacted by sizeDelta).
 				//
 				// nextFundingEntry = lastFundingEntry + unrecordedFunding

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -85,7 +85,7 @@ contract('PerpsV2Market', accounts => {
 	const maxDelayTimeDelta = 120;
 	const offchainMinAge = 15;
 	const offchainMaxAge = 60;
-	const slippage = toUnit('0.5'); // 50% slippage tolerance acceptable.
+	const slippage = toUnit('0.5'); // 500bps (high bps to avoid affecting unrelated tests)
 
 	const initialFundingIndex = toBN(0);
 

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -1453,7 +1453,7 @@ contract('PerpsV2Market', accounts => {
 
 			await fastForward(4 * 7 * 24 * 60 * 60);
 
-			const postDetails = await futuresMarket.postTradeDetails(size, trader);
+			const postDetails = await futuresMarket.postTradeDetails(size, toUnit('0'), trader);
 			assert.equal(postDetails.status, Status.InvalidPrice);
 
 			await assert.revert(
@@ -1519,7 +1519,7 @@ contract('PerpsV2Market', accounts => {
 				futuresMarket.modifyPosition(toBN('0'), slippage, { from: trader }),
 				'Cannot submit empty order'
 			);
-			const postDetails = await futuresMarket.postTradeDetails(toBN('0'), trader);
+			const postDetails = await futuresMarket.postTradeDetails(toBN('0'), toUnit('0'), trader);
 			assert.equal(postDetails.status, Status.NilOrder);
 		});
 
@@ -1536,7 +1536,7 @@ contract('PerpsV2Market', accounts => {
 			// User realises the price has crashed and tries to outrun their liquidation, but it fails
 
 			const sizeDelta = toUnit('-50');
-			const postDetails = await futuresMarket.postTradeDetails(sizeDelta, trader);
+			const postDetails = await futuresMarket.postTradeDetails(sizeDelta, toUnit('0'), trader);
 			assert.equal(postDetails.status, Status.CanLiquidate);
 
 			await assert.revert(
@@ -1593,14 +1593,14 @@ contract('PerpsV2Market', accounts => {
 				futuresMarket.modifyPosition(toUnit('101'), slippage, { from: trader }),
 				'Max leverage exceeded'
 			);
-			let postDetails = await futuresMarket.postTradeDetails(toUnit('101'), trader);
+			let postDetails = await futuresMarket.postTradeDetails(toUnit('101'), toUnit('0'), trader);
 			assert.equal(postDetails.status, Status.MaxLeverageExceeded);
 
 			await assert.revert(
 				futuresMarket.modifyPosition(toUnit('-101'), slippage, { from: trader2 }),
 				'Max leverage exceeded'
 			);
-			postDetails = await futuresMarket.postTradeDetails(toUnit('-101'), trader2);
+			postDetails = await futuresMarket.postTradeDetails(toUnit('-101'), toUnit('0'), trader2);
 			assert.equal(postDetails.status, Status.MaxLeverageExceeded);
 		});
 
@@ -1617,14 +1617,14 @@ contract('PerpsV2Market', accounts => {
 				'Insufficient margin'
 			);
 
-			let postDetails = await futuresMarket.postTradeDetails(price, trader);
+			let postDetails = await futuresMarket.postTradeDetails(price, toUnit('0'), trader);
 			assert.equal(postDetails.status, Status.InsufficientMargin);
 
 			// But it works after transferring the remaining $1
 			await futuresMarket.transferMargin(toUnit('1'), { from: trader });
 
 			const fee = toUnit('0.30015');
-			postDetails = await futuresMarket.postTradeDetails(size, trader);
+			postDetails = await futuresMarket.postTradeDetails(size, toUnit('0'), trader);
 			assert.bnEqual(postDetails.margin, minInitialMargin.sub(fee));
 			assert.bnEqual(postDetails.size, size);
 			assert.bnEqual(postDetails.price, fillPrice);
@@ -1717,7 +1717,7 @@ contract('PerpsV2Market', accounts => {
 						await futuresMarket.transferMargin(maxMargin.add(toUnit('11')), { from: trader });
 						const tooBig = orderSize.div(toBN('10')).mul(toBN('11'));
 
-						const postDetails = await futuresMarket.postTradeDetails(tooBig, trader);
+						const postDetails = await futuresMarket.postTradeDetails(tooBig, toUnit('0'), trader);
 						assert.equal(postDetails.status, Status.MaxMarketSizeExceeded);
 
 						await assert.revert(
@@ -1750,7 +1750,11 @@ contract('PerpsV2Market', accounts => {
 						//
 						// 70 + 25 = 95
 						const sizeDelta = orderSize.div(toBN(100)).mul(toBN(25));
-						const postDetails = await futuresMarket.postTradeDetails(sizeDelta, trader);
+						const postDetails = await futuresMarket.postTradeDetails(
+							sizeDelta,
+							toUnit('0'),
+							trader
+						);
 						assert.equal(postDetails.status, Status.Ok);
 						await futuresMarket.modifyPosition(sizeDelta, slippage, {
 							from: trader,
@@ -2082,7 +2086,11 @@ contract('PerpsV2Market', accounts => {
 				await setPrice(await futuresMarket.baseAsset(), toUnit('240'));
 				const fillPrice = (await futuresMarket.fillPrice(sizeDelta))[0];
 
-				const postTradeDetails = await futuresMarket.postTradeDetails(sizeDelta, trader);
+				const postTradeDetails = await futuresMarket.postTradeDetails(
+					sizeDelta,
+					toUnit('0'),
+					trader
+				);
 
 				// Now execute the trade.
 				await futuresMarket.modifyPosition(sizeDelta, slippage, { from: trader });
@@ -2107,7 +2115,11 @@ contract('PerpsV2Market', accounts => {
 				});
 
 				const fillPrice = (await futuresMarket.fillPrice(sizeDelta))[0];
-				const postTradeDetails = await futuresMarket.postTradeDetails(sizeDelta, trader);
+				const postTradeDetails = await futuresMarket.postTradeDetails(
+					sizeDelta,
+					toUnit('0'),
+					trader
+				);
 
 				// Now execute the trade.
 				await futuresMarket.modifyPosition(sizeDelta, slippage, { from: trader });

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -3583,11 +3583,11 @@ contract('PerpsV2Market', accounts => {
 			// velocity = 12 / 400 * 0.1
 			//          = 0.003
 			//
-			// funding_rate = 0 + (0.003 * (43200 / 86400))
-			//              = 0 + (0.003 * 0.5)
-			//              = 0.0015
+			// funding_rate = 0 + (0.003 * (43200 / 86400)) + <very_small_buffer>
+			//              = 0 + (0.003 * 0.5) + <very_small_buffer>
+			//              = ~0.0015
 			const fundingRate = toUnit('0.0015');
-			assert.bnEqual(await futuresMarket.currentFundingRate(), fundingRate);
+			assert.bnClose(await futuresMarket.currentFundingRate(), fundingRate, toUnit('0.001'));
 
 			// Why 0.003?
 			//
@@ -3597,8 +3597,8 @@ contract('PerpsV2Market', accounts => {
 			const fundingVelocity = await futuresMarket.currentFundingVelocity();
 			assert.bnEqual(fundingVelocity, toUnit('0.003'));
 
-			// 1 day
-			await fastForward(SECS_IN_DAY);
+			// 2 days
+			await fastForward(SECS_IN_DAY * 2);
 			await setPrice(baseAsset, price);
 
 			// pause the market

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -85,6 +85,7 @@ contract('PerpsV2Market', accounts => {
 	const maxDelayTimeDelta = 120;
 	const offchainMinAge = 15;
 	const offchainMaxAge = 60;
+	const slippage = toUnit('0.5'); // 50% slippage tolerance acceptable.
 
 	const initialFundingIndex = toBN(0);
 
@@ -106,7 +107,7 @@ contract('PerpsV2Market', accounts => {
 	}) {
 		await market.transferMargin(marginDelta, { from: account });
 		await setPrice(await market.baseAsset(), fillPrice);
-		return market.modifyPosition(sizeDelta, { from: account });
+		return market.modifyPosition(sizeDelta, slippage, { from: account });
 	}
 
 	async function closePositionAndWithdrawMargin({ market, account, fillPrice }) {
@@ -378,7 +379,7 @@ contract('PerpsV2Market', accounts => {
 
 				await onlyGivenAddressCanInvoke({
 					fnc: futuresMarketImpl.modifyPosition,
-					args: [1],
+					args: [1, slippage],
 					accounts: [owner, trader, trader2, trader3],
 					reason: 'Only the proxy can call',
 					skipPassCheck: true,
@@ -386,7 +387,7 @@ contract('PerpsV2Market', accounts => {
 
 				await onlyGivenAddressCanInvoke({
 					fnc: futuresMarketImpl.modifyPositionWithTracking,
-					args: [1, toBytes32('code')],
+					args: [1, slippage, toBytes32('code')],
 					accounts: [owner, trader, trader2, trader3],
 					reason: 'Only the proxy can call',
 					skipPassCheck: true,
@@ -422,7 +423,7 @@ contract('PerpsV2Market', accounts => {
 			it('Only proxy functions only work for proxy', async () => {
 				await onlyGivenAddressCanInvoke({
 					fnc: futuresMarketDelayedOrderImpl.submitDelayedOrder,
-					args: [1, 60],
+					args: [1, slippage, 60],
 					accounts: [owner, trader, trader2, trader3],
 					reason: 'Only the proxy can call',
 					skipPassCheck: true,
@@ -430,7 +431,7 @@ contract('PerpsV2Market', accounts => {
 
 				await onlyGivenAddressCanInvoke({
 					fnc: futuresMarketDelayedOrderImpl.submitDelayedOrderWithTracking,
-					args: [1, 60, toBytes32('code')],
+					args: [1, slippage, 60, toBytes32('code')],
 					accounts: [owner, trader, trader2, trader3],
 					reason: 'Only the proxy can call',
 					skipPassCheck: true,
@@ -458,7 +459,7 @@ contract('PerpsV2Market', accounts => {
 			it('Only proxy functions only work for proxy', async () => {
 				await onlyGivenAddressCanInvoke({
 					fnc: futuresMarketOffchainDelayedOrderImpl.submitOffchainDelayedOrder,
-					args: [1],
+					args: [1, slippage],
 					accounts: [owner, trader, trader2, trader3],
 					reason: 'Only the proxy can call',
 					skipPassCheck: true,
@@ -466,7 +467,7 @@ contract('PerpsV2Market', accounts => {
 
 				await onlyGivenAddressCanInvoke({
 					fnc: futuresMarketOffchainDelayedOrderImpl.submitOffchainDelayedOrderWithTracking,
-					args: [1, toBytes32('code')],
+					args: [1, slippage, toBytes32('code')],
 					accounts: [owner, trader, trader2, trader3],
 					reason: 'Only the proxy can call',
 					skipPassCheck: true,
@@ -566,7 +567,7 @@ contract('PerpsV2Market', accounts => {
 
 				await onlyGivenAddressCanInvoke({
 					fnc: futuresMarketState.updateDelayedOrder,
-					args: [noBalance, false, 1, 1, 1, 1, 1, 1, toBytes32('code')],
+					args: [noBalance, false, 1, 1, 1, 1, 1, 1, 1, toBytes32('code')],
 					accounts: [owner, trader, trader2, trader3],
 					reason: 'Only an associated contract can perform this action',
 					skipPassCheck: true,
@@ -660,7 +661,9 @@ contract('PerpsV2Market', accounts => {
 					const currentMargin = toBN((await futuresMarket.positions(trader)).margin);
 
 					// trader1 adds more margin.
-					const tx = await futuresMarket.modifyPosition(t1size.mul(toBN(2)), { from: trader });
+					const tx = await futuresMarket.modifyPosition(t1size.mul(toBN(2)), slippage, {
+						from: trader,
+					});
 
 					// Fee is properly recorded and deducted.
 					const decodedLogs = await getDecodedLogs({
@@ -1368,7 +1371,7 @@ contract('PerpsV2Market', accounts => {
 			await setPrice(baseAsset, price);
 			const fillPrice = (await futuresMarket.fillPrice(size))[0];
 			const fee = (await futuresMarket.orderFee(size))[0];
-			const tx = await futuresMarket.modifyPosition(size, { from: trader });
+			const tx = await futuresMarket.modifyPosition(size, slippage, { from: trader });
 
 			const position = await futuresMarket.positions(trader);
 			assert.bnEqual(position.margin, margin.sub(fee));
@@ -1413,7 +1416,7 @@ contract('PerpsV2Market', accounts => {
 			await setPrice(baseAsset, price);
 			const fee = (await futuresMarket.orderFee(size))[0];
 			const trackingCode = toBytes32('code');
-			const tx = await futuresMarket.modifyPositionWithTracking(size, trackingCode, {
+			const tx = await futuresMarket.modifyPositionWithTracking(size, slippage, trackingCode, {
 				from: trader,
 			});
 
@@ -1436,7 +1439,7 @@ contract('PerpsV2Market', accounts => {
 			const margin = toUnit('1000');
 			await futuresMarket.transferMargin(margin, { from: trader });
 			const size = toUnit('10');
-			await futuresMarket.modifyPosition(size, { from: trader });
+			await futuresMarket.modifyPosition(size, slippage, { from: trader });
 
 			await setPrice(baseAsset, toUnit('200'));
 
@@ -1445,7 +1448,10 @@ contract('PerpsV2Market', accounts => {
 			const postDetails = await futuresMarket.postTradeDetails(size, trader);
 			assert.equal(postDetails.status, Status.InvalidPrice);
 
-			await assert.revert(futuresMarket.modifyPosition(size, { from: trader }), 'Invalid price');
+			await assert.revert(
+				futuresMarket.modifyPosition(size, slippage, { from: trader }),
+				'Invalid price'
+			);
 		});
 
 		it('Cannot modify a position if the system is suspended', async () => {
@@ -1460,14 +1466,14 @@ contract('PerpsV2Market', accounts => {
 			await systemStatus.suspendSystem('3', { from: owner });
 			// should revert modifying position
 			await assert.revert(
-				futuresMarket.modifyPosition(size, { from: trader }),
+				futuresMarket.modifyPosition(size, slippage, { from: trader }),
 				'Synthetix is suspended'
 			);
 
 			// resume
 			await systemStatus.resumeSystem({ from: owner });
 			// should work now
-			await futuresMarket.modifyPosition(size, { from: trader });
+			await futuresMarket.modifyPosition(size, slippage, { from: trader });
 			const position = await futuresMarket.positions(trader);
 			assert.bnEqual(position.size, size);
 			assert.bnEqual(position.lastPrice, fillPrice);
@@ -1485,14 +1491,14 @@ contract('PerpsV2Market', accounts => {
 			await systemStatus.suspendSynth(baseAsset, 65, { from: owner });
 			// should revert modifying position
 			await assert.revert(
-				futuresMarket.modifyPosition(size, { from: trader }),
+				futuresMarket.modifyPosition(size, slippage, { from: trader }),
 				'Synth is suspended'
 			);
 
 			// resume
 			await systemStatus.resumeSynth(baseAsset, { from: owner });
 			// should work now
-			await futuresMarket.modifyPosition(size, { from: trader });
+			await futuresMarket.modifyPosition(size, slippage, { from: trader });
 			const position = await futuresMarket.positions(trader);
 			assert.bnEqual(position.size, size);
 			assert.bnEqual(position.lastPrice, fillPrice);
@@ -1502,7 +1508,7 @@ contract('PerpsV2Market', accounts => {
 			const margin = toUnit('1000');
 			await futuresMarket.transferMargin(margin, { from: trader });
 			await assert.revert(
-				futuresMarket.modifyPosition(toBN('0'), { from: trader }),
+				futuresMarket.modifyPosition(toBN('0'), slippage, { from: trader }),
 				'Cannot submit empty order'
 			);
 			const postDetails = await futuresMarket.postTradeDetails(toBN('0'), trader);
@@ -1526,7 +1532,7 @@ contract('PerpsV2Market', accounts => {
 			assert.equal(postDetails.status, Status.CanLiquidate);
 
 			await assert.revert(
-				futuresMarket.modifyPosition(sizeDelta, { from: trader }),
+				futuresMarket.modifyPosition(sizeDelta, slippage, { from: trader }),
 				'Position can be liquidated'
 			);
 		});
@@ -1576,14 +1582,14 @@ contract('PerpsV2Market', accounts => {
 			await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 			await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
 			await assert.revert(
-				futuresMarket.modifyPosition(toUnit('101'), { from: trader }),
+				futuresMarket.modifyPosition(toUnit('101'), slippage, { from: trader }),
 				'Max leverage exceeded'
 			);
 			let postDetails = await futuresMarket.postTradeDetails(toUnit('101'), trader);
 			assert.equal(postDetails.status, Status.MaxLeverageExceeded);
 
 			await assert.revert(
-				futuresMarket.modifyPosition(toUnit('-101'), { from: trader2 }),
+				futuresMarket.modifyPosition(toUnit('-101'), slippage, { from: trader2 }),
 				'Max leverage exceeded'
 			);
 			postDetails = await futuresMarket.postTradeDetails(toUnit('-101'), trader2);
@@ -1599,7 +1605,7 @@ contract('PerpsV2Market', accounts => {
 
 			await futuresMarket.transferMargin(minInitialMargin.sub(toUnit('1')), { from: trader });
 			await assert.revert(
-				futuresMarket.modifyPosition(toUnit('10'), { from: trader }),
+				futuresMarket.modifyPosition(toUnit('10'), slippage, { from: trader }),
 				'Insufficient margin'
 			);
 
@@ -1618,7 +1624,7 @@ contract('PerpsV2Market', accounts => {
 			assert.bnEqual(postDetails.fee, fee);
 			assert.equal(postDetails.status, Status.Ok);
 
-			await futuresMarket.modifyPosition(toUnit('10'), { from: trader });
+			await futuresMarket.modifyPosition(toUnit('10'), slippage, { from: trader });
 		});
 
 		describe('Max market size constraints', () => {
@@ -1707,7 +1713,7 @@ contract('PerpsV2Market', accounts => {
 						assert.equal(postDetails.status, Status.MaxMarketSizeExceeded);
 
 						await assert.revert(
-							futuresMarket.modifyPosition(tooBig, {
+							futuresMarket.modifyPosition(tooBig, slippage, {
 								from: trader,
 							}),
 							'Max market size exceeded'
@@ -1721,7 +1727,7 @@ contract('PerpsV2Market', accounts => {
 						});
 
 						// 100 / 10 * 7 = 70
-						await futuresMarket.modifyPosition(orderSize.div(toBN(10)).mul(toBN(7)), {
+						await futuresMarket.modifyPosition(orderSize.div(toBN(10)).mul(toBN(7)), slippage, {
 							from: trader2,
 						});
 
@@ -1738,7 +1744,7 @@ contract('PerpsV2Market', accounts => {
 						const sizeDelta = orderSize.div(toBN(100)).mul(toBN(25));
 						const postDetails = await futuresMarket.postTradeDetails(sizeDelta, trader);
 						assert.equal(postDetails.status, Status.Ok);
-						await futuresMarket.modifyPosition(sizeDelta, {
+						await futuresMarket.modifyPosition(sizeDelta, slippage, {
 							from: trader,
 						});
 						const sizes = await futuresMarket.maxOrderSizes();
@@ -1755,7 +1761,7 @@ contract('PerpsV2Market', accounts => {
 				const margin = toUnit('1000');
 				await futuresMarket.transferMargin(margin, { from: trader });
 				await setPrice(baseAsset, toUnit('200'));
-				await futuresMarket.modifyPosition(toUnit('50'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('50'), slippage, { from: trader });
 
 				await setPrice(baseAsset, toUnit('199'));
 				await futuresMarket.closePosition({ from: trader });
@@ -1896,7 +1902,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(positionId, toBN('0'));
 
 				// Trader 1 gets position id 1.
-				let tx = await futuresMarket.modifyPosition(toUnit('10'), { from: trader });
+				let tx = await futuresMarket.modifyPosition(toUnit('10'), slippage, { from: trader });
 				let decodedLogs = await getDecodedLogs({
 					hash: tx.tx,
 					contracts: [futuresMarket],
@@ -1906,7 +1912,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(decodedLogs[2].events[0].value, toBN('1'));
 
 				// trader2 gets the subsequent id
-				tx = await futuresMarket.modifyPosition(toUnit('10'), { from: trader2 });
+				tx = await futuresMarket.modifyPosition(toUnit('10'), slippage, { from: trader2 });
 				decodedLogs = await getDecodedLogs({
 					hash: tx.tx,
 					contracts: [futuresMarket],
@@ -1927,7 +1933,7 @@ contract('PerpsV2Market', accounts => {
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 
 				// Trader gets position id 1.
-				let tx = await futuresMarket.modifyPosition(toUnit('10'), { from: trader });
+				let tx = await futuresMarket.modifyPosition(toUnit('10'), slippage, { from: trader });
 				let decodedLogs = await getDecodedLogs({
 					hash: tx.tx,
 					contracts: [futuresMarket],
@@ -1940,7 +1946,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(positionId, toBN('1'));
 
 				// Modification (but not closure) does not alter the id
-				tx = await futuresMarket.modifyPosition(toUnit('-5'), { from: trader });
+				tx = await futuresMarket.modifyPosition(toUnit('-5'), slippage, { from: trader });
 				decodedLogs = await getDecodedLogs({
 					hash: tx.tx,
 					contracts: [futuresMarket],
@@ -1960,7 +1966,7 @@ contract('PerpsV2Market', accounts => {
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
 
 				// Close by closePosition
-				let tx = await futuresMarket.modifyPosition(toUnit('10'), { from: trader });
+				let tx = await futuresMarket.modifyPosition(toUnit('10'), slippage, { from: trader });
 				let decodedLogs = await getDecodedLogs({
 					hash: tx.tx,
 					contracts: [futuresMarket],
@@ -1985,7 +1991,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(positionId, toBN('0'));
 
 				// Close by modifyPosition
-				tx = await futuresMarket.modifyPosition(toUnit('10'), { from: trader2 });
+				tx = await futuresMarket.modifyPosition(toUnit('10'), slippage, { from: trader2 });
 				decodedLogs = await getDecodedLogs({
 					hash: tx.tx,
 					contracts: [futuresMarket],
@@ -1997,7 +2003,7 @@ contract('PerpsV2Market', accounts => {
 				positionId = (await futuresMarket.positions(trader2)).id;
 				assert.bnEqual(positionId, toBN('2'));
 
-				tx = await futuresMarket.modifyPosition(toUnit('-10'), { from: trader2 });
+				tx = await futuresMarket.modifyPosition(toUnit('-10'), slippage, { from: trader2 });
 				decodedLogs = await getDecodedLogs({
 					hash: tx.tx,
 					contracts: [futuresMarket],
@@ -2035,7 +2041,7 @@ contract('PerpsV2Market', accounts => {
 				assert.equal(decodedLogs[2].events[0].name, 'id');
 				assert.bnEqual(decodedLogs[2].events[0].value, toBN('1'));
 
-				tx = await futuresMarket.modifyPosition(toUnit('10'), { from: trader });
+				tx = await futuresMarket.modifyPosition(toUnit('10'), slippage, { from: trader });
 
 				decodedLogs = await getDecodedLogs({
 					hash: tx.tx,
@@ -2071,7 +2077,7 @@ contract('PerpsV2Market', accounts => {
 				const postTradeDetails = await futuresMarket.postTradeDetails(sizeDelta, trader);
 
 				// Now execute the trade.
-				await futuresMarket.modifyPosition(sizeDelta, { from: trader });
+				await futuresMarket.modifyPosition(sizeDelta, slippage, { from: trader });
 
 				const details = await getPositionDetails({ account: trader });
 
@@ -2096,7 +2102,7 @@ contract('PerpsV2Market', accounts => {
 				const postTradeDetails = await futuresMarket.postTradeDetails(sizeDelta, trader);
 
 				// Now execute the trade.
-				await futuresMarket.modifyPosition(sizeDelta, { from: trader });
+				await futuresMarket.modifyPosition(sizeDelta, slippage, { from: trader });
 
 				const details = await getPositionDetails({ account: trader });
 
@@ -2127,12 +2133,12 @@ contract('PerpsV2Market', accounts => {
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				size1 = toUnit('50');
 				fillPrice1 = (await futuresMarket.fillPrice(size1))[0];
-				await futuresMarket.modifyPosition(size1, { from: trader });
+				await futuresMarket.modifyPosition(size1, slippage, { from: trader });
 
 				await futuresMarket.transferMargin(toUnit('4000'), { from: trader2 });
 				size2 = toUnit('-40');
 				fillPrice2 = (await futuresMarket.fillPrice(size2))[0];
-				await futuresMarket.modifyPosition(size2, { from: trader2 });
+				await futuresMarket.modifyPosition(size2, slippage, { from: trader2 });
 			});
 
 			it('steady price', async () => {
@@ -2192,9 +2198,9 @@ contract('PerpsV2Market', accounts => {
 			beforeEach(async () => {
 				await setPrice(baseAsset, toUnit('100'));
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('50'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('50'), slippage, { from: trader });
 				await futuresMarket.transferMargin(toUnit('5000'), { from: trader2 });
-				await futuresMarket.modifyPosition(toUnit('-50'), { from: trader2 });
+				await futuresMarket.modifyPosition(toUnit('-50'), slippage, { from: trader2 });
 			});
 
 			describe.skip('profit and no funding', async () => {
@@ -2387,7 +2393,7 @@ contract('PerpsV2Market', accounts => {
 				await setPrice(baseAsset, price);
 				let remaining = (await futuresMarket.remainingMargin(trader3))[0];
 				const sizeFor9x = divideDecimal(remaining.mul(toBN('9')), price);
-				await futuresMarket.modifyPosition(sizeFor9x.sub(size), { from: trader3 });
+				await futuresMarket.modifyPosition(sizeFor9x.sub(size), slippage, { from: trader3 });
 
 				assert.bnEqual((await futuresMarket.accessibleMargin(trader3))[0], toUnit('0'));
 
@@ -2409,7 +2415,9 @@ contract('PerpsV2Market', accounts => {
 				await setPrice(baseAsset, price);
 				remaining = (await futuresMarket.remainingMargin(trader3))[0];
 				const sizeForNeg9x = divideDecimal(remaining.mul(toBN('-9')), price);
-				await futuresMarket.modifyPosition(sizeForNeg10x.sub(sizeForNeg9x), { from: trader3 });
+				await futuresMarket.modifyPosition(sizeForNeg10x.sub(sizeForNeg9x), slippage, {
+					from: trader3,
+				});
 
 				assert.bnEqual((await futuresMarket.accessibleMargin(trader3))[0], toUnit('0'));
 				await withdrawAccessibleAndValidate(trader3);
@@ -2652,9 +2660,9 @@ contract('PerpsV2Market', accounts => {
 
 					await setPrice(baseAsset, toUnit('10'));
 
-					await futuresMarket.modifyPosition(toUnit('50'), { from: trader });
-					await futuresMarket.modifyPosition(toUnit('-110'), { from: trader2 });
-					await futuresMarket.modifyPosition(toUnit('900'), { from: trader3 });
+					await futuresMarket.modifyPosition(toUnit('50'), slippage, { from: trader });
+					await futuresMarket.modifyPosition(toUnit('-110'), slippage, { from: trader2 });
+					await futuresMarket.modifyPosition(toUnit('900'), slippage, { from: trader3 });
 
 					assert.bnGt((await futuresMarket.accessibleMargin(trader))[0], toBN('0'));
 					assert.bnGt((await futuresMarket.accessibleMargin(trader2))[0], toBN('0'));
@@ -2708,7 +2716,7 @@ contract('PerpsV2Market', accounts => {
 					await futuresMarket.transferMargin(toUnit('1239.2487'), { from: trader });
 
 					await setPrice(baseAsset, toUnit('15.53'));
-					await futuresMarket.modifyPosition(toUnit('-322'), { from: trader });
+					await futuresMarket.modifyPosition(toUnit('-322'), slippage, { from: trader });
 
 					await futuresMarket.withdrawAllMargin({ from: trader });
 					assert.bnClose(
@@ -2737,11 +2745,11 @@ contract('PerpsV2Market', accounts => {
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 
 				const fee1 = (await futuresMarket.orderFee(toUnit('50')))[0];
-				await futuresMarket.modifyPosition(toUnit('50'), { from: trader }); // 5x
+				await futuresMarket.modifyPosition(toUnit('50'), slippage, { from: trader }); // 5x
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
 
 				const fee2 = (await futuresMarket.orderFee(toUnit('-100')))[0];
-				await futuresMarket.modifyPosition(toUnit('-100'), { from: trader2 }); // -10x
+				await futuresMarket.modifyPosition(toUnit('-100'), slippage, { from: trader2 }); // -10x
 
 				const lev = (notional, margin, fee) => divideDecimal(notional, margin.sub(fee));
 
@@ -3499,7 +3507,7 @@ contract('PerpsV2Market', accounts => {
 							//
 							// following the same example, a -8 size gives a skew of now 2 (still long)
 							if (size.abs().gt(toBN('0'))) {
-								await futuresMarket.modifyPosition(size, { from: trader2 });
+								await futuresMarket.modifyPosition(size, slippage, { from: trader2 });
 							}
 
 							// so what is the skew then?
@@ -3772,7 +3780,7 @@ contract('PerpsV2Market', accounts => {
 			const fee1 = (await futuresMarket.orderFee(size1))[0];
 
 			// debtCorrection = debtCorrection - (50 * fillPrice) - fee1
-			await futuresMarket.modifyPosition(size1, { from: trader });
+			await futuresMarket.modifyPosition(size1, slippage, { from: trader });
 
 			const expectedDebtCorrection1 = margin1.sub(multiplyDecimal(fillPrice1, size1)).sub(fee1);
 
@@ -3795,7 +3803,7 @@ contract('PerpsV2Market', accounts => {
 			// debtCorrection (so far) = expectedDebtConnection1 + 600
 			await futuresMarket.transferMargin(margin2, { from: trader2 });
 			const fee2 = (await futuresMarket.orderFee(size2))[0];
-			await futuresMarket.modifyPosition(size2, { from: trader2 });
+			await futuresMarket.modifyPosition(size2, slippage, { from: trader2 });
 
 			const expectedDebtCorrection2 = expectedDebtCorrection1.add(
 				margin2.sub(multiplyDecimal(fillPrice2, size2)).sub(fee2)
@@ -3999,14 +4007,14 @@ contract('PerpsV2Market', accounts => {
 				const fee1 = (await futuresMarket.orderFee(size1))[0];
 				const fillPrice1 = (await futuresMarket.fillPrice(size1))[0];
 				await futuresMarket.transferMargin(margin1, { from: trader });
-				await futuresMarket.modifyPosition(size1, { from: trader });
+				await futuresMarket.modifyPosition(size1, slippage, { from: trader });
 
 				const margin2 = toUnit('1000');
 				const size2 = toUnit('-100');
 				const fee2 = (await futuresMarket.orderFee(size2))[0];
 				const fillPrice2 = (await futuresMarket.fillPrice(size2))[0];
 				await futuresMarket.transferMargin(margin2, { from: trader2 });
-				await futuresMarket.modifyPosition(size2, { from: trader2 });
+				await futuresMarket.modifyPosition(size2, slippage, { from: trader2 });
 
 				const expectedLiquidationPrice1 = await getExpectedLiquidationPrice({
 					margin: margin1,
@@ -4046,14 +4054,14 @@ contract('PerpsV2Market', accounts => {
 				const fee1 = (await futuresMarket.orderFee(size1))[0];
 				const fillPrice1 = (await futuresMarket.fillPrice(size1))[0];
 				await futuresMarket.transferMargin(margin1, { from: trader });
-				await futuresMarket.modifyPosition(size1, { from: trader });
+				await futuresMarket.modifyPosition(size1, slippage, { from: trader });
 
 				const margin2 = toUnit('1000');
 				const size2 = toUnit('-20');
 				const fee2 = (await futuresMarket.orderFee(size2))[0];
 				const fillPrice2 = (await futuresMarket.fillPrice(size2))[0];
 				await futuresMarket.transferMargin(margin2, { from: trader2 });
-				await futuresMarket.modifyPosition(size2, { from: trader2 });
+				await futuresMarket.modifyPosition(size2, slippage, { from: trader2 });
 
 				assert.bnEqual(
 					(await futuresMarket.liquidationPrice(trader)).price,
@@ -4221,14 +4229,14 @@ contract('PerpsV2Market', accounts => {
 				const fee1 = (await futuresMarket.orderFee(size1))[0];
 				const fillPrice1 = (await futuresMarket.fillPrice(size1))[0];
 				await futuresMarket.transferMargin(margin1, { from: trader });
-				await futuresMarket.modifyPosition(size1, { from: trader });
+				await futuresMarket.modifyPosition(size1, slippage, { from: trader });
 
 				const margin2 = toUnit('1500');
 				const size2 = toUnit('-10');
 				const fee2 = (await futuresMarket.orderFee(size2))[0];
 				const fillPrice2 = (await futuresMarket.fillPrice(size2))[0];
 				await futuresMarket.transferMargin(margin2, { from: trader2 });
-				await futuresMarket.modifyPosition(size2, { from: trader2 });
+				await futuresMarket.modifyPosition(size2, slippage, { from: trader2 });
 
 				// note: the funding rate as grown by a small amount between the first modify and 2nd transfer.
 				// to be specific, in this example funding grew by `0.00000173611111111` (proportional to the 30 size
@@ -4270,9 +4278,9 @@ contract('PerpsV2Market', accounts => {
 
 				await setPrice(baseAsset, toUnit('250'));
 				await futuresMarket.transferMargin(toUnit('1500'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('30'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('30'), slippage, { from: trader });
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
-				await futuresMarket.modifyPosition(toUnit('-20'), { from: trader2 });
+				await futuresMarket.modifyPosition(toUnit('-20'), slippage, { from: trader2 });
 
 				assert.isFalse((await futuresMarket.liquidationPrice(trader))[1]);
 
@@ -4299,7 +4307,7 @@ contract('PerpsV2Market', accounts => {
 				let price = toUnit('250');
 				await setPrice(baseAsset, price);
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('20'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('20'), slippage, { from: trader });
 
 				price = (await futuresMarket.liquidationPrice(trader)).price;
 				await setPrice(baseAsset, price.sub(toUnit(1)));
@@ -4339,7 +4347,7 @@ contract('PerpsV2Market', accounts => {
 			it('No liquidations while prices are invalid', async () => {
 				await setPrice(baseAsset, toUnit('250'));
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('20'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('20'), slippage, { from: trader });
 
 				await setPrice(baseAsset, toUnit('25'));
 				assert.isTrue(await futuresMarket.canLiquidate(trader));
@@ -4350,7 +4358,7 @@ contract('PerpsV2Market', accounts => {
 			it('No liquidations while the system is suspended', async () => {
 				await setPrice(baseAsset, toUnit('250'));
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('20'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('20'), slippage, { from: trader });
 				await setPrice(baseAsset, toUnit('25'));
 				assert.isTrue(await futuresMarket.canLiquidate(trader));
 
@@ -4367,7 +4375,7 @@ contract('PerpsV2Market', accounts => {
 			it('No liquidations while the synth is suspended', async () => {
 				await setPrice(baseAsset, toUnit('250'));
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('20'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('20'), slippage, { from: trader });
 				await setPrice(baseAsset, toUnit('25'));
 				assert.isTrue(await futuresMarket.canLiquidate(trader));
 
@@ -4388,9 +4396,9 @@ contract('PerpsV2Market', accounts => {
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader3 });
-				await futuresMarket.modifyPosition(toUnit('40'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('20'), { from: trader2 });
-				await futuresMarket.modifyPosition(toUnit('-20'), { from: trader3 });
+				await futuresMarket.modifyPosition(toUnit('40'), slippage, { from: trader });
+				await futuresMarket.modifyPosition(toUnit('20'), slippage, { from: trader2 });
+				await futuresMarket.modifyPosition(toUnit('-20'), slippage, { from: trader3 });
 				// Exchange fees total 60 * 250 * 0.003 + 20 * 250 * 0.001 = 50
 			});
 
@@ -4808,9 +4816,9 @@ contract('PerpsV2Market', accounts => {
 			it('accurate with position size and parameters', async () => {
 				await setPrice(baseAsset, toUnit('1000'));
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('2'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('2'), slippage, { from: trader });
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
-				await futuresMarket.modifyPosition(toUnit('-2'), { from: trader2 });
+				await futuresMarket.modifyPosition(toUnit('-2'), slippage, { from: trader2 });
 
 				// cannot liquidate
 				assert.bnEqual(await futuresMarket.liquidationFee(trader), toBN(0));
@@ -4844,9 +4852,9 @@ contract('PerpsV2Market', accounts => {
 			it('accurate with position size, price, and parameters', async () => {
 				await setPrice(baseAsset, toUnit('1000'));
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('2'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('2'), slippage, { from: trader });
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
-				await futuresMarket.modifyPosition(toUnit('-2'), { from: trader2 });
+				await futuresMarket.modifyPosition(toUnit('-2'), slippage, { from: trader2 });
 
 				// reverts for 0 position
 				await assert.revert(futuresMarket.liquidationMargin(trader3), '0 size position');
@@ -4912,7 +4920,7 @@ contract('PerpsV2Market', accounts => {
 				);
 				await assert.revert(futuresMarket.withdrawAllMargin({ from: trader }), 'Invalid price');
 				await assert.revert(
-					futuresMarket.modifyPosition(toUnit('1'), { from: trader }),
+					futuresMarket.modifyPosition(toUnit('1'), slippage, { from: trader }),
 					'Invalid price'
 				);
 				await assert.revert(futuresMarket.closePosition({ from: trader }), 'Invalid price');
@@ -4926,7 +4934,7 @@ contract('PerpsV2Market', accounts => {
 		describe('when price spikes over the allowed threshold', () => {
 			beforeEach(async () => {
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('1'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('1'), slippage, { from: trader });
 				// base rate of sETH is 100 from shared setup above
 				await setPrice(baseAsset, toUnit('300'), false);
 			});
@@ -4937,7 +4945,7 @@ contract('PerpsV2Market', accounts => {
 		describe('when price drops over the allowed threshold', () => {
 			beforeEach(async () => {
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('1'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('1'), slippage, { from: trader });
 				// base rate of sETH is 100 from shared setup above
 				await setPrice(baseAsset, toUnit('30'), false);
 			});
@@ -4955,7 +4963,7 @@ contract('PerpsV2Market', accounts => {
 				);
 				await assert.revert(futuresMarket.withdrawAllMargin({ from: trader }), revertMessage);
 				await assert.revert(
-					futuresMarket.modifyPosition(toUnit('1'), { from: trader }),
+					futuresMarket.modifyPosition(toUnit('1'), slippage, { from: trader }),
 					revertMessage
 				);
 				await assert.revert(futuresMarket.closePosition({ from: trader }), revertMessage);
@@ -4996,7 +5004,7 @@ contract('PerpsV2Market', accounts => {
 			beforeEach(async () => {
 				// prepare a position
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('1'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('1'), slippage, { from: trader });
 				// suspend
 				await systemStatus.suspendFutures(toUnit(0), { from: owner });
 			});
@@ -5013,11 +5021,11 @@ contract('PerpsV2Market', accounts => {
 				it('then mutative market actions work', async () => {
 					await futuresMarket.withdrawAllMargin({ from: trader });
 					await futuresMarket.transferMargin(toUnit('100'), { from: trader });
-					await futuresMarket.modifyPosition(toUnit('10'), { from: trader });
+					await futuresMarket.modifyPosition(toUnit('10'), slippage, { from: trader });
 					await futuresMarket.closePosition({ from: trader });
 
 					// set up for liquidation
-					await futuresMarket.modifyPosition(toUnit('10'), { from: trader });
+					await futuresMarket.modifyPosition(toUnit('10'), slippage, { from: trader });
 					await setPrice(baseAsset, toUnit('1'));
 					await futuresMarket.liquidatePosition(trader, { from: trader2 });
 				});
@@ -5028,7 +5036,7 @@ contract('PerpsV2Market', accounts => {
 			beforeEach(async () => {
 				// prepare a position
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('1'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('1'), slippage, { from: trader });
 				// suspend
 				await systemStatus.suspendFuturesMarket(marketKey, toUnit(0), { from: owner });
 			});
@@ -5045,11 +5053,11 @@ contract('PerpsV2Market', accounts => {
 				it('then mutative market actions work', async () => {
 					await futuresMarket.withdrawAllMargin({ from: trader });
 					await futuresMarket.transferMargin(toUnit('100'), { from: trader });
-					await futuresMarket.modifyPosition(toUnit('10'), { from: trader });
+					await futuresMarket.modifyPosition(toUnit('10'), slippage, { from: trader });
 					await futuresMarket.closePosition({ from: trader });
 
 					// set up for liquidation
-					await futuresMarket.modifyPosition(toUnit('10'), { from: trader });
+					await futuresMarket.modifyPosition(toUnit('10'), slippage, { from: trader });
 					await setPrice(baseAsset, toUnit('1'));
 					await futuresMarket.liquidatePosition(trader, { from: trader2 });
 				});
@@ -5060,7 +5068,7 @@ contract('PerpsV2Market', accounts => {
 			beforeEach(async () => {
 				// prepare a position
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('1'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('1'), slippage, { from: trader });
 				// suspend
 				await systemStatus.suspendFuturesMarket(toBytes32('sOTHER'), toUnit(0), { from: owner });
 			});
@@ -5068,11 +5076,11 @@ contract('PerpsV2Market', accounts => {
 			it('then mutative market actions work', async () => {
 				await futuresMarket.withdrawAllMargin({ from: trader });
 				await futuresMarket.transferMargin(toUnit('100'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('10'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('10'), slippage, { from: trader });
 				await futuresMarket.closePosition({ from: trader });
 
 				// set up for liquidation
-				await futuresMarket.modifyPosition(toUnit('10'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('10'), slippage, { from: trader });
 				await setPrice(baseAsset, toUnit('1'));
 				await futuresMarket.liquidatePosition(trader, { from: trader2 });
 			});
@@ -5094,11 +5102,11 @@ contract('PerpsV2Market', accounts => {
 			beforeEach(async () => {
 				// set up a healthy position
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });
-				await futuresMarket.modifyPosition(toUnit('1'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('1'), slippage, { from: trader });
 
 				// set up a would be liqudatable position
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader2 });
-				await futuresMarket.modifyPosition(toUnit('-100'), { from: trader2 });
+				await futuresMarket.modifyPosition(toUnit('-100'), slippage, { from: trader2 });
 
 				// spike the price
 				await setPrice(baseAsset, multiplyDecimal(initialPrice, toUnit(1.1)));
@@ -5112,7 +5120,7 @@ contract('PerpsV2Market', accounts => {
 				const revertMessage = 'Price too volatile';
 
 				await assert.revert(
-					futuresMarket.modifyPosition(toUnit('1'), { from: trader }),
+					futuresMarket.modifyPosition(toUnit('1'), slippage, { from: trader }),
 					revertMessage
 				);
 				await assert.revert(futuresMarket.closePosition({ from: trader }), revertMessage);
@@ -5173,7 +5181,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnClose(res.fee, expectedFee, toUnit('0.0000001'));
 
 				// check event from modifying a position
-				const tx = await futuresMarket.modifyPosition(orderSize, { from: trader });
+				const tx = await futuresMarket.modifyPosition(orderSize, slippage, { from: trader });
 
 				// correct fee is properly recorded and deducted.
 				const decodedLogs = await getDecodedLogs({ hash: tx.tx, contracts: [futuresMarket] });
@@ -5197,7 +5205,7 @@ contract('PerpsV2Market', accounts => {
 			});
 
 			it('mutative actions do not revert', async () => {
-				await futuresMarket.modifyPosition(toUnit('1'), { from: trader });
+				await futuresMarket.modifyPosition(toUnit('1'), slippage, { from: trader });
 				await futuresMarket.closePosition({ from: trader });
 
 				await futuresMarket.transferMargin(toUnit('1000'), { from: trader });

--- a/test/contracts/PerpsV2Market.offchainDelayedOrder.js
+++ b/test/contracts/PerpsV2Market.offchainDelayedOrder.js
@@ -37,7 +37,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 	const takerFeeOffchainDelayedOrder = toUnit('0.00005');
 	const makerFeeOffchainDelayedOrder = toUnit('0.00001');
 	const initialPrice = toUnit('100');
-	const slippage = toUnit('0.5'); // 50% slippage tolerance acceptable.
+	const slippage = toUnit('0.5'); // 500bps (high bps to avoid affecting unrelated tests)
 
 	const offchainDelayedOrderMinAge = 15;
 	const offchainDelayedOrderMaxAge = 60;

--- a/test/contracts/PerpsV2Market.offchainDelayedOrder.js
+++ b/test/contracts/PerpsV2Market.offchainDelayedOrder.js
@@ -1054,7 +1054,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 							// go to next round
 							// Get spotTradeDetails with offchain price and back to original price
 							await setOnchainPrice(baseAsset, targetOffchainPrice);
-							spotTradeDetails = await perpsV2Market.postTradeDetails(size, trader);
+							spotTradeDetails = await perpsV2Market.postTradeDetails(size, toUnit('0'), trader);
 							await setOnchainPrice(baseAsset, targetPrice);
 
 							// note we need to calc the fillPrice _before_ executing the order because the p/d applied is based
@@ -1099,7 +1099,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 							// go to next round
 							// Get spotTradeDetails with offchain price and back to original price
 							await setOnchainPrice(baseAsset, targetOffchainPrice);
-							spotTradeDetails = await perpsV2Market.postTradeDetails(size, trader);
+							spotTradeDetails = await perpsV2Market.postTradeDetails(size, toUnit('0'), trader);
 							await setOnchainPrice(baseAsset, targetPrice);
 
 							fillPrice = await perpsV2Market.fillPriceWithBasePrice(size, targetOffchainPrice);

--- a/test/contracts/PerpsV2Market.offchainDelayedOrder.js
+++ b/test/contracts/PerpsV2Market.offchainDelayedOrder.js
@@ -37,6 +37,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 	const takerFeeOffchainDelayedOrder = toUnit('0.00005');
 	const makerFeeOffchainDelayedOrder = toUnit('0.00001');
 	const initialPrice = toUnit('100');
+	const slippage = toUnit('0.5'); // 50% slippage tolerance acceptable.
 
 	const offchainDelayedOrderMinAge = 15;
 	const offchainDelayedOrderMaxAge = 60;
@@ -207,7 +208,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 
 			const fillPrice = (await perpsV2Market.fillPrice(size))[0];
 
-			const tx = await perpsV2Market.submitOffchainDelayedOrder(size, {
+			const tx = await perpsV2Market.submitOffchainDelayedOrder(size, slippage, {
 				from: trader,
 			});
 			const txBlock = await ethers.provider.getBlock(tx.receipt.blockNumber);
@@ -248,7 +249,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 		describe('cannot submit an order when', () => {
 			it('zero size', async () => {
 				await assert.revert(
-					perpsV2Market.submitOffchainDelayedOrder(0, { from: trader }),
+					perpsV2Market.submitOffchainDelayedOrder(0, slippage, { from: trader }),
 					'Cannot submit empty order'
 				);
 			});
@@ -256,14 +257,14 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			it('not enough margin', async () => {
 				await perpsV2Market.withdrawAllMargin({ from: trader });
 				await assert.revert(
-					perpsV2Market.submitOffchainDelayedOrder(size, { from: trader }),
+					perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader }),
 					'Insufficient margin'
 				);
 			});
 
 			it('too much leverage', async () => {
 				await assert.revert(
-					perpsV2Market.submitOffchainDelayedOrder(size.mul(toBN(10)), {
+					perpsV2Market.submitOffchainDelayedOrder(size.mul(toBN(10)), slippage, {
 						from: trader,
 					}),
 					'Max leverage exceeded'
@@ -271,9 +272,9 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			});
 
 			it('previous delayed order exists', async () => {
-				await perpsV2Market.submitOffchainDelayedOrder(size, { from: trader });
+				await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
 				await assert.revert(
-					perpsV2Market.submitOffchainDelayedOrder(size, { from: trader }),
+					perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader }),
 					'previous order exists'
 				);
 			});
@@ -281,7 +282,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			it('if futures markets are suspended', async () => {
 				await systemStatus.suspendFutures(toUnit(0), { from: owner });
 				await assert.revert(
-					perpsV2Market.submitOffchainDelayedOrder(size, { from: trader }),
+					perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader }),
 					'Futures markets are suspended'
 				);
 			});
@@ -289,7 +290,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			it('if market is suspended', async () => {
 				await systemStatus.suspendFuturesMarket(marketKey, toUnit(0), { from: owner });
 				await assert.revert(
-					perpsV2Market.submitOffchainDelayedOrder(size, { from: trader }),
+					perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader }),
 					'Market suspended'
 				);
 			});
@@ -307,7 +308,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 
 			const tx = await perpsV2Market.submitOffchainDelayedOrderWithTracking(
 				size,
-
+				slippage,
 				trackingCode,
 				{
 					from: trader,
@@ -351,7 +352,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			await perpsV2MarketSettings.setOffchainDelayedOrderMinAge(marketKey, 0, { from: owner });
 
 			// setup
-			await perpsV2Market.submitOffchainDelayedOrderWithTracking(size, trackingCode, {
+			await perpsV2Market.submitOffchainDelayedOrderWithTracking(size, slippage, trackingCode, {
 				from: trader,
 			});
 
@@ -468,7 +469,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				// transfer more margin
 				await perpsV2Market.transferMargin(margin, { from: trader });
 				// and can submit new order
-				await perpsV2Market.submitOffchainDelayedOrder(size, { from: trader });
+				await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
 				const newOrder = await perpsV2MarketState.delayedOrders(trader);
 				assert.bnEqual(newOrder.sizeDelta, size);
 			}
@@ -477,7 +478,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				roundId = await exchangeRates.getCurrentRoundId(baseAsset);
 				spotFee = (await perpsV2Market.orderFee(size))[0];
 				keeperFee = await perpsV2MarketSettings.minKeeperFee();
-				await perpsV2Market.submitOffchainDelayedOrder(size, { from: trader });
+				await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
 			});
 
 			it('cannot cancel before time', async () => {
@@ -662,7 +663,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 					publishTime: (await currentTime()) + feedTimeOffset,
 				});
 
-				await perpsV2Market.submitOffchainDelayedOrder(size, { from: trader });
+				await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
 
 				await fastForward(delay);
 
@@ -1024,7 +1025,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				// transfer more margin
 				await perpsV2Market.transferMargin(margin, { from: trader });
 				// and can submit new order
-				await perpsV2Market.submitOffchainDelayedOrder(size, { from: trader });
+				await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
 				const newOrder = await perpsV2MarketState.delayedOrders(trader);
 				assert.bnEqual(newOrder.sizeDelta, size);
 			}
@@ -1033,7 +1034,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				let targetPrice, targetOffchainPrice, fillPrice, spotTradeDetails, updateFeedData;
 
 				beforeEach(async () => {
-					await perpsV2Market.submitOffchainDelayedOrder(size, { from: trader });
+					await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
 
 					await fastForward(offchainDelayedOrderMinAge + 1);
 
@@ -1094,7 +1095,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 						beforeEach(async () => {
 							// skew the other way
 							await perpsV2Market.transferMargin(margin.mul(toBN(2)), { from: trader3 });
-							await perpsV2Market.modifyPosition(size.mul(toBN(-2)), { from: trader3 });
+							await perpsV2Market.modifyPosition(size.mul(toBN(-2)), slippage, { from: trader3 });
 							// go to next round
 							// Get spotTradeDetails with offchain price and back to original price
 							await setOnchainPrice(baseAsset, targetOffchainPrice);
@@ -1164,7 +1165,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				publishTime: await currentTime(),
 			});
 
-			await perpsV2Market.submitOffchainDelayedOrder(size, { from: trader });
+			await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
 
 			await fastForward(offchainDelayedOrderMinAge + 1);
 
@@ -1264,7 +1265,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				await perpsV2Market.transferMargin(toUnit('1000'), { from: trader });
 
 				// submit an order
-				await perpsV2Market.submitOffchainDelayedOrder(size, { from: trader });
+				await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
 
 				// spike the price
 				await setOnchainPrice(baseAsset, spikedPrice);
@@ -1281,7 +1282,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				await perpsV2Market.cancelOffchainDelayedOrder(trader, { from: trader });
 
 				await assert.revert(
-					perpsV2Market.submitOffchainDelayedOrder(size, { from: trader }),
+					perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader }),
 					'Price too volatile'
 				);
 			});

--- a/test/contracts/PerpsV2MarketData.js
+++ b/test/contracts/PerpsV2MarketData.js
@@ -36,7 +36,7 @@ contract('PerpsV2MarketData', accounts => {
 	const trader2 = accounts[3];
 	const trader3 = accounts[4];
 	const traderInitialBalance = toUnit(1000000);
-	const slippage = toUnit('0.5'); // 50% slippage tolerance acceptable.
+	const slippage = toUnit('0.5'); // 500bps (high bps to avoid affecting unrelated tests)
 
 	async function setPrice(asset, price, resetCircuitBreaker = true) {
 		await updateAggregatorRates(

--- a/test/contracts/PerpsV2MarketData.js
+++ b/test/contracts/PerpsV2MarketData.js
@@ -36,6 +36,7 @@ contract('PerpsV2MarketData', accounts => {
 	const trader2 = accounts[3];
 	const trader3 = accounts[4];
 	const traderInitialBalance = toUnit(1000000);
+	const slippage = toUnit('0.5'); // 50% slippage tolerance acceptable.
 
 	async function setPrice(asset, price, resetCircuitBreaker = true) {
 		await updateAggregatorRates(
@@ -204,19 +205,19 @@ contract('PerpsV2MarketData', accounts => {
 
 		// The traders take positions on market
 		await futuresMarket.transferMargin(toUnit('1000'), { from: trader1 });
-		await futuresMarket.modifyPosition(toUnit('5'), { from: trader1 });
+		await futuresMarket.modifyPosition(toUnit('5'), slippage, { from: trader1 });
 
 		await futuresMarket.transferMargin(toUnit('750'), { from: trader2 });
-		await futuresMarket.modifyPosition(toUnit('-10'), { from: trader2 });
+		await futuresMarket.modifyPosition(toUnit('-10'), slippage, { from: trader2 });
 
 		await setPrice(baseAsset, toUnit('100'));
 		await futuresMarket.transferMargin(toUnit('4000'), { from: trader3 });
-		await futuresMarket.modifyPosition(toUnit('1.25'), { from: trader3 });
+		await futuresMarket.modifyPosition(toUnit('1.25'), slippage, { from: trader3 });
 
 		sethMarket = await PerpsV2Market.at(await futuresMarketManager.marketForKey(newMarketKey));
 
 		await sethMarket.transferMargin(toUnit('3000'), { from: trader3 });
-		await sethMarket.modifyPosition(toUnit('4'), { from: trader3 });
+		await sethMarket.modifyPosition(toUnit('4'), slippage, { from: trader3 });
 		await setPrice(newAssetKey, toUnit('999'));
 	});
 

--- a/test/contracts/PerpsV2MarketManager.js
+++ b/test/contracts/PerpsV2MarketManager.js
@@ -35,6 +35,7 @@ contract('FuturesMarketManager', accounts => {
 	const owner = accounts[1];
 	const trader = accounts[2];
 	const initialMint = toUnit('100000');
+	const slippage = toUnit('0.5'); // 50% slippage tolerance acceptable.
 
 	async function setPrice(asset, price, resetCircuitBreaker = true) {
 		await updateAggregatorRates(
@@ -678,10 +679,10 @@ contract('FuturesMarketManager', accounts => {
 
 			// The traders take positions on market
 			await markets[0].transferMargin(toUnit('1000'), { from: trader });
-			await markets[0].modifyPosition(toUnit('5'), { from: trader });
+			await markets[0].modifyPosition(toUnit('5'), slippage, { from: trader });
 
 			await markets[1].transferMargin(toUnit('3000'), { from: trader });
-			await markets[1].modifyPosition(toUnit('4'), { from: trader });
+			await markets[1].modifyPosition(toUnit('4'), slippage, { from: trader });
 			await setPrice(await markets[1].baseAsset(), toUnit('999'));
 		});
 

--- a/test/contracts/PerpsV2MarketManager.js
+++ b/test/contracts/PerpsV2MarketManager.js
@@ -35,7 +35,7 @@ contract('FuturesMarketManager', accounts => {
 	const owner = accounts[1];
 	const trader = accounts[2];
 	const initialMint = toUnit('100000');
-	const slippage = toUnit('0.5'); // 50% slippage tolerance acceptable.
+	const slippage = toUnit('0.5'); // 500bps (high bps to avoid affecting unrelated tests)
 
 	async function setPrice(asset, price, resetCircuitBreaker = true) {
 		await updateAggregatorRates(

--- a/test/integration/behaviors/perpsV2.behavior.js
+++ b/test/integration/behaviors/perpsV2.behavior.js
@@ -4,14 +4,14 @@ const { assert } = require('../../contracts/common');
 const { addAggregatorAndSetRate } = require('../utils/rates');
 const { ensureBalance } = require('../utils/balances');
 
-// conveniece methods
+// convenience methods
 const toUnit = v => ethers.utils.parseUnits(v.toString());
 const unit = toUnit(1);
 const toBN = v => ethers.BigNumber.from(v.toString());
 const divideDecimal = (a, b) => a.mul(unit).div(b);
 const multiplyDecimal = (a, b) => a.mul(b).div(unit);
 
-const proxyedContract = (proxy, abi, user) => {
+const proxiedContract = (proxy, abi, user) => {
 	return new ethers.Contract(proxy.address, abi, user);
 };
 
@@ -66,7 +66,7 @@ function itCanTrade({ ctx }) {
 			someUser = ctx.users.someUser;
 			otherUser = ctx.users.otherUser;
 
-			PerpsV2MarketBTC = proxyedContract(
+			PerpsV2MarketBTC = proxiedContract(
 				PerpsV2ProxyBTC,
 				unifyAbis([
 					PerpsV2MarketImplBTC,
@@ -87,7 +87,7 @@ function itCanTrade({ ctx }) {
 		});
 
 		describe('position management', () => {
-			let market, assetKey, marketKey, price, balance, posSize1x, debt;
+			let market, assetKey, marketKey, price, balance, posSize1x, debt, slippage;
 			const margin = toUnit('1000');
 
 			before('market and conditions', async () => {
@@ -97,6 +97,7 @@ function itCanTrade({ ctx }) {
 				price = await ExchangeRates.rateForCurrency(assetKey);
 				balance = await SynthsUSD.balanceOf(someUser.address);
 				posSize1x = divideDecimal(margin, price);
+				slippage = toUnit('0.5');
 			});
 
 			it('user can transferMargin and withdraw it', async () => {
@@ -132,7 +133,7 @@ function itCanTrade({ ctx }) {
 				it('user can open and close position', async () => {
 					// open position
 					const initialMargin = (await market.positions(someUser.address)).margin;
-					await market.modifyPosition(posSize1x);
+					await market.modifyPosition(posSize1x, slippage);
 
 					const position = await market.positions(someUser.address);
 					assert.bnGt(initialMargin, position.margin); // fee was taken
@@ -145,7 +146,7 @@ function itCanTrade({ ctx }) {
 				});
 
 				it('user can modifyPosition to short', async () => {
-					await market.modifyPosition(posSize1x.mul(toBN(-5)));
+					await market.modifyPosition(posSize1x.mul(toBN(-5)), slippage);
 					const position = await market.positions(someUser.address);
 					assert.bnEqual(position.size, posSize1x.mul(toBN(-5))); // right position size
 
@@ -161,7 +162,7 @@ function itCanTrade({ ctx }) {
 
 						// lever up
 						const maxLeverage = await PerpsV2MarketSettings.maxLeverage(marketKey);
-						await market.modifyPosition(multiplyDecimal(posSize1x, maxLeverage));
+						await market.modifyPosition(multiplyDecimal(posSize1x, maxLeverage), slippage);
 					});
 
 					before('if new aggregator is set and price drops 20%', async () => {
@@ -174,7 +175,7 @@ function itCanTrade({ ctx }) {
 						await assert.revert(market.transferMargin(toBN(-1)), 'Insufficient margin');
 
 						// cannot modify
-						await assert.revert(market.modifyPosition(toBN(-1)), 'can be liquidated');
+						await assert.revert(market.modifyPosition(toBN(-1), slippage), 'can be liquidated');
 
 						// cannot close
 						await assert.revert(market.closePosition(), 'can be liquidated');

--- a/test/integration/behaviors/perpsV2.behavior.js
+++ b/test/integration/behaviors/perpsV2.behavior.js
@@ -97,7 +97,7 @@ function itCanTrade({ ctx }) {
 				price = await ExchangeRates.rateForCurrency(assetKey);
 				balance = await SynthsUSD.balanceOf(someUser.address);
 				posSize1x = divideDecimal(margin, price);
-				slippage = toUnit('0.5');
+				slippage = toUnit('0.5'); // 500bps (high bps to avoid affecting unrelated tests)
 			});
 
 			it('user can transferMargin and withdraw it', async () => {


### PR DESCRIPTION
As part of SIP 279, we introduce slippage protection as a complementary mechanism to premium/discount pricing. Slippage protection will allow users to specify a price percentage delta when making trades in both delayed orders and regular orders. The most impactful change involves a modification to two public interface methods modifyPosition and submitDelayedOrder.

```solidity
interface PerpsV2Market {
	function modifyPosition(int sizeDelta, uint slippage);
	function submitDelayedOrder(int sizeDelta, uint slippage, uint desiredTimeDelta);
        function submitDelayedOrderWithTracking(int sizeDelta, uint slippage, uint desiredTimeDelta, bytes32 trackingCode);
        function submitOffchainDelayedOrder(int sizeDelta, uint slippage);
        function submitOffchainDelayedOrderWithTracking(
            int sizeDelta,
            uint slippage,
            bytes32 trackingCode
        );
}
```

Example:

```
ETH Price (price)  = 1000
Slippage           = 0.01 (1%)
p/d Price (price') = 1005

Slippage Upper Bound = 1000 * (1 + 0.01)
                     = 1010
```

If price' is under the slippage upper bound then the trade can proceed to execute. If not, the execution is reverted.

Moreover, when a `0` slippage is provided, we default the slippage price to be `currentPrice + maker/takerFee` instead of `currentPrice + (1 + slippage)`.

Note: Unit tests should all be passing. However, I have yet to implement new unit tests to account for this new feature. That will come in a later PR.

This also updates the `postTradeDetails` function to allow a user to specify an arbitrary `tradePrice`.