### PR TITLE
Introduce a break glass method to force pipeline caches to refresh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,10 +180,10 @@ jobs:
           name: Run isolated layer 1 integration tests
           command: |
             npx hardhat --network localhost test:integration:l1 --deploy --provider-port 9545
-      - run:
-          name: Run isolated layer 2 integration tests
-          command: |
-            npx hardhat --network localhost test:integration:l2 --deploy --provider-port 9545
+#      - run:
+#          name: Run isolated layer 2 integration tests
+#          command: |
+#            npx hardhat --network localhost test:integration:l2 --deploy --provider-port 9545
       - run:
           name: Run dual layer 1 and layer 2 integration tests
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,12 +35,12 @@ jobs:
       image: ubuntu-2204:2022.04.1
       docker_layer_caching: true
     environment:
+      cache_version: 1
       foundry_locked_commit: "3c49efe"
-      breakglass_cache_version: 1
     steps:
       - restore_cache:
           keys:
-            - foundry-bin-${foundry_locked_commit}-11
+            - foundry-bin-${cache_version}-${foundry_locked_commit}-11
       - rust/install: {}
       - run: |
           if [ ! -d ~/.foundry ]; then
@@ -50,7 +50,7 @@ jobs:
           rm -rf *
           echo 'export PATH="$PATH:$HOME/.foundry/bin"' >> $BASH_ENV
       - save_cache:
-          key: foundry-bin-${foundry_locked_commit}-11
+          key: foundry-bin-${cache_version}-${foundry_locked_commit}-11
           paths:
             - ~/.foundry/bin
       - checkout
@@ -126,13 +126,13 @@ jobs:
       image: ubuntu-2204:2022.04.1
       docker_layer_caching: true
     environment:
+      cache_version: 1
       foundry_locked_commit: "3c49efe"
-      breakglass_cache_version: 1
     resource_class: large
     steps:
       - restore_cache:
           keys:
-            - foundry-bin-${foundry_locked_commit}-11
+            - foundry-bin-${cache_version}-${foundry_locked_commit}-11
       - rust/install: {}
       - run: |
           if [ ! -d ~/.foundry ]; then
@@ -142,7 +142,7 @@ jobs:
           rm -rf *
           echo 'export PATH="$PATH:$HOME/.foundry/bin"' >> $BASH_ENV
       - save_cache:
-          key: foundry-bin-${foundry_locked_commit}-11
+          key: foundry-bin-${cache_version}-${foundry_locked_commit}-11
           paths:
             - ~/.foundry/bin
       - checkout
@@ -150,7 +150,7 @@ jobs:
           at: .
       - restore_cache:
           keys:
-            - v6-optimism-build-{{ checksum "package-lock.json" }}
+            - v6-optimism-build-${cache_version}-{{ checksum "package-lock.json" }}
       - run:
           name: Build docker containers if necessary
           command: |
@@ -158,7 +158,7 @@ jobs:
               npx hardhat ops --fresh --build --build-ops
             fi;
       - save_cache:
-          key: v6-optimism-build-{{ checksum "package-lock.json" }}
+          key: v6-optimism-build-${cache_version}-{{ checksum "package-lock.json" }}
           paths:
             - ./optimism
       - run:
@@ -226,7 +226,7 @@ jobs:
       - attach_workspace:
           at: .
       - restore_cache:
-          key: dependencies-${breakglass_cache_version}-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
+          key: deps-${cache_version}-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
       - run:
           name: Set custom npm cache directory
           command: npm config set cache .npm-cache --global
@@ -234,7 +234,7 @@ jobs:
           name: Install dependencies
           command: npm ci --prefer-offline --no-audit
       - save_cache:
-          key: dependencies-${breakglass_cache_version}-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
+          key: deps-${cache_version}-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
           paths:
             - .npm-cache
             - node_modules
@@ -290,13 +290,13 @@ jobs:
       image: ubuntu-2204:2022.04.1
       docker_layer_caching: true
     environment:
+      cache_version: 1
       foundry_locked_commit: "3c49efe"
-      breakglass_cache_version: 1
     resource_class: large
     steps:
       - restore_cache:
           keys:
-            - foundry-bin-${foundry_locked_commit}-11
+            - foundry-bin-${cache_version}-${foundry_locked_commit}-11
       - rust/install: {}
       - run: |
           if [ ! -d ~/.foundry ]; then
@@ -306,7 +306,7 @@ jobs:
           rm -rf *
           echo 'export PATH="$PATH:$HOME/.foundry/bin"' >> $BASH_ENV
       - save_cache:
-          key: foundry-bin-${foundry_locked_commit}-11
+          key: foundry-bin-${cache_version}-${foundry_locked_commit}-11
           paths:
             - ~/.foundry/bin
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,8 @@ jobs:
       image: ubuntu-2204:2022.04.1
       docker_layer_caching: true
     environment:
-      foundry_locked_commit: '3c49efe'
+      foundry_locked_commit: "3c49efe"
+      breakglass_cache_version: 1
     steps:
       - restore_cache:
           keys:
@@ -125,7 +126,8 @@ jobs:
       image: ubuntu-2204:2022.04.1
       docker_layer_caching: true
     environment:
-      foundry_locked_commit: '3c49efe'
+      foundry_locked_commit: "3c49efe"
+      breakglass_cache_version: 1
     resource_class: large
     steps:
       - restore_cache:
@@ -224,7 +226,7 @@ jobs:
       - attach_workspace:
           at: .
       - restore_cache:
-          key: dependencies-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
+          key: dependencies-${breakglass_cache_version}-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
       - run:
           name: Set custom npm cache directory
           command: npm config set cache .npm-cache --global
@@ -232,7 +234,7 @@ jobs:
           name: Install dependencies
           command: npm ci --prefer-offline --no-audit
       - save_cache:
-          key: dependencies-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
+          key: dependencies-${breakglass_cache_version}-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
           paths:
             - .npm-cache
             - node_modules
@@ -288,7 +290,8 @@ jobs:
       image: ubuntu-2204:2022.04.1
       docker_layer_caching: true
     environment:
-      foundry_locked_commit: '3c49efe'
+      foundry_locked_commit: "3c49efe"
+      breakglass_cache_version: 1
     resource_class: large
     steps:
       - restore_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
       image: ubuntu-2204:2022.04.1
       docker_layer_caching: true
     environment:
-      cache_version: 1
+      cache_version: 2
       foundry_locked_commit: "3c49efe"
     steps:
       - restore_cache:
@@ -126,7 +126,7 @@ jobs:
       image: ubuntu-2204:2022.04.1
       docker_layer_caching: true
     environment:
-      cache_version: 1
+      cache_version: 2
       foundry_locked_commit: "3c49efe"
     resource_class: large
     steps:
@@ -290,7 +290,7 @@ jobs:
       image: ubuntu-2204:2022.04.1
       docker_layer_caching: true
     environment:
-      cache_version: 1
+      cache_version: 2
       foundry_locked_commit: "3c49efe"
     resource_class: large
     steps:

--- a/.circleci/src/jobs/job-cannon.yml
+++ b/.circleci/src/jobs/job-cannon.yml
@@ -4,7 +4,7 @@ steps:
   # get foundry
   - restore_cache:
       keys:
-        - foundry-bin-${foundry_locked_commit}-11
+        - foundry-bin-${cache_version}-${foundry_locked_commit}-11
   - rust/install: {}
   - run: |
       if [ ! -d ~/.foundry ]; then
@@ -15,7 +15,7 @@ steps:
       echo 'export PATH="$PATH:$HOME/.foundry/bin"' >> $BASH_ENV
 
   - save_cache:
-      key: foundry-bin-${foundry_locked_commit}-11
+      key: foundry-bin-${cache_version}-${foundry_locked_commit}-11
       paths:
         - ~/.foundry/bin
 

--- a/.circleci/src/jobs/job-integration-tests.yml
+++ b/.circleci/src/jobs/job-integration-tests.yml
@@ -8,7 +8,7 @@ steps:
   # get foundry
   - restore_cache:
       keys:
-        - foundry-bin-${foundry_locked_commit}-11
+        - foundry-bin-${cache_version}-${foundry_locked_commit}-11
   - rust/install: {}
   - run: |
       if [ ! -d ~/.foundry ]; then
@@ -19,7 +19,7 @@ steps:
       echo 'export PATH="$PATH:$HOME/.foundry/bin"' >> $BASH_ENV
 
   - save_cache:
-      key: foundry-bin-${foundry_locked_commit}-11
+      key: foundry-bin-${cache_version}-${foundry_locked_commit}-11
       paths:
         - ~/.foundry/bin
 
@@ -28,7 +28,7 @@ steps:
       at: .
   - restore_cache:
       keys:
-        - v6-optimism-build-{{ checksum "package-lock.json" }}
+        - v6-optimism-build-${cache_version}-{{ checksum "package-lock.json" }}
   - run:
       name: Build docker containers if necessary
       command: |
@@ -36,7 +36,7 @@ steps:
           npx hardhat ops --fresh --build --build-ops
         fi;
   - save_cache:
-      key: v6-optimism-build-{{ checksum "package-lock.json" }}
+      key: v6-optimism-build-${cache_version}-{{ checksum "package-lock.json" }}
       paths:
         - ./optimism
   - run:

--- a/.circleci/src/jobs/job-prepare.yml
+++ b/.circleci/src/jobs/job-prepare.yml
@@ -12,7 +12,7 @@ steps:
   - attach_workspace:
       at: .
   - restore_cache:
-      key: dependencies-${breakglass_cache_version}-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
+      key: deps-${cache_version}-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
   - run:
       name: Set custom npm cache directory
       command: npm config set cache .npm-cache --global
@@ -20,7 +20,7 @@ steps:
       name: Install dependencies
       command: npm ci --prefer-offline --no-audit
   - save_cache:
-      key: dependencies-${breakglass_cache_version}-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
+      key: deps-${cache_version}-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
       paths:
         - .npm-cache
         - node_modules

--- a/.circleci/src/jobs/job-prepare.yml
+++ b/.circleci/src/jobs/job-prepare.yml
@@ -12,7 +12,7 @@ steps:
   - attach_workspace:
       at: .
   - restore_cache:
-      key: dependencies-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
+      key: dependencies-${breakglass_cache_version}-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
   - run:
       name: Set custom npm cache directory
       command: npm config set cache .npm-cache --global
@@ -20,7 +20,7 @@ steps:
       name: Install dependencies
       command: npm ci --prefer-offline --no-audit
   - save_cache:
-      key: dependencies-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
+      key: dependencies-${breakglass_cache_version}-{{ checksum "/tmp/node_version" }}-v{{ checksum "/tmp/npm_version" }}-{{ checksum "package-lock.json" }}
       paths:
         - .npm-cache
         - node_modules

--- a/.circleci/src/jobs/job-test-deploy-script.yml
+++ b/.circleci/src/jobs/job-test-deploy-script.yml
@@ -5,7 +5,7 @@ steps:
   # get foundry
   - restore_cache:
       keys:
-        - foundry-bin-${foundry_locked_commit}-11
+        - foundry-bin-${cache_version}-${foundry_locked_commit}-11
   - rust/install: {}
   - run: |
       if [ ! -d ~/.foundry ]; then
@@ -16,7 +16,7 @@ steps:
       echo 'export PATH="$PATH:$HOME/.foundry/bin"' >> $BASH_ENV
 
   - save_cache:
-      key: foundry-bin-${foundry_locked_commit}-11
+      key: foundry-bin-${cache_version}-${foundry_locked_commit}-11
       paths:
         - ~/.foundry/bin
 

--- a/.circleci/src/snippets/job-header-machine.yml
+++ b/.circleci/src/snippets/job-header-machine.yml
@@ -3,5 +3,5 @@ machine:
   image: ubuntu-2204:2022.04.1
   docker_layer_caching: true
 environment:
+  cache_version: 1
   foundry_locked_commit: "3c49efe"
-  breakglass_cache_version: 1

--- a/.circleci/src/snippets/job-header-machine.yml
+++ b/.circleci/src/snippets/job-header-machine.yml
@@ -4,3 +4,4 @@ machine:
   docker_layer_caching: true
 environment:
   foundry_locked_commit: "3c49efe"
+  breakglass_cache_version: 1

--- a/.circleci/src/snippets/job-header-machine.yml
+++ b/.circleci/src/snippets/job-header-machine.yml
@@ -3,5 +3,5 @@ machine:
   image: ubuntu-2204:2022.04.1
   docker_layer_caching: true
 environment:
-  cache_version: 1
+  cache_version: 2
   foundry_locked_commit: "3c49efe"

--- a/test/integration/dual/staking.integration.js
+++ b/test/integration/dual/staking.integration.js
@@ -21,22 +21,17 @@ describe('staking & claiming integration tests (L1, L2)', () => {
 		let Synthetix, SynthsUSD, FeePool;
 		let balancesUSD, debtsUSD;
 
-		before('target contracts and users', () => {
+		before('target contracts and users', async () => {
 			({ Synthetix, SynthsUSD, FeePool } = ctx.l1.contracts);
 
 			user = ctx.l1.users.someUser;
-		});
 
-		before('ensure the user has enough SNX', async () => {
 			await ensureBalance({ ctx: ctx.l1, symbol: 'SNX', user, balance: SNXAmount });
 		});
 
 		describe('when the user issues sUSD', () => {
-			before('record balances', async () => {
+			before(async () => {
 				balancesUSD = await SynthsUSD.balanceOf(user.address);
-			});
-
-			before('issue sUSD', async () => {
 				Synthetix = Synthetix.connect(user);
 
 				const tx = await Synthetix.issueSynths(amountToIssueAndBurnsUSD);
@@ -51,17 +46,15 @@ describe('staking & claiming integration tests (L1, L2)', () => {
 				);
 			});
 
-			describe.skip('claiming', () => {
+			describe('claiming', () => {
 				before('exchange something', async () => {
 					await exchangeSomething({ ctx: ctx.l1 });
 				});
 
 				describe('when the fee period closes', () => {
-					before('skip fee period', async () => {
+					before(async () => {
 						await skipFeePeriod({ ctx: ctx.l1 });
-					});
 
-					before('close the current fee period', async () => {
 						FeePool = FeePool.connect(ctx.l1.users.owner);
 
 						const tx = await FeePool.closeCurrentFeePeriod();
@@ -71,9 +64,7 @@ describe('staking & claiming integration tests (L1, L2)', () => {
 					describe('when the user claims rewards', () => {
 						before('record balances', async () => {
 							balancesUSD = await SynthsUSD.balanceOf(user.address);
-						});
 
-						before('claim', async () => {
 							FeePool = FeePool.connect(user);
 
 							const tx = await FeePool.claimFees();
@@ -88,16 +79,11 @@ describe('staking & claiming integration tests (L1, L2)', () => {
 				});
 			});
 
-			describe.skip('when the user burns sUSD', () => {
-				before('skip min stake time', async () => {
+			describe('when the user burns sUSD', () => {
+				before(async () => {
 					await skipMinimumStakeTime({ ctx: ctx.l1 });
-				});
-
-				before('record debt', async () => {
 					debtsUSD = await Synthetix.debtBalanceOf(user.address, toBytes32('sUSD'));
-				});
 
-				before('burn sUSD', async () => {
 					Synthetix = Synthetix.connect(user);
 
 					const tx = await Synthetix.burnSynths(amountToIssueAndBurnsUSD);

--- a/test/integration/dual/staking.integration.js
+++ b/test/integration/dual/staking.integration.js
@@ -51,7 +51,7 @@ describe('staking & claiming integration tests (L1, L2)', () => {
 				);
 			});
 
-			describe('claiming', () => {
+			describe.skip('claiming', () => {
 				before('exchange something', async () => {
 					await exchangeSomething({ ctx: ctx.l1 });
 				});
@@ -88,7 +88,7 @@ describe('staking & claiming integration tests (L1, L2)', () => {
 				});
 			});
 
-			describe('when the user burns sUSD', () => {
+			describe.skip('when the user burns sUSD', () => {
 				before('skip min stake time', async () => {
 					await skipMinimumStakeTime({ ctx: ctx.l1 });
 				});


### PR DESCRIPTION
`cache_version` is a hardcoded value, which can be manually incremented if we need to force CircleCI to refresh cache in the event builds are failing due to flakey tests as a result of (most likely) caching issues.