### PR TITLE
Add Cap to keeper liquidation fee

### DIFF
--- a/contracts/MixinPerpsV2MarketSettings.sol
+++ b/contracts/MixinPerpsV2MarketSettings.sol
@@ -38,6 +38,8 @@ contract MixinPerpsV2MarketSettings is MixinResolver {
     // Global settings
     // minimum liquidation fee payable to liquidator
     bytes32 internal constant SETTING_MIN_KEEPER_FEE = "futuresMinKeeperFee";
+    // maximum liquidation fee payable to liquidator
+    bytes32 internal constant SETTING_MAX_KEEPER_FEE = "futuresMaxKeeperFee";
     // liquidation fee basis points payed to liquidator
     bytes32 internal constant SETTING_LIQUIDATION_FEE_RATIO = "futuresLiquidationFeeRatio";
     // liquidation buffer to prevent negative margin upon liquidation
@@ -151,6 +153,10 @@ contract MixinPerpsV2MarketSettings is MixinResolver {
 
     function _minKeeperFee() internal view returns (uint) {
         return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_KEEPER_FEE);
+    }
+
+    function _maxKeeperFee() internal view returns (uint) {
+        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_MAX_KEEPER_FEE);
     }
 
     function _liquidationFeeRatio() internal view returns (uint) {

--- a/contracts/PerpsV2Market.sol
+++ b/contracts/PerpsV2Market.sol
@@ -269,7 +269,7 @@ contract PerpsV2Market is IPerpsV2Market, PerpsV2MarketProxyable {
         marketState.deletePosition(account);
 
         // Issue the reward to the liquidator.
-        uint liqFee = _liquidationFee(positionSize, price);
+        uint liqFee = _liquidationFee(positionSize, price, true);
         _manager().issueSUSD(liquidator, liqFee);
 
         emitPositionModified(positionId, account, 0, 0, 0, price, fundingIndex, 0);

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -359,8 +359,8 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
 
     /**
      * The fee charged from the margin during liquidation. Fee is proportional to position size
-     * but is at least the _minKeeperFee() of sUSD to prevent underincentivising
-     * liquidations of small positions.
+     * but is between _minKeeperFee() and _maxKeeperFee() of sUSD to prevent underincentivising
+     * liquidations of small positions, or overpaying.
      * @param positionSize size of position in fixed point decimal baseAsset units
      * @param price price of single baseAsset unit in sUSD fixed point decimal units
      * @return lFee liquidation fee to be paid to liquidator in sUSD fixed point decimal units
@@ -368,9 +368,12 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
     function _liquidationFee(int positionSize, uint price) internal view returns (uint lFee) {
         // size * price * fee-ratio
         uint proportionalFee = _abs(positionSize).multiplyDecimal(price).multiplyDecimal(_liquidationFeeRatio());
+        uint maxFee = _maxKeeperFee();
+        uint topedProportionalFee = proportionalFee > maxFee ? maxFee : proportionalFee;
         uint minFee = _minKeeperFee();
+
         // max(proportionalFee, minFee) - to prevent not incentivising liquidations enough
-        return proportionalFee > minFee ? proportionalFee : minFee; // not using _max() helper because it's for signed ints
+        return topedProportionalFee > minFee ? topedProportionalFee : minFee; // not using _max() helper because it's for signed ints
     }
 
     /**

--- a/contracts/PerpsV2MarketData.sol
+++ b/contracts/PerpsV2MarketData.sol
@@ -18,6 +18,7 @@ contract PerpsV2MarketData {
         uint liquidationFeeRatio;
         uint liquidationBufferRatio;
         uint minKeeperFee;
+        uint maxKeeperFee;
     }
 
     struct MarketSummary {
@@ -132,7 +133,8 @@ contract PerpsV2MarketData {
                 minInitialMargin: settings.minInitialMargin(),
                 liquidationFeeRatio: settings.liquidationFeeRatio(),
                 liquidationBufferRatio: settings.liquidationBufferRatio(),
-                minKeeperFee: settings.minKeeperFee()
+                minKeeperFee: settings.minKeeperFee(),
+                maxKeeperFee: settings.maxKeeperFee()
             });
     }
 

--- a/contracts/PerpsV2MarketSettings.sol
+++ b/contracts/PerpsV2MarketSettings.sol
@@ -205,8 +205,15 @@ contract PerpsV2MarketSettings is Owned, MixinPerpsV2MarketSettings, IPerpsV2Mar
     }
 
     /*
+     * The maximum amount of sUSD paid to a liquidator when they successfully liquidate a position.
+     */
+    function maxKeeperFee() external view returns (uint) {
+        return _maxKeeperFee();
+    }
+
+    /*
      * Liquidation fee basis points paid to liquidator.
-     * Use together with minKeeperFee() to calculate the actual fee paid.
+     * Use together with minKeeperFee() and maxKeeperFee() to calculate the actual fee paid.
      */
     function liquidationFeeRatio() external view returns (uint) {
         return _liquidationFeeRatio();
@@ -372,8 +379,18 @@ contract PerpsV2MarketSettings is Owned, MixinPerpsV2MarketSettings, IPerpsV2Mar
 
     function setMinKeeperFee(uint _sUSD) external onlyOwner {
         require(_sUSD <= _minInitialMargin(), "min margin < liquidation fee");
+        if (_maxKeeperFee() > 0) {
+            // only check if already set
+            require(_sUSD <= _maxKeeperFee(), "max fee < min fee");
+        }
         _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_KEEPER_FEE, _sUSD);
         emit MinKeeperFeeUpdated(_sUSD);
+    }
+
+    function setMaxKeeperFee(uint _sUSD) external onlyOwner {
+        require(_sUSD >= _minKeeperFee(), "max fee < min fee");
+        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_MAX_KEEPER_FEE, _sUSD);
+        emit MaxKeeperFeeUpdated(_sUSD);
     }
 
     function setLiquidationFeeRatio(uint _ratio) external onlyOwner {
@@ -397,6 +414,7 @@ contract PerpsV2MarketSettings is Owned, MixinPerpsV2MarketSettings, IPerpsV2Mar
     event ParameterUpdated(bytes32 indexed marketKey, bytes32 indexed parameter, uint value);
     event ParameterUpdatedBytes32(bytes32 indexed marketKey, bytes32 indexed parameter, bytes32 value);
     event MinKeeperFeeUpdated(uint sUSD);
+    event MaxKeeperFeeUpdated(uint sUSD);
     event LiquidationFeeRatioUpdated(uint bps);
     event LiquidationBufferRatioUpdated(uint bps);
     event MinInitialMarginUpdated(uint minMargin);

--- a/contracts/PerpsV2MarketViews.sol
+++ b/contracts/PerpsV2MarketViews.sol
@@ -190,7 +190,7 @@ contract PerpsV2MarketViews is PerpsV2MarketBase, IPerpsV2MarketViews {
     function liquidationFee(address account) external view returns (uint) {
         (uint price, bool invalid) = _assetPrice();
         if (!invalid && _canLiquidate(marketState.positions(account), price)) {
-            return _liquidationFee(int(marketState.positions(account).size), price);
+            return _liquidationFee(int(marketState.positions(account).size), price, true);
         } else {
             // theoretically we can calculate a value, but this value is always incorrect because
             // it's for a price at which liquidation cannot happen - so is misleading, because
@@ -225,7 +225,6 @@ contract PerpsV2MarketViews is PerpsV2MarketBase, IPerpsV2MarketViews {
         (uint price, bool isInvalid) = _assetPrice();
         (uint dynamicFeeRate, bool tooVolatile) = _dynamicFeeRate();
 
-        bytes32 marketKey = _marketKey();
         (uint makerFee, uint takerFee, bool invalid) = _makerTakeFeeByOrderType(orderType);
         if (invalid) {
             return (0, true);

--- a/contracts/interfaces/IPerpsV2MarketSettings.sol
+++ b/contracts/interfaces/IPerpsV2MarketSettings.sol
@@ -64,6 +64,8 @@ interface IPerpsV2MarketSettings {
 
     function minKeeperFee() external view returns (uint);
 
+    function maxKeeperFee() external view returns (uint);
+
     function liquidationFeeRatio() external view returns (uint);
 
     function liquidationBufferRatio() external view returns (uint);

--- a/index.js
+++ b/index.js
@@ -206,6 +206,7 @@ const defaults = {
 	ETHER_WRAPPER_BURN_FEE_RATE: '0',
 
 	FUTURES_MIN_KEEPER_FEE: w3utils.toWei('1'), // 1 sUSD min keeper fee
+	FUTURES_MAX_KEEPER_FEE: w3utils.toWei('1000'), // 1000 sUSD min keeper fee
 	FUTURES_LIQUIDATION_FEE_RATIO: w3utils.toWei('0.0035'), // 35 basis points liquidation incentive
 	FUTURES_LIQUIDATION_BUFFER_RATIO: w3utils.toWei('0.0025'), // 25 basis points liquidation buffer
 	FUTURES_MIN_INITIAL_MARGIN: w3utils.toWei('40'), // minimum initial margin for all markets

--- a/publish/src/commands/deploy/configure-perpsv2.js
+++ b/publish/src/commands/deploy/configure-perpsv2.js
@@ -73,6 +73,17 @@ module.exports = async ({
 		comment: 'Set the minimum reward for liquidating a perpsV2 position (SIP-80)',
 	});
 
+	const FUTURES_MAX_KEEPER_FEE = await getDeployParameter('FUTURES_MAX_KEEPER_FEE');
+	await runStep({
+		contract: 'PerpsV2MarketSettings',
+		target: futuresMarketSettings,
+		read: 'maxKeeperFee',
+		expected: input => input === FUTURES_MAX_KEEPER_FEE,
+		write: 'setMaxKeeperFee',
+		writeArg: FUTURES_MAX_KEEPER_FEE,
+		comment: 'Set the maximum reward for liquidating a perpsV2 position',
+	});
+
 	//
 	// Configure parameters for each market.
 	//

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -5109,8 +5109,10 @@ contract('PerpsV2Market PerpsV2MarketAtomic', accounts => {
 				await perpsV2MarketSettings.setLiquidationFeeRatio(toUnit(0.02), { from: owner });
 				assert.bnEqual(await perpsV2Market.liquidationFee(trader2), toUnit(60));
 			});
+		});
 
-			it('top up liquidation fee', async () => {
+		describe('max liquidationFee', () => {
+			it('only send the max liquidation fee to the liquidator', async () => {
 				await perpsV2MarketSettings.setMaxKeeperFee(maxKeeperFee, { from: owner });
 
 				await setPrice(baseAsset, toUnit('1000'));
@@ -5125,8 +5127,9 @@ contract('PerpsV2Market PerpsV2MarketAtomic', accounts => {
 
 				// long
 				await setPrice(baseAsset, toUnit('500'));
+
 				// max liquidation fee = 1000
-				// proportional fee: 0.0035 * 500 * 200 = 350
+				// proportional fee: 0.0035 * price * 200 = 350
 				// min (1000,350) = 350
 				assert.bnEqual(await perpsV2Market.liquidationFee(trader), toUnit('350'));
 
@@ -5144,6 +5147,112 @@ contract('PerpsV2Market PerpsV2MarketAtomic', accounts => {
 				// min (2000,1050) = 1050
 				await perpsV2MarketSettings.setMaxKeeperFee(toUnit(2000), { from: owner });
 				assert.bnEqual(await perpsV2Market.liquidationFee(trader2), toUnit('1050'));
+			});
+
+			it('send the remaining to the fee pool when max is exceeded - long', async () => {
+				await setPrice(baseAsset, toUnit('1000'));
+				// increase margin so that we can play with it
+				await perpsV2MarketSettings.setLiquidationBufferRatio(toUnit('0.1'), { from: owner });
+
+				await perpsV2Market.transferMargin(toUnit('100000'), { from: trader });
+				await perpsV2Market.modifyPosition(toUnit('200'), priceImpactDelta, { from: trader });
+				await perpsV2Market.transferMargin(toUnit('100000'), { from: trader2 });
+				await perpsV2Market.modifyPosition(toUnit('-200'), priceImpactDelta, { from: trader2 });
+
+				// cannot liquidate
+				assert.isFalse(await perpsV2Market.canLiquidate(trader));
+
+				// long
+				const liqPrice = (await perpsV2Market.liquidationPrice(trader)).price;
+
+				// move the price so that is liquidatable but there's still margin to use
+				const newPrice = liqPrice.sub(toUnit(100));
+				await setPrice(baseAsset, newPrice);
+
+				// confirm is liquidatable
+				assert.isTrue(await perpsV2Market.canLiquidate(trader));
+
+				// reduce maximum fee
+				await perpsV2MarketSettings.setMinKeeperFee(toUnit(1), { from: owner });
+				await perpsV2MarketSettings.setMaxKeeperFee(toUnit(10), { from: owner });
+
+				const liquidationFee = await perpsV2Market.liquidationFee(trader);
+				const expectedLiquidationFee = toUnit('10'); // max keeper fee
+				assert.bnEqual(liquidationFee, expectedLiquidationFee);
+
+				const remainingMargin = (await perpsV2Market.remainingMargin(trader)).marginRemaining;
+				const poolFee = remainingMargin.sub(expectedLiquidationFee);
+
+				// the price needs to be set in a way that leaves positive margin after fee
+				assert.isTrue(poolFee.gt(toBN(0)));
+
+				const feeAddress = await feePool.FEE_ADDRESS();
+				const preFeePoolBalance = await sUSD.balanceOf(feeAddress);
+				const preLiquidatorBalance = await sUSD.balanceOf(noBalance);
+
+				await perpsV2Market.liquidatePosition(trader, { from: noBalance });
+
+				assert.bnEqual(
+					await sUSD.balanceOf(noBalance),
+					preLiquidatorBalance.add(expectedLiquidationFee)
+				);
+
+				const postFeePoolBalance = await sUSD.balanceOf(feeAddress);
+				assert.bnGt(postFeePoolBalance, preFeePoolBalance.add(toUnit(1))); // we are exceeding the 'close' margin below
+				assert.bnClose(postFeePoolBalance, preFeePoolBalance.add(poolFee), toUnit('0.0000001'));
+			});
+
+			it('send the remaining to the fee pool when max is exceeded - short', async () => {
+				await setPrice(baseAsset, toUnit('1000'));
+				// increase margin so that we can play with it
+				await perpsV2MarketSettings.setLiquidationBufferRatio(toUnit('0.1'), { from: owner });
+
+				await perpsV2Market.transferMargin(toUnit('100000'), { from: trader });
+				await perpsV2Market.modifyPosition(toUnit('200'), priceImpactDelta, { from: trader });
+				await perpsV2Market.transferMargin(toUnit('100000'), { from: trader2 });
+				await perpsV2Market.modifyPosition(toUnit('-200'), priceImpactDelta, { from: trader2 });
+
+				// cannot liquidate
+				assert.isFalse(await perpsV2Market.canLiquidate(trader2));
+
+				// long
+				const liqPrice = (await perpsV2Market.liquidationPrice(trader2)).price;
+
+				// move the price so that is liquidatable but there's still margin to use
+				const newPrice = liqPrice.add(toUnit(100));
+				await setPrice(baseAsset, newPrice);
+
+				// confirm is liquidatable
+				assert.isTrue(await perpsV2Market.canLiquidate(trader2));
+
+				// reduce maximum fee
+				await perpsV2MarketSettings.setMinKeeperFee(toUnit(1), { from: owner });
+				await perpsV2MarketSettings.setMaxKeeperFee(toUnit(10), { from: owner });
+
+				const liquidationFee = await perpsV2Market.liquidationFee(trader2);
+				const expectedLiquidationFee = toUnit('10'); // max keeper fee
+				assert.bnEqual(liquidationFee, expectedLiquidationFee);
+
+				const remainingMargin = (await perpsV2Market.remainingMargin(trader2)).marginRemaining;
+				const poolFee = remainingMargin.sub(expectedLiquidationFee);
+
+				// the price needs to be set in a way that leaves positive margin after fee
+				assert.isTrue(poolFee.gt(toBN(0)));
+
+				const feeAddress = await feePool.FEE_ADDRESS();
+				const preFeePoolBalance = await sUSD.balanceOf(feeAddress);
+				const preLiquidatorBalance = await sUSD.balanceOf(noBalance);
+
+				await perpsV2Market.liquidatePosition(trader2, { from: noBalance });
+
+				assert.bnEqual(
+					await sUSD.balanceOf(noBalance),
+					preLiquidatorBalance.add(expectedLiquidationFee)
+				);
+
+				const postFeePoolBalance = await sUSD.balanceOf(feeAddress);
+				assert.bnGt(postFeePoolBalance, preFeePoolBalance.add(toUnit(1))); // we are exceeding the 'close' margin below
+				assert.bnClose(postFeePoolBalance, preFeePoolBalance.add(poolFee), toUnit('0.0000001'));
 			});
 		});
 

--- a/test/contracts/PerpsV2MarketData.js
+++ b/test/contracts/PerpsV2MarketData.js
@@ -250,7 +250,9 @@ contract('PerpsV2MarketData', accounts => {
 			assert.bnEqual(await perpsV2MarketSettings.minInitialMargin(), globals.minInitialMargin);
 			assert.bnEqual(globals.minInitialMargin, toUnit('40'));
 			assert.bnEqual(await perpsV2MarketSettings.minKeeperFee(), globals.minKeeperFee);
+			assert.bnEqual(await perpsV2MarketSettings.maxKeeperFee(), globals.maxKeeperFee);
 			assert.bnEqual(globals.minKeeperFee, toUnit('20'));
+			assert.bnEqual(globals.maxKeeperFee, toUnit('1000'));
 			assert.bnEqual(
 				await perpsV2MarketSettings.liquidationFeeRatio(),
 				globals.liquidationFeeRatio

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -57,6 +57,7 @@ const constantsOverrides = {
 	EXCHANGE_DYNAMIC_FEE_THRESHOLD: toWei('0.004'),
 	EXCHANGE_MAX_DYNAMIC_FEE: toWei('0.05'),
 	FUTURES_MIN_KEEPER_FEE: toWei('20'),
+	FUTURES_MAX_KEEPER_FEE: toWei('1000'),
 };
 
 /**
@@ -1857,6 +1858,12 @@ const setupAllContracts = async ({
 				}),
 				returnObj['PerpsV2MarketSettings'].setMinKeeperFee(
 					constantsOverrides.FUTURES_MIN_KEEPER_FEE,
+					{
+						from: owner,
+					}
+				),
+				returnObj['PerpsV2MarketSettings'].setMaxKeeperFee(
+					constantsOverrides.FUTURES_MAX_KEEPER_FEE,
 					{
 						from: owner,
 					}

--- a/test/integration/behaviors/perpsV2.behavior.js
+++ b/test/integration/behaviors/perpsV2.behavior.js
@@ -364,6 +364,11 @@ function itCanTrade({ ctx }) {
 				assert.bnGte(minKeeperFee, toUnit(1));
 				assert.bnLt(minKeeperFee, toUnit(100));
 
+				// maxKeeperFee
+				const maxKeeperFee = await PerpsV2MarketSettings.maxKeeperFee();
+				assert.bnGte(maxKeeperFee, toUnit(100));
+				assert.bnLt(maxKeeperFee, toUnit(10000));
+
 				// minInitialMargin
 				const minInitialMargin = await PerpsV2MarketSettings.minInitialMargin();
 				assert.bnGt(minInitialMargin, toUnit(1));


### PR DESCRIPTION
This PR introduces a new parameter `maxKeeperFee` and use it to cap keeper liquidation fee