### PR TITLE
Fix/improvements feedback

### DIFF
--- a/contracts/PerpsV2Market.sol
+++ b/contracts/PerpsV2Market.sol
@@ -247,8 +247,11 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
     ) internal {
         Position memory position = marketState.positions(account);
 
-        // get remaining margin for sending any leftover buffer to fee pool
-        uint remMargin = _remainingLiquidatableMargin(position, price);
+        // Get remaining margin for sending any leftover buffer to fee pool
+        //
+        // note: we do _not_ use `_remainingLiquidatableMargin` here as we want to send this premium to the fee pool
+        // upon liquidation to give back to stakers.
+        uint remMargin = _remainingMargin(position, price);
 
         // Record updates to market size and debt.
         int positionSize = position.size;

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -648,16 +648,24 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
     function _maxPriceImpact(
         uint price,
         uint priceImpactDelta,
+        int sizeDelta,
         uint orderFee
     ) internal pure returns (uint) {
+        uint priceImpactUsd;
+
         // No priceImpactDelta is specified, use the orderFee for the upper bound.
         //
         // note: We look at orderFee (not maker/taker fee) because orderFee considers the case when a
         // trade with large enough size can flip the skew.
         if (priceImpactDelta == 0) {
-            return price.add(orderFee);
+            priceImpactUsd = orderFee;
+        } else {
+            priceImpactUsd = price.multiplyDecimal(priceImpactDelta);
         }
-        return price.multiplyDecimal(uint(_UNIT).add(priceImpactDelta));
+
+        // A lower price would be less desirable for shorts and a higher price is less desirable for longs. As such
+        // we derive the maxPriceImpact based on whether the position is going long/short.
+        return sizeDelta > 0 ? price.add(priceImpactUsd) : price.sub(priceImpactDelta);
     }
 
     /*

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -582,7 +582,7 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
 
     /*
      * @dev SIP-279 fillPrice price at which a trade is executed against accounting for how this position's
-     * size impacts the skew. If the size contracts the skew (reduces) then a discount is apply on the price
+     * size impacts the skew. If the size contracts the skew (reduces) then a discount is applied on the price
      * whereas expanding the skew incurs an additional premium.
      */
     function _fillPrice(int size, uint price) internal view returns (uint) {

--- a/contracts/PerpsV2MarketProxyable.sol
+++ b/contracts/PerpsV2MarketProxyable.sol
@@ -100,15 +100,14 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
         uint price,
         uint fillPrice,
         uint priceImpactDelta,
-        int sizeDelta,
-        uint orderFee
+        int sizeDelta
     ) internal view returns (uint) {
-        uint maxPriceImpact = _maxPriceImpact(price, priceImpactDelta, sizeDelta, orderFee);
+        uint priceImpactLimit = _priceImpactLimit(price, priceImpactDelta, sizeDelta);
         _revertIfError(
-            sizeDelta > 0 ? fillPrice > maxPriceImpact : fillPrice < maxPriceImpact,
+            sizeDelta > 0 ? fillPrice > priceImpactLimit : fillPrice < priceImpactLimit,
             Status.PriceImpactToleranceExceeded
         );
-        return maxPriceImpact;
+        return priceImpactLimit;
     }
 
     function _recomputeFunding() internal returns (uint lastIndex) {
@@ -197,7 +196,7 @@ contract PerpsV2MarketProxyable is PerpsV2MarketBase, Proxyable {
         (Position memory newPosition, uint fee, Status status) = _postTradeDetails(oldPosition, params);
         _revertIfError(status);
 
-        _assertPriceImpact(price, params.price, params.priceImpactDelta, params.sizeDelta, fee);
+        _assertPriceImpact(price, params.price, params.priceImpactDelta, params.sizeDelta);
 
         // Update the aggregated market size and skew with the new order size
         marketState.setMarketSkew(int128(int(marketState.marketSkew()).add(newPosition.size).sub(oldPosition.size)));

--- a/contracts/test-helpers/TestablePerpsV2Market.sol
+++ b/contracts/test-helpers/TestablePerpsV2Market.sol
@@ -167,11 +167,6 @@ contract TestablePerpsV2Market is PerpsV2Market, IPerpsV2MarketViews, IPerpsV2Ma
         return (0, false);
     }
 
-    function liquidationPremium(address account) external view returns (uint) {
-        (uint price, ) = _assetPrice();
-        return _liquidationPremium(marketState.positions(account).size, price);
-    }
-
     function liquidationFee(address account) external view returns (uint) {
         return 0;
     }

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -4183,6 +4183,7 @@ contract('PerpsV2Market', accounts => {
 	describe('Liquidations', () => {
 		describe('Liquidation price', () => {
 			const getExpectedLiquidationPrice = async ({
+				skewScale,
 				margin,
 				size,
 				fillPrice,
@@ -4217,7 +4218,10 @@ contract('PerpsV2Market', accounts => {
 					liqBufferRatio
 				).add(expectedLiquidationFee);
 
-				const premium = await futuresMarket.liquidationPremium(account);
+				const premium = divideDecimal(
+					multiplyDecimal(divideDecimal(size.abs(), skewScale), price),
+					toUnit('2')
+				);
 				return fillPrice
 					.add(divideDecimal(expectedLiquidationMargin.sub(margin.sub(fee).sub(premium)), size))
 					.sub(expectedNetFundingPerUnit);
@@ -4242,6 +4246,7 @@ contract('PerpsV2Market', accounts => {
 				await futuresMarket.modifyPosition(size2, priceImpactDelta, { from: trader2 });
 
 				const expectedLiquidationPrice1 = await getExpectedLiquidationPrice({
+					skewScale,
 					margin: margin1,
 					size: size1,
 					fillPrice: fillPrice1,
@@ -4256,6 +4261,7 @@ contract('PerpsV2Market', accounts => {
 				assert.isFalse(liquidationPrice1.invalid);
 
 				const expectedLiquidationPrice2 = await getExpectedLiquidationPrice({
+					skewScale,
 					margin: margin2,
 					size: size2,
 					fillPrice: fillPrice2,
@@ -4291,6 +4297,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(
 					(await futuresMarket.liquidationPrice(trader)).price,
 					await getExpectedLiquidationPrice({
+						skewScale,
 						margin: margin1,
 						size: size1,
 						fillPrice: fillPrice1,
@@ -4302,6 +4309,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(
 					(await futuresMarket.liquidationPrice(trader2)).price,
 					await getExpectedLiquidationPrice({
+						skewScale,
 						margin: margin2,
 						size: size2,
 						fillPrice: fillPrice2,
@@ -4318,6 +4326,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(
 					(await futuresMarket.liquidationPrice(trader)).price,
 					await getExpectedLiquidationPrice({
+						skewScale,
 						margin: margin1,
 						size: size1,
 						fillPrice: fillPrice1,
@@ -4330,6 +4339,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(
 					(await futuresMarket.liquidationPrice(trader2)).price,
 					await getExpectedLiquidationPrice({
+						skewScale,
 						margin: margin2,
 						size: size2,
 						fillPrice: fillPrice2,
@@ -4348,6 +4358,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(
 					(await futuresMarket.liquidationPrice(trader)).price,
 					await getExpectedLiquidationPrice({
+						skewScale,
 						margin: margin1,
 						size: size1,
 						fillPrice: fillPrice1,
@@ -4361,6 +4372,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(
 					(await futuresMarket.liquidationPrice(trader2)).price,
 					await getExpectedLiquidationPrice({
+						skewScale,
 						margin: margin2,
 						size: size2,
 						fillPrice: fillPrice2,
@@ -4380,6 +4392,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(
 					(await futuresMarket.liquidationPrice(trader)).price,
 					await getExpectedLiquidationPrice({
+						skewScale,
 						margin: margin1,
 						size: size1,
 						fillPrice: fillPrice1,
@@ -4394,6 +4407,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(
 					(await futuresMarket.liquidationPrice(trader2)).price,
 					await getExpectedLiquidationPrice({
+						skewScale,
 						margin: margin2,
 						size: size2,
 						fillPrice: fillPrice2,
@@ -4415,6 +4429,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(
 					(await futuresMarket.liquidationPrice(trader)).price,
 					await getExpectedLiquidationPrice({
+						skewScale,
 						margin: margin1,
 						size: size1,
 						fillPrice: fillPrice1,
@@ -4429,6 +4444,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(
 					(await futuresMarket.liquidationPrice(trader2)).price,
 					await getExpectedLiquidationPrice({
+						skewScale,
 						margin: margin2,
 						size: size2,
 						fillPrice: fillPrice2,
@@ -4443,7 +4459,8 @@ contract('PerpsV2Market', accounts => {
 			});
 
 			it('Liquidation price is accurate with funding (ff 1 day)', async () => {
-				await futuresMarketSettings.setSkewScale(marketKey, toUnit('1000'), { from: owner });
+				const skewScale = toUnit('1000');
+				await futuresMarketSettings.setSkewScale(marketKey, skewScale, { from: owner });
 
 				const price = toUnit('250');
 				await setPrice(baseAsset, price);
@@ -4476,6 +4493,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(
 					(await futuresMarket.liquidationPrice(trader)).price,
 					await getExpectedLiquidationPrice({
+						skewScale,
 						margin: margin1,
 						size: size1,
 						fillPrice: fillPrice1,
@@ -4487,6 +4505,7 @@ contract('PerpsV2Market', accounts => {
 				assert.bnEqual(
 					(await futuresMarket.liquidationPrice(trader2)).price,
 					await getExpectedLiquidationPrice({
+						skewScale,
 						margin: margin2,
 						size: size2,
 						fillPrice: fillPrice2,

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -4719,7 +4719,6 @@ contract('PerpsV2Market', accounts => {
 				assert.isTrue(await futuresMarket.canLiquidate(trader));
 
 				const remainingMargin = (await futuresMarket.remainingMargin(trader)).marginRemaining;
-				const premium = await futuresMarket.liquidationPremium(trader);
 				const tx = await futuresMarket.liquidatePosition(trader, { from: noBalance });
 
 				const liquidationFee = multiplyDecimal(
@@ -4735,7 +4734,7 @@ contract('PerpsV2Market', accounts => {
 				);
 				assert.equal(decodedLogs.length, 5); // additional sUSD issue event
 
-				const poolFee = remainingMargin.sub(liquidationFee).sub(premium);
+				const poolFee = remainingMargin.sub(liquidationFee);
 				// the price needs to be set in a way that leaves positive margin after fee
 				assert.isTrue(poolFee.gt(toBN(0)));
 
@@ -4823,7 +4822,6 @@ contract('PerpsV2Market', accounts => {
 				assert.isTrue(await futuresMarket.canLiquidate(trader3));
 
 				const remainingMargin = (await futuresMarket.remainingMargin(trader3)).marginRemaining;
-				const premium = await futuresMarket.liquidationPremium(trader3);
 				const tx = await futuresMarket.liquidatePosition(trader3, { from: noBalance });
 
 				const liquidationFee = multiplyDecimal(
@@ -4839,7 +4837,7 @@ contract('PerpsV2Market', accounts => {
 				);
 				assert.equal(decodedLogs.length, 5); // additional sUSD issue event
 
-				const poolFee = remainingMargin.sub(liquidationFee).sub(premium);
+				const poolFee = remainingMargin.sub(liquidationFee);
 				// the price needs to be set in a way that leaves positive margin after fee
 				assert.isTrue(poolFee.gt(toBN(0)));
 


### PR DESCRIPTION
A couple things in this PR:

1. Fixes a bug `_liquidatePosition`, ensuring we always pass the premium made on the liquidation to the fee pool
2. Updates the price impact calculation to be side aware (applying a min/max depending if you're short/long respectively)
3. No longer defaults the min/max price impact to maker/taker fees. Instead, trades _must_ be explicit with the price impact delta (on bps)
4. Finally, comments and more unit tests for coverage (more to be added later)