### PR TITLE
PerpsV2: Add helper interface and contract

### DIFF
--- a/contracts/interfaces/IPerpsV2MarketConsolidated.sol
+++ b/contracts/interfaces/IPerpsV2MarketConsolidated.sol
@@ -1,0 +1,166 @@
+pragma solidity ^0.5.16;
+pragma experimental ABIEncoderV2;
+
+// Helper Interface, only used in tests and to provide a consolidated interface to PerpsV2 users/integrators
+
+interface IPerpsV2MarketConsolidated {
+    /* ========== TYPES ========== */
+    enum Status {
+        Ok,
+        InvalidPrice,
+        PriceOutOfBounds,
+        CanLiquidate,
+        CannotLiquidate,
+        MaxMarketSizeExceeded,
+        MaxLeverageExceeded,
+        InsufficientMargin,
+        NotPermitted,
+        NilOrder,
+        NoPositionOpen,
+        PriceTooVolatile,
+        PriceImpactToleranceExceeded
+    }
+
+    // If margin/size are positive, the position is long; if negative then it is short.
+    struct Position {
+        uint64 id;
+        uint64 lastFundingIndex;
+        uint128 margin;
+        uint128 lastPrice;
+        int128 size;
+    }
+
+    // Delayed order storage
+    struct DelayedOrder {
+        bool isOffchain; // flag indicating the delayed order is offchain
+        int128 sizeDelta; // difference in position to pass to modifyPosition
+        uint128 priceImpactDelta; // price impact tolerance as a percentage used on fillPrice at execution
+        uint128 targetRoundId; // price oracle roundId using which price this order needs to executed
+        uint128 commitDeposit; // the commitDeposit paid upon submitting that needs to be refunded if order succeeds
+        uint128 keeperDeposit; // the keeperDeposit paid upon submitting that needs to be paid / refunded on tx confirmation
+        uint256 executableAtTime; // The timestamp at which this order is executable at
+        uint256 intentionTime; // The block timestamp of submission
+        bytes32 trackingCode; // tracking code to emit on execution for volume source fee sharing
+    }
+
+    /* ========== Views ========== */
+    /* ---------- Market Details ---------- */
+
+    function marketKey() external view returns (bytes32 key);
+
+    function baseAsset() external view returns (bytes32 key);
+
+    function marketSize() external view returns (uint128 size);
+
+    function marketSkew() external view returns (int128 skew);
+
+    function fundingLastRecomputed() external view returns (uint32 timestamp);
+
+    function fundingSequence(uint index) external view returns (int128 netFunding);
+
+    function positions(address account) external view returns (Position memory);
+
+    function delayedOrders(address account) external view returns (DelayedOrder memory);
+
+    function assetPrice() external view returns (uint price, bool invalid);
+
+    function marketSizes() external view returns (uint long, uint short);
+
+    function marketDebt() external view returns (uint debt, bool isInvalid);
+
+    function currentFundingRate() external view returns (int fundingRate);
+
+    function currentFundingVelocity() external view returns (int fundingRateVelocity);
+
+    function unrecordedFunding() external view returns (int funding, bool invalid);
+
+    function fundingSequenceLength() external view returns (uint length);
+
+    /* ---------- Position Details ---------- */
+
+    function notionalValue(address account) external view returns (int value, bool invalid);
+
+    function profitLoss(address account) external view returns (int pnl, bool invalid);
+
+    function accruedFunding(address account) external view returns (int funding, bool invalid);
+
+    function remainingMargin(address account) external view returns (uint marginRemaining, bool invalid);
+
+    function accessibleMargin(address account) external view returns (uint marginAccessible, bool invalid);
+
+    function liquidationPrice(address account) external view returns (uint price, bool invalid);
+
+    function liquidationFee(address account) external view returns (uint);
+
+    function canLiquidate(address account) external view returns (bool);
+
+    function orderFee(int sizeDelta) external view returns (uint fee, bool invalid);
+
+    function postTradeDetails(
+        int sizeDelta,
+        uint tradePrice,
+        address sender
+    )
+        external
+        view
+        returns (
+            uint margin,
+            int size,
+            uint price,
+            uint liqPrice,
+            uint fee,
+            Status status
+        );
+
+    /* ========== Market ========== */
+    function recomputeFunding() external returns (uint lastIndex);
+
+    function transferMargin(int marginDelta) external;
+
+    function withdrawAllMargin() external;
+
+    function modifyPosition(int sizeDelta, uint priceImpactDelta) external;
+
+    function modifyPositionWithTracking(
+        int sizeDelta,
+        uint priceImpactDelta,
+        bytes32 trackingCode
+    ) external;
+
+    function closePosition(uint priceImpactDelta) external;
+
+    function closePositionWithTracking(uint priceImpactDelta, bytes32 trackingCode) external;
+
+    function liquidatePosition(address account) external;
+
+    /* ========== DelayedOrder ========== */
+    function submitDelayedOrder(
+        int sizeDelta,
+        uint priceImpactDelta,
+        uint desiredTimeDelta
+    ) external;
+
+    function submitDelayedOrderWithTracking(
+        int sizeDelta,
+        uint priceImpactDelta,
+        uint desiredTimeDelta,
+        bytes32 trackingCode
+    ) external;
+
+    function cancelDelayedOrder(address account) external;
+
+    function executeDelayedOrder(address account) external;
+
+    /* ========== OffchainDelayedOrder ========== */
+    function submitOffchainDelayedOrder(int sizeDelta, uint priceImpactDelta) external;
+
+    function submitOffchainDelayedOrderWithTracking(
+        int sizeDelta,
+        uint priceImpactDelta,
+        bytes32 trackingCode
+    ) external;
+
+    function cancelOffchainDelayedOrder(address account) external;
+
+    function executeOffchainDelayedOrder(address account, bytes[] calldata priceUpdateData) external payable;
+}

--- a/contracts/interfaces/IPerpsV2MarketConsolidated.sol
+++ b/contracts/interfaces/IPerpsV2MarketConsolidated.sol
@@ -163,4 +163,46 @@ interface IPerpsV2MarketConsolidated {
     function cancelOffchainDelayedOrder(address account) external;
 
     function executeOffchainDelayedOrder(address account, bytes[] calldata priceUpdateData) external payable;
+
+    /* ========== Events ========== */
+
+    event PositionModified(
+        uint indexed id,
+        address indexed account,
+        uint margin,
+        int size,
+        int tradeSize,
+        uint lastPrice,
+        uint fundingIndex,
+        uint fee
+    );
+
+    event MarginTransferred(address indexed account, int marginDelta);
+
+    event PositionLiquidated(uint id, address account, address liquidator, int size, uint price, uint fee);
+
+    event FundingRecomputed(int funding, int fundingRate, uint index, uint timestamp);
+
+    event FuturesTracking(bytes32 indexed trackingCode, bytes32 baseAsset, bytes32 marketKey, int sizeDelta, uint fee);
+
+    event DelayedOrderRemoved(
+        address indexed account,
+        uint currentRoundId,
+        int sizeDelta,
+        uint targetRoundId,
+        uint commitDeposit,
+        uint keeperDeposit,
+        bytes32 trackingCode
+    );
+
+    event DelayedOrderSubmitted(
+        address indexed account,
+        bool isOffchain,
+        int sizeDelta,
+        uint targetRoundId,
+        uint executableAtTime,
+        uint commitDeposit,
+        uint keeperDeposit,
+        bytes32 trackingCode
+    );
 }

--- a/contracts/test-helpers/TestablePerpsV2MarketEmpty.sol
+++ b/contracts/test-helpers/TestablePerpsV2MarketEmpty.sol
@@ -1,0 +1,233 @@
+pragma solidity ^0.5.16;
+pragma experimental ABIEncoderV2;
+
+import "../interfaces/IPerpsV2MarketConsolidated.sol";
+
+// Helper Contract, only used in tests and to provide a consolidated interface to PerpsV2 users/integrators
+
+contract TestablePerpsV2MarketEmpty is IPerpsV2MarketConsolidated {
+    function marketKey() external view returns (bytes32 key) {
+        return "";
+    }
+
+    function baseAsset() external view returns (bytes32 key) {
+        return "";
+    }
+
+    function marketSize() external view returns (uint128 size) {
+        return 0;
+    }
+
+    function marketSkew() external view returns (int128 skew) {
+        return 0;
+    }
+
+    function fundingLastRecomputed() external view returns (uint32 timestamp) {
+        return 0;
+    }
+
+    function fundingSequence(uint index) external view returns (int128 netFunding) {
+        index;
+        return 0;
+    }
+
+    function positions(address account) external view returns (Position memory) {
+        account;
+        return Position(0, 0, 0, 0, 0);
+    }
+
+    function delayedOrders(address account) external view returns (DelayedOrder memory) {
+        account;
+        return DelayedOrder(false, 0, 0, 0, 0, 0, 0, 0, "");
+    }
+
+    function assetPrice() external view returns (uint price, bool invalid) {
+        return (0, false);
+    }
+
+    function marketSizes() external view returns (uint long, uint short) {
+        return (0, 0);
+    }
+
+    function marketDebt() external view returns (uint debt, bool isInvalid) {
+        return (0, false);
+    }
+
+    function currentFundingRate() external view returns (int fundingRate) {
+        return 0;
+    }
+
+    function currentFundingVelocity() external view returns (int fundingRateVelocity) {
+        return 0;
+    }
+
+    function unrecordedFunding() external view returns (int funding, bool invalid) {
+        return (0, false);
+    }
+
+    function fundingSequenceLength() external view returns (uint length) {
+        return 0;
+    }
+
+    /* ---------- Position Details ---------- */
+
+    function notionalValue(address account) external view returns (int value, bool invalid) {
+        account;
+        return (0, false);
+    }
+
+    function profitLoss(address account) external view returns (int pnl, bool invalid) {
+        account;
+        return (0, false);
+    }
+
+    function accruedFunding(address account) external view returns (int funding, bool invalid) {
+        account;
+        return (0, false);
+    }
+
+    function remainingMargin(address account) external view returns (uint marginRemaining, bool invalid) {
+        account;
+        return (0, false);
+    }
+
+    function accessibleMargin(address account) external view returns (uint marginAccessible, bool invalid) {
+        account;
+        return (0, false);
+    }
+
+    function liquidationPrice(address account) external view returns (uint price, bool invalid) {
+        account;
+        return (0, false);
+    }
+
+    function liquidationFee(address account) external view returns (uint) {
+        account;
+        return 0;
+    }
+
+    function canLiquidate(address account) external view returns (bool) {
+        account;
+        return false;
+    }
+
+    function orderFee(int sizeDelta) external view returns (uint fee, bool invalid) {
+        sizeDelta;
+        return (0, false);
+    }
+
+    function postTradeDetails(
+        int sizeDelta,
+        uint tradePrice,
+        address sender
+    )
+        external
+        view
+        returns (
+            uint margin,
+            int size,
+            uint price,
+            uint liqPrice,
+            uint fee,
+            Status status
+        )
+    {
+        sizeDelta;
+        tradePrice;
+        sender;
+        return (0, 0, 0, 0, 0, Status.Ok);
+    }
+
+    /* ========== Market ========== */
+    function recomputeFunding() external returns (uint lastIndex) {
+        return 0;
+    }
+
+    function transferMargin(int marginDelta) external {
+        marginDelta;
+    }
+
+    function withdrawAllMargin() external {}
+
+    function modifyPosition(int sizeDelta, uint priceImpactDelta) external {
+        sizeDelta;
+        priceImpactDelta;
+    }
+
+    function modifyPositionWithTracking(
+        int sizeDelta,
+        uint priceImpactDelta,
+        bytes32 trackingCode
+    ) external {
+        sizeDelta;
+        priceImpactDelta;
+        trackingCode;
+    }
+
+    function closePosition(uint priceImpactDelta) external {
+        priceImpactDelta;
+    }
+
+    function closePositionWithTracking(uint priceImpactDelta, bytes32 trackingCode) external {
+        priceImpactDelta;
+        trackingCode;
+    }
+
+    function liquidatePosition(address account) external {}
+
+    /* ========== DelayedOrder ========== */
+    function submitDelayedOrder(
+        int sizeDelta,
+        uint priceImpactDelta,
+        uint desiredTimeDelta
+    ) external {
+        sizeDelta;
+        priceImpactDelta;
+        desiredTimeDelta;
+    }
+
+    function submitDelayedOrderWithTracking(
+        int sizeDelta,
+        uint priceImpactDelta,
+        uint desiredTimeDelta,
+        bytes32 trackingCode
+    ) external {
+        sizeDelta;
+        priceImpactDelta;
+        desiredTimeDelta;
+        trackingCode;
+    }
+
+    function cancelDelayedOrder(address account) external {
+        account;
+    }
+
+    function executeDelayedOrder(address account) external {
+        account;
+    }
+
+    /* ========== OffchainDelayedOrder ========== */
+    function submitOffchainDelayedOrder(int sizeDelta, uint priceImpactDelta) external {
+        sizeDelta;
+        priceImpactDelta;
+    }
+
+    function submitOffchainDelayedOrderWithTracking(
+        int sizeDelta,
+        uint priceImpactDelta,
+        bytes32 trackingCode
+    ) external {
+        sizeDelta;
+        priceImpactDelta;
+        trackingCode;
+    }
+
+    function cancelOffchainDelayedOrder(address account) external {
+        account;
+    }
+
+    function executeOffchainDelayedOrder(address account, bytes[] calldata priceUpdateData) external payable {
+        account;
+        priceUpdateData;
+    }
+}


### PR DESCRIPTION
This PR introduces a consolidated interface and empty test contract that can be used as a base to connect to the proxied PerpsV2 markets. 

This can be used to connect any PerpsV2 market deployed on using the proxy address of the market address and the ABI of `TestablePerpsV2MarketEmpty` contract and use it as a simple contract.

i.e. if you want to connect to the ETH PerpsV2 market deployed in Goerli-optimism with ethers.js you can use:

```
const consolidatedPerpsV2MarketABI = [...] // the abi of the contract
const ethPerpsAddress = '0x111BAbcdd66b1B60A20152a2D3D06d36F8B5703c'

const contract = new ethers.Contract(ethPerpsAddress, consolidatedPerpsV2MarketABI, provider);
```
