### PR TITLE
SIP 279 (cont.) Premiums applied on Liquidation

### DIFF
--- a/contracts/PerpsV2Market.sol
+++ b/contracts/PerpsV2Market.sol
@@ -174,8 +174,8 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
      * Adjust the sender's position size.
      * Reverts if the resulting position is too large, outside the max leverage, or is liquidating.
      */
-    function modifyPosition(int sizeDelta, uint slippage) external {
-        _modifyPosition(sizeDelta, slippage, bytes32(0));
+    function modifyPosition(int sizeDelta, uint priceImpactDelta) external {
+        _modifyPosition(sizeDelta, priceImpactDelta, bytes32(0));
     }
 
     /*
@@ -184,15 +184,15 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
      */
     function modifyPositionWithTracking(
         int sizeDelta,
-        uint slippage,
+        uint priceImpactDelta,
         bytes32 trackingCode
     ) external {
-        _modifyPosition(sizeDelta, slippage, trackingCode);
+        _modifyPosition(sizeDelta, priceImpactDelta, trackingCode);
     }
 
     function _modifyPosition(
         int sizeDelta,
-        uint slippage,
+        uint priceImpactDelta,
         bytes32 trackingCode
     ) internal onlyProxy {
         uint price = _assetPriceRequireSystemChecks();
@@ -204,7 +204,7 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
                 price: price,
                 takerFee: _takerFee(_marketKey()),
                 makerFee: _makerFee(_marketKey()),
-                slippage: slippage,
+                priceImpactDelta: priceImpactDelta,
                 trackingCode: trackingCode
             })
         );
@@ -213,16 +213,16 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
     /*
      * Submit an order to close a position.
      */
-    function closePosition(uint slippage) external {
-        _closePosition(slippage, bytes32(0));
+    function closePosition(uint priceImpactDelta) external {
+        _closePosition(priceImpactDelta, bytes32(0));
     }
 
     /// Same as closePosition, but emits an even with the trackingCode for volume source fee sharing
-    function closePositionWithTracking(uint slippage, bytes32 trackingCode) external {
-        _closePosition(slippage, trackingCode);
+    function closePositionWithTracking(uint priceImpactDelta, bytes32 trackingCode) external {
+        _closePosition(priceImpactDelta, trackingCode);
     }
 
-    function _closePosition(uint slippage, bytes32 trackingCode) internal onlyProxy {
+    function _closePosition(uint priceImpactDelta, bytes32 trackingCode) internal onlyProxy {
         int size = marketState.positions(messageSender).size;
         _revertIfError(size == 0, Status.NoPositionOpen);
         uint price = _assetPriceRequireSystemChecks();
@@ -234,7 +234,7 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
                 price: price,
                 takerFee: _takerFee(_marketKey()),
                 makerFee: _makerFee(_marketKey()),
-                slippage: slippage,
+                priceImpactDelta: priceImpactDelta,
                 trackingCode: trackingCode
             })
         );

--- a/contracts/PerpsV2Market.sol
+++ b/contracts/PerpsV2Market.sol
@@ -248,7 +248,7 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
         Position memory position = marketState.positions(account);
 
         // get remaining margin for sending any leftover buffer to fee pool
-        uint remMargin = _remainingMargin(position, price);
+        uint remMargin = _remainingLiquidatableMargin(position, price);
 
         // Record updates to market size and debt.
         int positionSize = position.size;

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -71,7 +71,7 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
         uint price;
         uint takerFee;
         uint makerFee;
-        uint slippage;
+        uint priceImpactDelta;
         bytes32 trackingCode; // optional tracking code for volume source fee sharing
     }
 
@@ -96,7 +96,7 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
         _errorMessages[uint8(Status.NilOrder)] = "Cannot submit empty order";
         _errorMessages[uint8(Status.NoPositionOpen)] = "No position open";
         _errorMessages[uint8(Status.PriceTooVolatile)] = "Price too volatile";
-        _errorMessages[uint8(Status.SlippageToleranceExceeded)] = "Price exceeded slippage tolerance";
+        _errorMessages[uint8(Status.PriceImpactToleranceExceeded)] = "Price impact exceeded tolerance";
     }
 
     /* ---------- External Contracts ---------- */
@@ -629,39 +629,39 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
     }
 
     /*
-     * @dev Given the current oracle price (not fillPrice) and slippage, return the max slippage
-     * price which is a price that is inclusive of the slippage tolerance.
+     * @dev Given the current oracle price (not fillPrice) and priceImpactDelta, return the max priceImpactDelta
+     * price which is a price that is inclusive of the priceImpactDelta tolerance.
      *
-     * For instance, if price ETH is $1000 and slippage is 1% then maxSlippagePrice is $1010. The fillPrice
+     * For instance, if price ETH is $1000 and priceImpactDelta is 1% then maxPriceImpact is $1010. The fillPrice
      * on the trade must be below $1010 for the trade to succeed.
      *
-     * For clarity when slippage is:
+     * For clarity when priceImpactDelta is:
      *  0.1   then 10%
      *  0.01  then 1%
      *  0.001 then 0.1%
      *
-     * When price is $1000 and slippage is:
+     * When price is $1000 and priceImpactDelta is:
      *  0.1   then price * (1 + 0.1)   = 1100
      *  0.01  then price * (1 + 0.01)  = 1010
      *  0.001 then price * (1 + 0.001) = 1001
      *
-     * When slippage is not specified (i.e. 0) then we derive the price by looking at the orderFee as a
+     * When priceImpactDelta is not specified (i.e. 0) then we derive the price by looking at the orderFee as a
      * percentage of the fillPrice. So assuming no dynamic fees and this is a taker trade with a 0.0045
-     * fee on a 10k USD sized trade then the slippagePrice would be 100 + 10000 * 0.0045 = 145.
+     * fee on a 10k USD sized trade then the maxPriceImpact would be 100 + 10000 * 0.0045 = 145
      */
-    function _maxSlippagePrice(
+    function _maxPriceImpact(
         uint price,
-        uint slippage,
+        uint priceImpactDelta,
         uint orderFee
     ) internal pure returns (uint) {
-        // No slippage is specified, use the orderFee for the upper bound.
+        // No priceImpactDelta is specified, use the orderFee for the upper bound.
         //
         // note: We look at orderFee (not maker/taker fee) because orderFee considers the case when a
         // trade with large enough size can flip the skew.
-        if (slippage == 0) {
+        if (priceImpactDelta == 0) {
             return price.add(orderFee);
         }
-        return price.multiplyDecimal(uint(_UNIT).add(slippage));
+        return price.multiplyDecimal(uint(_UNIT).add(priceImpactDelta));
     }
 
     /*

--- a/contracts/PerpsV2MarketDelayedOrders.sol
+++ b/contracts/PerpsV2MarketDelayedOrders.sol
@@ -41,32 +41,32 @@ contract PerpsV2MarketDelayedOrders is IPerpsV2MarketDelayedOrders, PerpsV2Marke
      * Reverts if the desiredTimeDelta is < minimum required delay.
      *
      * @param sizeDelta size in baseAsset (notional terms) of the order, similar to `modifyPosition` interface
-     * @param slippage is a percentage tolerance on fillPrice to be check upon execution
+     * @param priceImpactDelta is a percentage tolerance on fillPrice to be check upon execution
      * @param desiredTimeDelta maximum time in seconds to wait before filling this order
      */
     function submitDelayedOrder(
         int sizeDelta,
-        uint slippage,
+        uint priceImpactDelta,
         uint desiredTimeDelta
     ) external onlyProxy {
         // @dev market key is obtained here and not in internal function to prevent stack too deep there
         // bytes32 marketKey = _marketKey();
 
-        _submitDelayedOrder(_marketKey(), sizeDelta, slippage, desiredTimeDelta, bytes32(0), false);
+        _submitDelayedOrder(_marketKey(), sizeDelta, priceImpactDelta, desiredTimeDelta, bytes32(0), false);
     }
 
     /// same as submitDelayedOrder but emits an event with the tracking code
     /// to allow volume source fee sharing for integrations
     function submitDelayedOrderWithTracking(
         int sizeDelta,
-        uint slippage,
+        uint priceImpactDelta,
         uint desiredTimeDelta,
         bytes32 trackingCode
     ) external onlyProxy {
         // @dev market key is obtained here and not in internal function to prevent stack too deep there
         // bytes32 marketKey = _marketKey();
 
-        _submitDelayedOrder(_marketKey(), sizeDelta, slippage, desiredTimeDelta, trackingCode, false);
+        _submitDelayedOrder(_marketKey(), sizeDelta, priceImpactDelta, desiredTimeDelta, trackingCode, false);
     }
 
     /**

--- a/contracts/PerpsV2MarketDelayedOrdersBase.sol
+++ b/contracts/PerpsV2MarketDelayedOrdersBase.sol
@@ -39,7 +39,7 @@ contract PerpsV2MarketDelayedOrdersBase is PerpsV2MarketProxyable {
     function _submitDelayedOrder(
         bytes32 marketKey,
         int sizeDelta,
-        uint slippage,
+        uint priceImpactDelta,
         uint desiredTimeDelta,
         bytes32 trackingCode,
         bool isOffchain
@@ -72,7 +72,7 @@ contract PerpsV2MarketDelayedOrdersBase is PerpsV2MarketProxyable {
                 price: price,
                 takerFee: isOffchain ? _takerFeeOffchainDelayedOrder(marketKey) : _takerFeeDelayedOrder(marketKey),
                 makerFee: isOffchain ? _makerFeeOffchainDelayedOrder(marketKey) : _makerFeeDelayedOrder(marketKey),
-                slippage: slippage,
+                priceImpactDelta: priceImpactDelta,
                 trackingCode: trackingCode
             });
         (, , Status status) = _postTradeDetails(position, params);
@@ -91,7 +91,7 @@ contract PerpsV2MarketDelayedOrdersBase is PerpsV2MarketProxyable {
             DelayedOrder({
                 isOffchain: isOffchain,
                 sizeDelta: int128(sizeDelta),
-                slippage: uint128(slippage),
+                priceImpactDelta: uint128(priceImpactDelta),
                 targetRoundId: uint128(targetRoundId),
                 commitDeposit: uint128(commitDeposit),
                 keeperDeposit: uint128(keeperDeposit),
@@ -115,7 +115,7 @@ contract PerpsV2MarketDelayedOrdersBase is PerpsV2MarketProxyable {
             messageSender,
             order.isOffchain,
             order.sizeDelta,
-            order.slippage,
+            order.priceImpactDelta,
             order.targetRoundId,
             order.commitDeposit,
             order.keeperDeposit,
@@ -206,7 +206,7 @@ contract PerpsV2MarketDelayedOrdersBase is PerpsV2MarketProxyable {
                 price: currentPrice, // the funding is applied only from order confirmation time
                 takerFee: takerFee, //_takerFeeDelayedOrder(_marketKey()),
                 makerFee: makerFee, //_makerFeeDelayedOrder(_marketKey()),
-                slippage: order.slippage,
+                priceImpactDelta: order.priceImpactDelta,
                 trackingCode: order.trackingCode
             })
         );

--- a/contracts/PerpsV2MarketDelayedOrdersOffchain.sol
+++ b/contracts/PerpsV2MarketDelayedOrdersOffchain.sol
@@ -49,25 +49,25 @@ contract PerpsV2MarketDelayedOrdersOffchain is IPerpsV2MarketOffchainOrders, Per
      * Reverts if the desiredTimeDelta is < minimum required delay.
      *
      * @param sizeDelta size in baseAsset (notional terms) of the order, similar to `modifyPosition` interface
-     * @param slippage is a percentage tolerance on fillPrice to be check upon execution
+     * @param priceImpactDelta is a percentage tolerance on fillPrice to be check upon execution
      */
-    function submitOffchainDelayedOrder(int sizeDelta, uint slippage) external onlyProxy {
+    function submitOffchainDelayedOrder(int sizeDelta, uint priceImpactDelta) external onlyProxy {
         // @dev market key is obtained here and not in internal function to prevent stack too deep there
         // bytes32 marketKey = _marketKey();
 
         // enforcing desiredTimeDelta to 0 to use default (not needed for offchain delayed order)
-        _submitDelayedOrder(_marketKey(), sizeDelta, slippage, 0, bytes32(0), true);
+        _submitDelayedOrder(_marketKey(), sizeDelta, priceImpactDelta, 0, bytes32(0), true);
     }
 
     function submitOffchainDelayedOrderWithTracking(
         int sizeDelta,
-        uint slippage,
+        uint priceImpactDelta,
         bytes32 trackingCode
     ) external onlyProxy {
         // @dev market key is obtained here and not in internal function to prevent stack too deep there
         // bytes32 marketKey = _marketKey();
 
-        _submitDelayedOrder(_marketKey(), sizeDelta, slippage, 0, trackingCode, true);
+        _submitDelayedOrder(_marketKey(), sizeDelta, priceImpactDelta, 0, trackingCode, true);
     }
 
     /**

--- a/contracts/PerpsV2MarketProxyable.sol
+++ b/contracts/PerpsV2MarketProxyable.sol
@@ -35,8 +35,8 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
     function _positionDebtCorrection(Position memory position) internal view returns (int) {
         /**
         This method only returns the correction term for the debt calculation of the position, and not it's 
-        debt. This is needed for keeping track of the _marketDebt() in an efficient manner to allow O(1) marketDebt
-        calculation in _marketDebt().
+        debt. This is needed for keeping track of the marketDebt() in an efficient manner to allow O(1) marketDebt
+        calculation in marketDebt().
 
         Explanation of the full market debt calculation from the SIP https://sips.synthetix.io/sips/sip-80/:
 
@@ -56,7 +56,7 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
         The last term: sum( initial-margin - q * ( last-price + initial-funding ) ) being the position debt correction
             that is tracked with each position change using this method. 
         
-        The first term and the full debt calculation using current skew, price, and funding is calculated globally in _marketDebt().
+        The first term and the full debt calculation using current skew, price, and funding is calculated globally in marketDebt().
          */
         return
             int(position.margin).sub(

--- a/contracts/PerpsV2MarketState.sol
+++ b/contracts/PerpsV2MarketState.sol
@@ -171,7 +171,7 @@ contract PerpsV2MarketState is Owned, StateShared, IPerpsV2MarketBaseTypes {
      * @dev Only the associated contract may call this.
      * @param account The account whose value to set.
      * @param sizeDelta Difference in position to pass to modifyPosition
-     * @param slippage Slippage tolerance as a percentage used on fillPrice at execution
+     * @param priceImpactDelta Price impact tolerance as a percentage used on fillPrice at execution
      * @param targetRoundId Price oracle roundId using which price this order needs to executed
      * @param commitDeposit The commitDeposit paid upon submitting that needs to be refunded if order succeeds
      * @param keeperDeposit The keeperDeposit paid upon submitting that needs to be paid / refunded on tx confirmation
@@ -183,7 +183,7 @@ contract PerpsV2MarketState is Owned, StateShared, IPerpsV2MarketBaseTypes {
         address account,
         bool isOffchain,
         int128 sizeDelta,
-        uint128 slippage,
+        uint128 priceImpactDelta,
         uint128 targetRoundId,
         uint128 commitDeposit,
         uint128 keeperDeposit,
@@ -194,7 +194,7 @@ contract PerpsV2MarketState is Owned, StateShared, IPerpsV2MarketBaseTypes {
         delayedOrders[account] = DelayedOrder(
             isOffchain,
             sizeDelta,
-            slippage,
+            priceImpactDelta,
             targetRoundId,
             commitDeposit,
             keeperDeposit,

--- a/contracts/PerpsV2MarketViews.sol
+++ b/contracts/PerpsV2MarketViews.sol
@@ -225,7 +225,7 @@ contract PerpsV2MarketViews is PerpsV2MarketBase, IPerpsV2MarketViews {
                 price: _fillPrice(sizeDelta, price),
                 takerFee: _takerFee(_marketKey()),
                 makerFee: _makerFee(_marketKey()),
-                slippage: 0, // slippage is not needed to calculate order fees.
+                priceImpactDelta: 0, // price impact is not needed to calculate order fees.
                 trackingCode: bytes32(0)
             });
         return (_orderFee(params, dynamicFeeRate), isInvalid || tooVolatile);
@@ -234,7 +234,7 @@ contract PerpsV2MarketViews is PerpsV2MarketBase, IPerpsV2MarketViews {
     /*
      * @notice Returns all new position details if a given order from `sender` was confirmed at the current price.
      *
-     * note: We do not check for slippage during this trade simulation.
+     * note: We do not check for price impact during this trade simulation.
      *
      * @param sizeDelta The size of the next trade
      * @param tradePrice An arbitrary price to simulate on. When price is 0 then the current price will be used
@@ -270,7 +270,7 @@ contract PerpsV2MarketViews is PerpsV2MarketBase, IPerpsV2MarketViews {
                 price: _fillPrice(sizeDelta, tradePrice), // we use fillPrice here as we're not actually calling _trade.
                 takerFee: _takerFee(_marketKey()),
                 makerFee: _makerFee(_marketKey()),
-                slippage: 0,
+                priceImpactDelta: 0,
                 trackingCode: bytes32(0)
             });
         (Position memory newPosition, uint fee_, Status status_) = _postTradeDetails(marketState.positions(sender), params);

--- a/contracts/interfaces/IPerpsV2Market.sol
+++ b/contracts/interfaces/IPerpsV2Market.sol
@@ -13,17 +13,17 @@ interface IPerpsV2Market {
 
     function withdrawAllMargin() external;
 
-    function modifyPosition(int sizeDelta, uint slippage) external;
+    function modifyPosition(int sizeDelta, uint priceImpactDelta) external;
 
     function modifyPositionWithTracking(
         int sizeDelta,
-        uint slippage,
+        uint priceImpactDelta,
         bytes32 trackingCode
     ) external;
 
-    function closePosition(uint slippage) external;
+    function closePosition(uint priceImpactDelta) external;
 
-    function closePositionWithTracking(uint slippage, bytes32 trackingCode) external;
+    function closePositionWithTracking(uint priceImpactDelta, bytes32 trackingCode) external;
 
     function liquidatePosition(address account) external;
 }

--- a/contracts/interfaces/IPerpsV2MarketBaseTypes.sol
+++ b/contracts/interfaces/IPerpsV2MarketBaseTypes.sol
@@ -16,7 +16,7 @@ interface IPerpsV2MarketBaseTypes {
         NilOrder,
         NoPositionOpen,
         PriceTooVolatile,
-        SlippageToleranceExceeded
+        PriceImpactToleranceExceeded
     }
 
     // If margin/size are positive, the position is long; if negative then it is short.
@@ -32,7 +32,7 @@ interface IPerpsV2MarketBaseTypes {
     struct DelayedOrder {
         bool isOffchain; // flag indicating the delayed order is offchain
         int128 sizeDelta; // difference in position to pass to modifyPosition
-        uint128 slippage; // slippage tolerance as a percentage used on fillPrice at execution
+        uint128 priceImpactDelta; // price impact tolerance as a percentage used on fillPrice at execution
         uint128 targetRoundId; // price oracle roundId using which price this order needs to executed
         uint128 commitDeposit; // the commitDeposit paid upon submitting that needs to be refunded if order succeeds
         uint128 keeperDeposit; // the keeperDeposit paid upon submitting that needs to be paid / refunded on tx confirmation

--- a/contracts/interfaces/IPerpsV2MarketDelayedOrders.sol
+++ b/contracts/interfaces/IPerpsV2MarketDelayedOrders.sol
@@ -3,13 +3,13 @@ pragma solidity ^0.5.16;
 interface IPerpsV2MarketDelayedOrders {
     function submitDelayedOrder(
         int sizeDelta,
-        uint slippage,
+        uint priceImpactDelta,
         uint desiredTimeDelta
     ) external;
 
     function submitDelayedOrderWithTracking(
         int sizeDelta,
-        uint slippage,
+        uint priceImpactDelta,
         uint desiredTimeDelta,
         bytes32 trackingCode
     ) external;

--- a/contracts/interfaces/IPerpsV2MarketOffchainOrders.sol
+++ b/contracts/interfaces/IPerpsV2MarketOffchainOrders.sol
@@ -2,11 +2,11 @@ pragma solidity ^0.5.16;
 pragma experimental ABIEncoderV2;
 
 interface IPerpsV2MarketOffchainOrders {
-    function submitOffchainDelayedOrder(int sizeDelta, uint slippage) external;
+    function submitOffchainDelayedOrder(int sizeDelta, uint priceImpactDelta) external;
 
     function submitOffchainDelayedOrderWithTracking(
         int sizeDelta,
-        uint slippage,
+        uint priceImpactDelta,
         bytes32 trackingCode
     ) external;
 

--- a/contracts/interfaces/IPerpsV2MarketState.sol
+++ b/contracts/interfaces/IPerpsV2MarketState.sol
@@ -62,7 +62,7 @@ interface IPerpsV2MarketState {
         address account,
         bool isOffchain,
         int128 sizeDelta,
-        uint128 slippage,
+        uint128 priceImpactDelta,
         uint128 targetRoundId,
         uint128 commitDeposit,
         uint128 keeperDeposit,

--- a/contracts/test-helpers/TestablePerpsV2Market.sol
+++ b/contracts/test-helpers/TestablePerpsV2Market.sol
@@ -176,6 +176,12 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
         return (0, false);
     }
 
+    function liquidationPremium(address account) external view returns (uint price) {
+        (uint price, ) = _assetPrice();
+        Position memory position = marketState.positions(account);
+        return _liquidationPremium(position.size, price);
+    }
+
     function liquidationFee(address account) external view returns (uint) {
         return 0;
     }

--- a/contracts/test-helpers/TestablePerpsV2Market.sol
+++ b/contracts/test-helpers/TestablePerpsV2Market.sol
@@ -104,8 +104,12 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
 
     /* @dev Given the size and basePrice (e.g. current off-chain price), return the expected fillPrice */
     function fillPriceWithBasePrice(int size, uint basePrice) external view returns (uint, bool) {
-        (uint price, bool invalid) = _assetPrice();
-        return (_fillPrice(size, basePrice == 0 ? price : basePrice), invalid);
+        uint price = basePrice;
+        bool invalid;
+        if (basePrice == 0) {
+            (price, invalid) = _assetPrice();
+        }
+        return (_fillPrice(size, price), invalid);
     }
 
     /* @dev Given an account, find the associated position and return the netFundingPerUnit. */

--- a/contracts/test-helpers/TestablePerpsV2Market.sol
+++ b/contracts/test-helpers/TestablePerpsV2Market.sol
@@ -221,13 +221,13 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
 
     function submitDelayedOrder(
         int sizeDelta,
-        uint slippage,
+        uint priceImpactDelta,
         uint desiredTimeDelta
     ) external {}
 
     function submitDelayedOrderWithTracking(
         int sizeDelta,
-        uint slippage,
+        uint priceImpactDelta,
         uint desiredTimeDelta,
         bytes32 trackingCode
     ) external {}
@@ -238,11 +238,11 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
 
     /* ---------- Offchain Delayed Orders ---------- */
 
-    function submitOffchainDelayedOrder(int sizeDelta, uint slippage) external {}
+    function submitOffchainDelayedOrder(int sizeDelta, uint priceImpactDelta) external {}
 
     function submitOffchainDelayedOrderWithTracking(
         int sizeDelta,
-        uint slippage,
+        uint priceImpactDelta,
         bytes32 trackingCode
     ) external {}
 

--- a/test/contracts/PerpsV2Market.delayedOrder.js
+++ b/test/contracts/PerpsV2Market.delayedOrder.js
@@ -113,7 +113,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 		desiredTimeDelta = 60;
 		minDelayTimeDelta = 60;
 		await setPrice(baseAsset, price);
-		fillPrice = (await futuresMarket.fillPrice(size))[0];
+		fillPrice = (await futuresMarket.fillPriceWithBasePrice(size, 0))[0];
 	});
 
 	describe('submitDelayedOrder()', () => {
@@ -333,7 +333,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 
 			// go to next round
 			await setPrice(baseAsset, price);
-			const fillPrice = (await futuresMarket.fillPrice(size))[0];
+			const fillPrice = (await futuresMarket.fillPriceWithBasePrice(size, 0))[0];
 			const expectedFee = multiplyDecimal(size, multiplyDecimal(fillPrice, takerFeeDelayedOrder));
 
 			// execute the order
@@ -698,7 +698,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 				// size delta as a % is lower post execution.
 				//
 				// e.g. 20 / 100 > 20 / 120
-				const fillPrice = (await futuresMarket.fillPrice(size))[0];
+				const fillPrice = (await futuresMarket.fillPriceWithBasePrice(size, 0))[0];
 
 				// execute the order
 				const tx = await futuresMarket.executeDelayedOrder(trader, { from: from });
@@ -806,7 +806,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 					// check we can execute.
 					//
 					// note the predicate uses `price` and not `targetPrice` because target is never reached
-					const expectedPrice = (await futuresMarket.fillPrice(size))[0];
+					const expectedPrice = (await futuresMarket.fillPriceWithBasePrice(size, 0))[0];
 					await checkExecution(trader, expectedPrice, takerFeeDelayedOrder, spotTradeDetails);
 				});
 
@@ -816,7 +816,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 						beforeEach(async () => {
 							// go to next round
 							await setPrice(baseAsset, targetPrice);
-							targetFillPrice = (await futuresMarket.fillPrice(size))[0];
+							targetFillPrice = (await futuresMarket.fillPriceWithBasePrice(size, 0))[0];
 							spotTradeDetails = await futuresMarket.postTradeDetails(size, toUnit('0'), trader);
 						});
 
@@ -843,7 +843,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 							});
 							// go to next round
 							await setPrice(baseAsset, targetPrice);
-							targetFillPrice = (await futuresMarket.fillPrice(size))[0];
+							targetFillPrice = (await futuresMarket.fillPriceWithBasePrice(size, 0))[0];
 							spotTradeDetails = await futuresMarket.postTradeDetails(size, toUnit('0'), trader);
 						});
 
@@ -898,7 +898,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 						beforeEach(async () => {
 							// go to next round
 							await setPrice(baseAsset, price);
-							targetFillPrice = (await futuresMarket.fillPrice(size))[0];
+							targetFillPrice = (await futuresMarket.fillPriceWithBasePrice(size, 0))[0];
 						});
 
 						it('from account owner', async () => {
@@ -933,7 +933,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 
 							// go to next round
 							await setPrice(baseAsset, price);
-							targetFillPrice = (await futuresMarket.fillPrice(size))[0];
+							targetFillPrice = (await futuresMarket.fillPriceWithBasePrice(size, 0))[0];
 						});
 
 						it('from account owner', async () => {

--- a/test/contracts/PerpsV2Market.offchainDelayedOrder.js
+++ b/test/contracts/PerpsV2Market.offchainDelayedOrder.js
@@ -37,7 +37,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 	const takerFeeOffchainDelayedOrder = toUnit('0.00005');
 	const makerFeeOffchainDelayedOrder = toUnit('0.00001');
 	const initialPrice = toUnit('100');
-	const slippage = toUnit('0.5'); // 500bps (high bps to avoid affecting unrelated tests)
+	const priceImpactDelta = toUnit('0.5'); // 500bps (high bps to avoid affecting unrelated tests)
 
 	const offchainDelayedOrderMinAge = 15;
 	const offchainDelayedOrderMaxAge = 60;
@@ -208,7 +208,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 
 			const fillPrice = (await perpsV2Market.fillPrice(size))[0];
 
-			const tx = await perpsV2Market.submitOffchainDelayedOrder(size, slippage, {
+			const tx = await perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, {
 				from: trader,
 			});
 			const txBlock = await ethers.provider.getBlock(tx.receipt.blockNumber);
@@ -249,7 +249,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 		describe('cannot submit an order when', () => {
 			it('zero size', async () => {
 				await assert.revert(
-					perpsV2Market.submitOffchainDelayedOrder(0, slippage, { from: trader }),
+					perpsV2Market.submitOffchainDelayedOrder(0, priceImpactDelta, { from: trader }),
 					'Cannot submit empty order'
 				);
 			});
@@ -257,14 +257,14 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			it('not enough margin', async () => {
 				await perpsV2Market.withdrawAllMargin({ from: trader });
 				await assert.revert(
-					perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader }),
+					perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, { from: trader }),
 					'Insufficient margin'
 				);
 			});
 
 			it('too much leverage', async () => {
 				await assert.revert(
-					perpsV2Market.submitOffchainDelayedOrder(size.mul(toBN(10)), slippage, {
+					perpsV2Market.submitOffchainDelayedOrder(size.mul(toBN(10)), priceImpactDelta, {
 						from: trader,
 					}),
 					'Max leverage exceeded'
@@ -272,9 +272,9 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			});
 
 			it('previous delayed order exists', async () => {
-				await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
+				await perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, { from: trader });
 				await assert.revert(
-					perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader }),
+					perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, { from: trader }),
 					'previous order exists'
 				);
 			});
@@ -282,7 +282,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			it('if futures markets are suspended', async () => {
 				await systemStatus.suspendFutures(toUnit(0), { from: owner });
 				await assert.revert(
-					perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader }),
+					perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, { from: trader }),
 					'Futures markets are suspended'
 				);
 			});
@@ -290,7 +290,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			it('if market is suspended', async () => {
 				await systemStatus.suspendFuturesMarket(marketKey, toUnit(0), { from: owner });
 				await assert.revert(
-					perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader }),
+					perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, { from: trader }),
 					'Market suspended'
 				);
 			});
@@ -308,7 +308,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 
 			const tx = await perpsV2Market.submitOffchainDelayedOrderWithTracking(
 				size,
-				slippage,
+				priceImpactDelta,
 				trackingCode,
 				{
 					from: trader,
@@ -352,9 +352,14 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			await perpsV2MarketSettings.setOffchainDelayedOrderMinAge(marketKey, 0, { from: owner });
 
 			// setup
-			await perpsV2Market.submitOffchainDelayedOrderWithTracking(size, slippage, trackingCode, {
-				from: trader,
-			});
+			await perpsV2Market.submitOffchainDelayedOrderWithTracking(
+				size,
+				priceImpactDelta,
+				trackingCode,
+				{
+					from: trader,
+				}
+			);
 
 			// go to next round
 			await setOnchainPrice(baseAsset, offChainPrice);
@@ -469,7 +474,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				// transfer more margin
 				await perpsV2Market.transferMargin(margin, { from: trader });
 				// and can submit new order
-				await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
+				await perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, { from: trader });
 				const newOrder = await perpsV2MarketState.delayedOrders(trader);
 				assert.bnEqual(newOrder.sizeDelta, size);
 			}
@@ -478,7 +483,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				roundId = await exchangeRates.getCurrentRoundId(baseAsset);
 				spotFee = (await perpsV2Market.orderFee(size))[0];
 				keeperFee = await perpsV2MarketSettings.minKeeperFee();
-				await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
+				await perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, { from: trader });
 			});
 
 			it('cannot cancel before time', async () => {
@@ -663,7 +668,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 					publishTime: (await currentTime()) + feedTimeOffset,
 				});
 
-				await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
+				await perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, { from: trader });
 
 				await fastForward(delay);
 
@@ -1025,7 +1030,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				// transfer more margin
 				await perpsV2Market.transferMargin(margin, { from: trader });
 				// and can submit new order
-				await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
+				await perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, { from: trader });
 				const newOrder = await perpsV2MarketState.delayedOrders(trader);
 				assert.bnEqual(newOrder.sizeDelta, size);
 			}
@@ -1034,7 +1039,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				let targetPrice, targetOffchainPrice, fillPrice, spotTradeDetails, updateFeedData;
 
 				beforeEach(async () => {
-					await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
+					await perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, { from: trader });
 
 					await fastForward(offchainDelayedOrderMinAge + 1);
 
@@ -1095,7 +1100,9 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 						beforeEach(async () => {
 							// skew the other way
 							await perpsV2Market.transferMargin(margin.mul(toBN(2)), { from: trader3 });
-							await perpsV2Market.modifyPosition(size.mul(toBN(-2)), slippage, { from: trader3 });
+							await perpsV2Market.modifyPosition(size.mul(toBN(-2)), priceImpactDelta, {
+								from: trader3,
+							});
 							// go to next round
 							// Get spotTradeDetails with offchain price and back to original price
 							await setOnchainPrice(baseAsset, targetOffchainPrice);
@@ -1165,7 +1172,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				publishTime: await currentTime(),
 			});
 
-			await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
+			await perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, { from: trader });
 
 			await fastForward(offchainDelayedOrderMinAge + 1);
 
@@ -1265,7 +1272,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				await perpsV2Market.transferMargin(toUnit('1000'), { from: trader });
 
 				// submit an order
-				await perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader });
+				await perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, { from: trader });
 
 				// spike the price
 				await setOnchainPrice(baseAsset, spikedPrice);
@@ -1282,7 +1289,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				await perpsV2Market.cancelOffchainDelayedOrder(trader, { from: trader });
 
 				await assert.revert(
-					perpsV2Market.submitOffchainDelayedOrder(size, slippage, { from: trader }),
+					perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, { from: trader }),
 					'Price too volatile'
 				);
 			});

--- a/test/contracts/PerpsV2Market.offchainDelayedOrder.js
+++ b/test/contracts/PerpsV2Market.offchainDelayedOrder.js
@@ -206,7 +206,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			const spotFee = (await perpsV2Market.orderFee(size))[0];
 			const keeperFee = await perpsV2MarketSettings.minKeeperFee();
 
-			const fillPrice = (await perpsV2Market.fillPrice(size))[0];
+			const fillPrice = (await perpsV2Market.fillPriceWithBasePrice(size, 0))[0];
 
 			const tx = await perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, {
 				from: trader,
@@ -373,7 +373,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				publishTime: latestPublishTime,
 			});
 
-			const fillPrice = await perpsV2Market.fillPriceWithBasePrice(size, offChainPrice);
+			const fillPrice = (await perpsV2Market.fillPriceWithBasePrice(size, offChainPrice))[0];
 			const expectedFee = multiplyDecimal(
 				size,
 				multiplyDecimal(fillPrice, takerFeeOffchainDelayedOrder)
@@ -1070,7 +1070,9 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 							//
 							// also, we set it here because this is when both onchain and offchain prices are set. we do _not_
 							// set the commitFee here because commitFee was _before_ the submit and price update.
-							fillPrice = await perpsV2Market.fillPriceWithBasePrice(size, targetOffchainPrice);
+							fillPrice = (
+								await perpsV2Market.fillPriceWithBasePrice(size, targetOffchainPrice)
+							)[0];
 						});
 
 						it('from account owner', async () => {
@@ -1109,7 +1111,9 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 							spotTradeDetails = await perpsV2Market.postTradeDetails(size, toUnit('0'), trader);
 							await setOnchainPrice(baseAsset, targetPrice);
 
-							fillPrice = await perpsV2Market.fillPriceWithBasePrice(size, targetOffchainPrice);
+							fillPrice = (
+								await perpsV2Market.fillPriceWithBasePrice(size, targetOffchainPrice)
+							)[0];
 						});
 
 						it('from account owner', async () => {

--- a/test/contracts/PerpsV2MarketData.js
+++ b/test/contracts/PerpsV2MarketData.js
@@ -36,7 +36,7 @@ contract('PerpsV2MarketData', accounts => {
 	const trader2 = accounts[3];
 	const trader3 = accounts[4];
 	const traderInitialBalance = toUnit(1000000);
-	const slippage = toUnit('0.5'); // 500bps (high bps to avoid affecting unrelated tests)
+	const priceImpactDelta = toUnit('0.5'); // 500bps (high bps to avoid affecting unrelated tests)
 
 	async function setPrice(asset, price, resetCircuitBreaker = true) {
 		await updateAggregatorRates(
@@ -222,19 +222,19 @@ contract('PerpsV2MarketData', accounts => {
 
 		// The traders take positions on market
 		await futuresMarket.transferMargin(toUnit('1000'), { from: trader1 });
-		await futuresMarket.modifyPosition(toUnit('5'), slippage, { from: trader1 });
+		await futuresMarket.modifyPosition(toUnit('5'), priceImpactDelta, { from: trader1 });
 
 		await futuresMarket.transferMargin(toUnit('750'), { from: trader2 });
-		await futuresMarket.modifyPosition(toUnit('-10'), slippage, { from: trader2 });
+		await futuresMarket.modifyPosition(toUnit('-10'), priceImpactDelta, { from: trader2 });
 
 		await setPrice(baseAsset, toUnit('100'));
 		await futuresMarket.transferMargin(toUnit('4000'), { from: trader3 });
-		await futuresMarket.modifyPosition(toUnit('1.25'), slippage, { from: trader3 });
+		await futuresMarket.modifyPosition(toUnit('1.25'), priceImpactDelta, { from: trader3 });
 
 		sethMarket = await PerpsV2Market.at(await futuresMarketManager.marketForKey(newMarketKey));
 
 		await sethMarket.transferMargin(toUnit('3000'), { from: trader3 });
-		await sethMarket.modifyPosition(toUnit('4'), slippage, { from: trader3 });
+		await sethMarket.modifyPosition(toUnit('4'), priceImpactDelta, { from: trader3 });
 		await setPrice(newAssetKey, toUnit('999'));
 	});
 

--- a/test/contracts/PerpsV2MarketManager.js
+++ b/test/contracts/PerpsV2MarketManager.js
@@ -37,7 +37,7 @@ contract('FuturesMarketManager (PerpsV2)', accounts => {
 	const trader = accounts[2];
 	const otherAddress = accounts[3];
 	const initialMint = toUnit('100000');
-	const slippage = toUnit('0.5'); // 500bps (high bps to avoid affecting unrelated tests)
+	const priceImpactDelta = toUnit('0.5'); // 500bps (high bps to avoid affecting unrelated tests)
 
 	async function setPrice(asset, price, resetCircuitBreaker = true) {
 		await updateAggregatorRates(
@@ -785,10 +785,10 @@ contract('FuturesMarketManager (PerpsV2)', accounts => {
 
 			// The traders take positions on market
 			await markets[0].transferMargin(toUnit('1000'), { from: trader });
-			await markets[0].modifyPosition(toUnit('5'), slippage, { from: trader });
+			await markets[0].modifyPosition(toUnit('5'), priceImpactDelta, { from: trader });
 
 			await markets[1].transferMargin(toUnit('3000'), { from: trader });
-			await markets[1].modifyPosition(toUnit('4'), slippage, { from: trader });
+			await markets[1].modifyPosition(toUnit('4'), priceImpactDelta, { from: trader });
 			await setPrice(await markets[1].baseAsset(), toUnit('999'));
 		});
 

--- a/test/integration/behaviors/perpsV2.behavior.js
+++ b/test/integration/behaviors/perpsV2.behavior.js
@@ -182,8 +182,8 @@ function itCanTrade({ ctx }) {
 						//      = 100 * 1.01 * 10 (10x)
 						//      = 1010
 						//
-						// causing a MaxLeverageExceeded error. we lower the multiple by 0.1 to stay within maxLev
-						const size = multiplyDecimal(posSize1x, maxLeverage.sub(toUnit('0.1')));
+						// causing a MaxLeverageExceeded error. we lower the multiple by 0.5 to stay within maxLev
+						const size = multiplyDecimal(posSize1x, maxLeverage.sub(toUnit('0.5')));
 
 						await market.modifyPosition(size, slippage);
 					});

--- a/test/integration/behaviors/perpsV2.behavior.js
+++ b/test/integration/behaviors/perpsV2.behavior.js
@@ -88,7 +88,7 @@ function itCanTrade({ ctx }) {
 
 		describe('position management', () => {
 			let market, assetKey, marketKey, price, balance, posSize1x, debt, slippage;
-			const margin = toUnit('1000');
+			const margin = toUnit('100');
 
 			before('market and conditions', async () => {
 				market = PerpsV2MarketBTC.connect(someUser);
@@ -146,23 +146,46 @@ function itCanTrade({ ctx }) {
 				});
 
 				it('user can modifyPosition to short', async () => {
-					await market.modifyPosition(posSize1x.mul(toBN(-5)), slippage);
+					const size = multiplyDecimal(posSize1x, toUnit('-5'));
+
+					await market.modifyPosition(size, slippage);
 					const position = await market.positions(someUser.address);
-					assert.bnEqual(position.size, posSize1x.mul(toBN(-5))); // right position size
+					assert.bnEqual(position.size, size); // right position size
 
 					// close
 					await market.closePosition(slippage);
 				});
 
 				describe('existing position', () => {
-					before('with max leverage', async () => {
+					before('with slightly under max leverage', async () => {
 						// reset to known margin
 						await market.withdrawAllMargin();
 						await market.transferMargin(margin);
 
 						// lever up
 						const maxLeverage = await PerpsV2MarketSettings.maxLeverage(marketKey);
-						await market.modifyPosition(multiplyDecimal(posSize1x, maxLeverage), slippage);
+
+						// can't use the _full_ max leverage because of slippage. it must be a little below to account
+						// for the premium if this is increasing the skew (which this test case it is).
+						//
+						// maxLeverage = 10x
+						// price       = 1
+						// margin      = 100
+						//
+						// size        = margin * price
+						//             = 100 * 1       (1x) = 100
+						//             = 100 * 1 * 10 (10x) = 1000
+						//
+						// however, opening a position with this will incur a premium of 0.01 (fillPrice = 1.01).
+						//
+						// size = margin * price
+						//      = 100 * 1.01 * 10 (10x)
+						//      = 1010
+						//
+						// causing a MaxLeverageExceeded error. we lower the multiple by 0.1 to stay within maxLev
+						const size = multiplyDecimal(posSize1x, maxLeverage.sub(toUnit('0.1')));
+
+						await market.modifyPosition(size, slippage);
 					});
 
 					before('if new aggregator is set and price drops 20%', async () => {


### PR DESCRIPTION
This PR introduces an additional premium to be paid by the trader when their position is liquidated. The period is _not_ paid to the keeper and given back to the stakers.

There are a few calculations that were changed, namely:

1. Liquidation price
2. Assertion in `canLiquidate`
3. Remaining margin on liquidation during liquidation

The liquidation premium is calculated as follows:

```
abs(size / skewScale) * 0.5
```

The adjustment to the liquidation price just subtracts the premium from their remaining margin:

```
int(position.lastPrice)
    .add(int(liqMargin).sub(int(position.margin).sub(int(liqPremium))).divideDecimal(positionSize))
    .sub(fundingPerUnit);
```

(2) and (3) use `_remainingLiquidatableMargin` to determine margin remaining after subtracting premium.