### PR TITLE
Remove commitment fee charged during delayed order submissions

### DIFF
--- a/contracts/MixinPerpsV2MarketSettings.sol
+++ b/contracts/MixinPerpsV2MarketSettings.sol
@@ -85,6 +85,7 @@ contract MixinPerpsV2MarketSettings is MixinResolver {
         return _parameter(_marketKey, PARAMETER_MAKER_FEE);
     }
 
+    // TODO: Remove me
     function _overrideCommitFee(bytes32 _marketKey) internal view returns (uint) {
         return _parameter(_marketKey, PARAMETER_OVERRIDE_COMMIT_FEE);
     }

--- a/contracts/MixinPerpsV2MarketSettings.sol
+++ b/contracts/MixinPerpsV2MarketSettings.sol
@@ -142,10 +142,10 @@ contract MixinPerpsV2MarketSettings is MixinResolver {
 
     function _offchainMarketKey(bytes32 _marketKey) internal view returns (bytes32) {
         return
-        _flexibleStorage().getBytes32Value(
-            SETTING_CONTRACT_NAME,
-            keccak256(abi.encodePacked(_marketKey, PARAMETER_OFFCHAIN_MARKET_KEY))
-        );
+            _flexibleStorage().getBytes32Value(
+                SETTING_CONTRACT_NAME,
+                keccak256(abi.encodePacked(_marketKey, PARAMETER_OFFCHAIN_MARKET_KEY))
+            );
     }
 
     function _offchainPriceDivergence(bytes32 _marketKey) internal view returns (uint) {

--- a/contracts/MixinPerpsV2MarketSettings.sol
+++ b/contracts/MixinPerpsV2MarketSettings.sol
@@ -17,7 +17,6 @@ contract MixinPerpsV2MarketSettings is MixinResolver {
     // Per-market settings
     bytes32 internal constant PARAMETER_TAKER_FEE = "takerFee";
     bytes32 internal constant PARAMETER_MAKER_FEE = "makerFee";
-    bytes32 internal constant PARAMETER_OVERRIDE_COMMIT_FEE = "overrideCommitFee";
     bytes32 internal constant PARAMETER_TAKER_FEE_DELAYED_ORDER = "takerFeeDelayedOrder";
     bytes32 internal constant PARAMETER_MAKER_FEE_DELAYED_ORDER = "makerFeeDelayedOrder";
     bytes32 internal constant PARAMETER_TAKER_FEE_OFFCHAIN_DELAYED_ORDER = "takerFeeOffchainDelayedOrder";
@@ -85,11 +84,6 @@ contract MixinPerpsV2MarketSettings is MixinResolver {
         return _parameter(_marketKey, PARAMETER_MAKER_FEE);
     }
 
-    // TODO: Remove me
-    function _overrideCommitFee(bytes32 _marketKey) internal view returns (uint) {
-        return _parameter(_marketKey, PARAMETER_OVERRIDE_COMMIT_FEE);
-    }
-
     function _takerFeeDelayedOrder(bytes32 _marketKey) internal view returns (uint) {
         return _parameter(_marketKey, PARAMETER_TAKER_FEE_DELAYED_ORDER);
     }
@@ -148,10 +142,10 @@ contract MixinPerpsV2MarketSettings is MixinResolver {
 
     function _offchainMarketKey(bytes32 _marketKey) internal view returns (bytes32) {
         return
-            _flexibleStorage().getBytes32Value(
-                SETTING_CONTRACT_NAME,
-                keccak256(abi.encodePacked(_marketKey, PARAMETER_OFFCHAIN_MARKET_KEY))
-            );
+        _flexibleStorage().getBytes32Value(
+            SETTING_CONTRACT_NAME,
+            keccak256(abi.encodePacked(_marketKey, PARAMETER_OFFCHAIN_MARKET_KEY))
+        );
     }
 
     function _offchainPriceDivergence(bytes32 _marketKey) internal view returns (uint) {

--- a/contracts/PerpsV2MarketData.sol
+++ b/contracts/PerpsV2MarketData.sol
@@ -69,7 +69,6 @@ contract PerpsV2MarketData {
         uint makerFeeDelayedOrder;
         uint takerFeeOffchainDelayedOrder;
         uint makerFeeOffchainDelayedOrder;
-        uint overrideCommitFee;
     }
 
     struct FundingDetails {
@@ -175,8 +174,7 @@ contract PerpsV2MarketData {
                     params.takerFeeDelayedOrder,
                     params.makerFeeDelayedOrder,
                     params.takerFeeOffchainDelayedOrder,
-                    params.makerFeeOffchainDelayedOrder,
-                    params.overrideCommitFee
+                    params.makerFeeOffchainDelayedOrder
                 )
             );
         }
@@ -232,8 +230,7 @@ contract PerpsV2MarketData {
                     params.takerFeeDelayedOrder,
                     params.makerFeeDelayedOrder,
                     params.takerFeeOffchainDelayedOrder,
-                    params.makerFeeOffchainDelayedOrder,
-                    params.overrideCommitFee
+                    params.makerFeeOffchainDelayedOrder
                 ),
                 MarketLimits(params.maxLeverage, params.maxMarketValue),
                 _fundingParameters(params),

--- a/contracts/PerpsV2MarketDelayedIntent.sol
+++ b/contracts/PerpsV2MarketDelayedIntent.sol
@@ -197,16 +197,9 @@ contract PerpsV2MarketDelayedIntent is IPerpsV2MarketDelayedIntent, PerpsV2Marke
             _revertIfError(status);
         }
 
-        // deduct fees from margin
-        //
-        // commitDeposit is simply the maker/taker fee. note the dynamic fee rate is 0 since for the purposes of the
-        // commitment deposit it is not important since at the time of the order execution it will be refunded and the
-        // correct dynamic fee will be charged.
-        // If the overrideCommitFee is set (value > 0) use this one instead.
-        uint commitDeposit = _overrideCommitFee(marketKey) > 0 ? _overrideCommitFee(marketKey) : _orderFee(params, 0);
         uint keeperDeposit = _minKeeperFee();
 
-        _updatePositionMargin(messageSender, position, sizeDelta, fillPrice, -int(commitDeposit + keeperDeposit));
+        _updatePositionMargin(messageSender, position, sizeDelta, fillPrice, -int(keeperDeposit));
         emitPositionModified(position.id, messageSender, position.margin, position.size, 0, fillPrice, fundingIndex, 0);
 
         uint targetRoundId = _exchangeRates().getCurrentRoundId(_baseAsset()) + 1; // next round
@@ -216,7 +209,7 @@ contract PerpsV2MarketDelayedIntent is IPerpsV2MarketDelayedIntent, PerpsV2Marke
                 sizeDelta: int128(sizeDelta),
                 priceImpactDelta: uint128(priceImpactDelta),
                 targetRoundId: isOffchain ? 0 : uint128(targetRoundId),
-                commitDeposit: uint128(commitDeposit),
+                commitDeposit: 0, // legacy - no longer charging a commitDeposit on submission.
                 keeperDeposit: uint128(keeperDeposit), // offchain orders do _not_ have an executableAtTime as it's based on price age.
                 executableAtTime: isOffchain ? 0 : block.timestamp + desiredTimeDelta, // zero out - not used and minimise confusion.
                 intentionTime: block.timestamp,

--- a/contracts/PerpsV2MarketDelayedIntent.sol
+++ b/contracts/PerpsV2MarketDelayedIntent.sol
@@ -209,7 +209,7 @@ contract PerpsV2MarketDelayedIntent is IPerpsV2MarketDelayedIntent, PerpsV2Marke
                 sizeDelta: int128(sizeDelta),
                 priceImpactDelta: uint128(priceImpactDelta),
                 targetRoundId: isOffchain ? 0 : uint128(targetRoundId),
-                commitDeposit: 0, // legacy - no longer charging a commitDeposit on submission.
+                commitDeposit: 0, // note: legacy as no longer charge a commitFee on submit
                 keeperDeposit: uint128(keeperDeposit), // offchain orders do _not_ have an executableAtTime as it's based on price age.
                 executableAtTime: isOffchain ? 0 : block.timestamp + desiredTimeDelta, // zero out - not used and minimise confusion.
                 intentionTime: block.timestamp,

--- a/contracts/frozen/FrozenMixinPerpsV2MarketSettings.sol
+++ b/contracts/frozen/FrozenMixinPerpsV2MarketSettings.sol
@@ -142,10 +142,10 @@ contract FrozenMixinPerpsV2MarketSettings is MixinResolver {
 
     function _offchainMarketKey(bytes32 _marketKey) internal view returns (bytes32) {
         return
-        _flexibleStorage().getBytes32Value(
-            SETTING_CONTRACT_NAME,
-            keccak256(abi.encodePacked(_marketKey, PARAMETER_OFFCHAIN_MARKET_KEY))
-        );
+            _flexibleStorage().getBytes32Value(
+                SETTING_CONTRACT_NAME,
+                keccak256(abi.encodePacked(_marketKey, PARAMETER_OFFCHAIN_MARKET_KEY))
+            );
     }
 
     function _offchainPriceDivergence(bytes32 _marketKey) internal view returns (uint) {

--- a/contracts/frozen/FrozenMixinPerpsV2MarketSettings.sol
+++ b/contracts/frozen/FrozenMixinPerpsV2MarketSettings.sol
@@ -1,435 +1,178 @@
 pragma solidity ^0.5.16;
 pragma experimental ABIEncoderV2;
 
-// Inheritance
-import "./Owned.sol";
-import "./MixinPerpsV2MarketSettings.sol";
+import "../MixinResolver.sol";
 
 // Internal references
-import "../interfaces/IPerpsV2MarketSettings.sol";
-import "../interfaces/IFuturesMarketManager.sol";
-import "../interfaces/IPerpsV2MarketViews.sol";
-import "../interfaces/IPerpsV2Market.sol";
+import "../interfaces/IFlexibleStorage.sol";
 
-// https://docs.synthetix.io/contracts/source/contracts/PerpsV2MarketSettings
-contract PerpsV2MarketSettings is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketSettings {
+// https://docs.synthetix.io/contracts/source/contracts/MixinPerpsV2MarketSettings
+contract FrozenMixinPerpsV2MarketSettings is MixinResolver {
     /* ========== CONSTANTS ========== */
+
+    bytes32 internal constant SETTING_CONTRACT_NAME = "PerpsV2MarketSettings";
+
+    /* ---------- Parameter Names ---------- */
+
+    // Per-market settings
+    bytes32 internal constant PARAMETER_TAKER_FEE = "takerFee";
+    bytes32 internal constant PARAMETER_MAKER_FEE = "makerFee";
+    bytes32 internal constant PARAMETER_OVERRIDE_COMMIT_FEE = "overrideCommitFee";
+    bytes32 internal constant PARAMETER_TAKER_FEE_DELAYED_ORDER = "takerFeeDelayedOrder";
+    bytes32 internal constant PARAMETER_MAKER_FEE_DELAYED_ORDER = "makerFeeDelayedOrder";
+    bytes32 internal constant PARAMETER_TAKER_FEE_OFFCHAIN_DELAYED_ORDER = "takerFeeOffchainDelayedOrder";
+    bytes32 internal constant PARAMETER_MAKER_FEE_OFFCHAIN_DELAYED_ORDER = "makerFeeOffchainDelayedOrder";
+    bytes32 internal constant PARAMETER_NEXT_PRICE_CONFIRM_WINDOW = "nextPriceConfirmWindow";
+    bytes32 internal constant PARAMETER_DELAYED_ORDER_CONFIRM_WINDOW = "delayedOrderConfirmWindow";
+    bytes32 internal constant PARAMETER_OFFCHAIN_DELAYED_ORDER_MIN_AGE = "offchainDelayedOrderMinAge";
+    bytes32 internal constant PARAMETER_OFFCHAIN_DELAYED_ORDER_MAX_AGE = "offchainDelayedOrderMaxAge";
+    bytes32 internal constant PARAMETER_MAX_LEVERAGE = "maxLeverage";
+    bytes32 internal constant PARAMETER_MAX_MARKET_VALUE = "maxMarketValue";
+    bytes32 internal constant PARAMETER_MAX_FUNDING_VELOCITY = "maxFundingVelocity";
+    bytes32 internal constant PARAMETER_MIN_SKEW_SCALE = "skewScale";
+    bytes32 internal constant PARAMETER_MIN_DELAY_TIME_DELTA = "minDelayTimeDelta";
+    bytes32 internal constant PARAMETER_MAX_DELAY_TIME_DELTA = "maxDelayTimeDelta";
+    bytes32 internal constant PARAMETER_OFFCHAIN_MARKET_KEY = "offchainMarketKey";
+    bytes32 internal constant PARAMETER_OFFCHAIN_PRICE_DIVERGENCE = "offchainPriceDivergence";
+    bytes32 internal constant PARAMETER_LIQUIDATION_PREMIUM_MULTIPLIER = "liquidationPremiumMultiplier";
+
+    // Global settings
+    // minimum liquidation fee payable to liquidator
+    bytes32 internal constant SETTING_MIN_KEEPER_FEE = "perpsV2MinKeeperFee";
+    // maximum liquidation fee payable to liquidator
+    bytes32 internal constant SETTING_MAX_KEEPER_FEE = "perpsV2MaxKeeperFee";
+    // liquidation fee basis points payed to liquidator
+    bytes32 internal constant SETTING_LIQUIDATION_FEE_RATIO = "perpsV2LiquidationFeeRatio";
+    // liquidation buffer to prevent negative margin upon liquidation
+    bytes32 internal constant SETTING_LIQUIDATION_BUFFER_RATIO = "perpsV2LiquidationBufferRatio";
+    bytes32 internal constant SETTING_MIN_INITIAL_MARGIN = "perpsV2MinInitialMargin";
 
     /* ---------- Address Resolver Configuration ---------- */
 
-    bytes32 internal constant CONTRACT_FUTURES_MARKET_MANAGER = "FuturesMarketManager";
+    bytes32 internal constant CONTRACT_FLEXIBLESTORAGE = "FlexibleStorage";
 
     /* ========== CONSTRUCTOR ========== */
 
-    constructor(address _owner, address _resolver) public Owned(_owner) MixinPerpsV2MarketSettings(_resolver) {}
+    constructor(address _resolver) internal MixinResolver(_resolver) {}
 
     /* ========== VIEWS ========== */
 
     function resolverAddressesRequired() public view returns (bytes32[] memory addresses) {
-        bytes32[] memory existingAddresses = MixinPerpsV2MarketSettings.resolverAddressesRequired();
-        bytes32[] memory newAddresses = new bytes32[](1);
-        newAddresses[0] = CONTRACT_FUTURES_MARKET_MANAGER;
-        addresses = combineArrays(existingAddresses, newAddresses);
+        addresses = new bytes32[](1);
+        addresses[0] = CONTRACT_FLEXIBLESTORAGE;
     }
 
-    function _futuresMarketManager() internal view returns (IFuturesMarketManager) {
-        return IFuturesMarketManager(requireAndGetAddress(CONTRACT_FUTURES_MARKET_MANAGER));
+    function _flexibleStorage() internal view returns (IFlexibleStorage) {
+        return IFlexibleStorage(requireAndGetAddress(CONTRACT_FLEXIBLESTORAGE));
     }
 
-    /* ---------- Getters ---------- */
+    /* ---------- Internals ---------- */
 
-    /*
-     * The fee charged when opening a position on the heavy side of a perpsV2 market.
-     */
-    function takerFee(bytes32 _marketKey) external view returns (uint) {
-        return _takerFee(_marketKey);
+    function _parameter(bytes32 _marketKey, bytes32 key) internal view returns (uint value) {
+        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, keccak256(abi.encodePacked(_marketKey, key)));
     }
 
-    /*
-     * The fee charged when opening a position on the light side of a perpsV2 market.
-     */
-    function makerFee(bytes32 _marketKey) public view returns (uint) {
-        return _makerFee(_marketKey);
+    function _takerFee(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_TAKER_FEE);
     }
 
-    /*
-     * The fee charged as commit fee if set. It will override the default calculation if this value is larger than  zero.
-     */
-    function overrideCommitFee(bytes32 _marketKey) external view returns (uint) {
+    function _makerFee(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_MAKER_FEE);
+    }
+
+    function _overrideCommitFee(bytes32 _marketKey) internal view returns (uint) {
         return _parameter(_marketKey, PARAMETER_OVERRIDE_COMMIT_FEE);
     }
 
-    /*
-     * The fee charged when opening a position on the heavy side of a perpsV2 market using delayed order mechanism.
-     */
-    function takerFeeDelayedOrder(bytes32 _marketKey) external view returns (uint) {
-        return _takerFeeDelayedOrder(_marketKey);
+    function _takerFeeDelayedOrder(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_TAKER_FEE_DELAYED_ORDER);
     }
 
-    /*
-     * The fee charged when opening a position on the light side of a perpsV2 market using delayed order mechanism.
-     */
-    function makerFeeDelayedOrder(bytes32 _marketKey) public view returns (uint) {
-        return _makerFeeDelayedOrder(_marketKey);
+    function _makerFeeDelayedOrder(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_MAKER_FEE_DELAYED_ORDER);
     }
 
-    /*
-     * The fee charged when opening a position on the heavy side of a perpsV2 market using offchain delayed order mechanism.
-     */
-    function takerFeeOffchainDelayedOrder(bytes32 _marketKey) external view returns (uint) {
-        return _takerFeeOffchainDelayedOrder(_marketKey);
+    function _takerFeeOffchainDelayedOrder(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_TAKER_FEE_OFFCHAIN_DELAYED_ORDER);
     }
 
-    /*
-     * The fee charged when opening a position on the light side of a perpsV2 market using offchain delayed order mechanism.
-     */
-    function makerFeeOffchainDelayedOrder(bytes32 _marketKey) public view returns (uint) {
-        return _makerFeeOffchainDelayedOrder(_marketKey);
+    function _makerFeeOffchainDelayedOrder(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_MAKER_FEE_OFFCHAIN_DELAYED_ORDER);
     }
 
-    /*
-     * The number of price update rounds during which confirming next-price is allowed
-     */
-    function nextPriceConfirmWindow(bytes32 _marketKey) public view returns (uint) {
-        return _nextPriceConfirmWindow(_marketKey);
+    function _nextPriceConfirmWindow(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_NEXT_PRICE_CONFIRM_WINDOW);
     }
 
-    /*
-     * The amount of time in seconds which confirming delayed orders is allow
-     */
-    function delayedOrderConfirmWindow(bytes32 _marketKey) public view returns (uint) {
-        return _delayedOrderConfirmWindow(_marketKey);
+    function _delayedOrderConfirmWindow(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_DELAYED_ORDER_CONFIRM_WINDOW);
     }
 
-    /*
-     * The amount of time in seconds which confirming delayed orders is allow
-     */
-    function offchainDelayedOrderMinAge(bytes32 _marketKey) public view returns (uint) {
-        return _offchainDelayedOrderMinAge(_marketKey);
+    function _offchainDelayedOrderMinAge(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_OFFCHAIN_DELAYED_ORDER_MIN_AGE);
     }
 
-    /*
-     * The amount of time in seconds which confirming delayed orders is allow
-     */
-    function offchainDelayedOrderMaxAge(bytes32 _marketKey) public view returns (uint) {
-        return _offchainDelayedOrderMaxAge(_marketKey);
+    function _offchainDelayedOrderMaxAge(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_OFFCHAIN_DELAYED_ORDER_MAX_AGE);
     }
 
-    /*
-     * The maximum allowable leverage in a market.
-     */
-    function maxLeverage(bytes32 _marketKey) public view returns (uint) {
-        return _maxLeverage(_marketKey);
+    function _maxLeverage(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_MAX_LEVERAGE);
     }
 
-    /*
-     * The maximum allowable value (base asset) on each side of a market.
-     */
-    function maxMarketValue(bytes32 _marketKey) public view returns (uint) {
-        return _maxMarketValue(_marketKey);
+    function _maxMarketValue(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_MAX_MARKET_VALUE);
     }
 
-    /*
-     * The skew level at which the max funding velocity will be charged.
-     */
-    function skewScale(bytes32 _marketKey) public view returns (uint) {
-        return _skewScale(_marketKey);
+    function _skewScale(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_MIN_SKEW_SCALE);
     }
 
-    /*
-     * The maximum theoretical funding velocity per day charged by a market.
-     */
-    function maxFundingVelocity(bytes32 _marketKey) public view returns (uint) {
-        return _maxFundingVelocity(_marketKey);
+    function _maxFundingVelocity(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_MAX_FUNDING_VELOCITY);
     }
 
-    /*
-     * The off-chain delayed order lower bound whereby the desired delta must be greater than or equal to.
-     */
-    function minDelayTimeDelta(bytes32 _marketKey) public view returns (uint) {
-        return _minDelayTimeDelta(_marketKey);
+    function _minDelayTimeDelta(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_MIN_DELAY_TIME_DELTA);
     }
 
-    /*
-     * The off-chain delayed order upper bound whereby the desired delta must be greater than or equal to.
-     */
-    function maxDelayTimeDelta(bytes32 _marketKey) public view returns (uint) {
-        return _maxDelayTimeDelta(_marketKey);
+    function _maxDelayTimeDelta(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_MAX_DELAY_TIME_DELTA);
     }
 
-    /*
-     * The off-chain delayed order market key, used to pause and resume offchain markets.
-     */
-    function offchainMarketKey(bytes32 _marketKey) public view returns (bytes32) {
-        return _offchainMarketKey(_marketKey);
-    }
-
-    /*
-     * The max divergence between onchain and offchain prices for an offchain delayed order execution.
-     */
-    function offchainPriceDivergence(bytes32 _marketKey) public view returns (uint) {
-        return _offchainPriceDivergence(_marketKey);
-    }
-
-    /*
-     * The liquidation premium multiplier applied when calculating the liquidation premium margin.
-     */
-    function liquidationPremiumMultiplier(bytes32 _marketKey) public view returns (uint) {
-        return _liquidationPremiumMultiplier(_marketKey);
-    }
-
-    function parameters(bytes32 _marketKey) external view returns (Parameters memory) {
+    function _offchainMarketKey(bytes32 _marketKey) internal view returns (bytes32) {
         return
-        Parameters(
-            _takerFee(_marketKey),
-            _makerFee(_marketKey),
-            _overrideCommitFee(_marketKey),
-            _takerFeeDelayedOrder(_marketKey),
-            _makerFeeDelayedOrder(_marketKey),
-            _takerFeeOffchainDelayedOrder(_marketKey),
-            _makerFeeOffchainDelayedOrder(_marketKey),
-            _maxLeverage(_marketKey),
-            _maxMarketValue(_marketKey),
-            _maxFundingVelocity(_marketKey),
-            _skewScale(_marketKey),
-            _nextPriceConfirmWindow(_marketKey),
-            _delayedOrderConfirmWindow(_marketKey),
-            _minDelayTimeDelta(_marketKey),
-            _maxDelayTimeDelta(_marketKey),
-            _offchainDelayedOrderMinAge(_marketKey),
-            _offchainDelayedOrderMaxAge(_marketKey),
-            _offchainMarketKey(_marketKey),
-            _offchainPriceDivergence(_marketKey),
-            _liquidationPremiumMultiplier(_marketKey)
-        );
-    }
-
-    /*
-     * The minimum amount of sUSD paid to a liquidator when they successfully liquidate a position.
-     * This quantity must be no greater than `minInitialMargin`.
-     */
-    function minKeeperFee() external view returns (uint) {
-        return _minKeeperFee();
-    }
-
-    /*
-     * The maximum amount of sUSD paid to a liquidator when they successfully liquidate a position.
-     */
-    function maxKeeperFee() external view returns (uint) {
-        return _maxKeeperFee();
-    }
-
-    /*
-     * Liquidation fee basis points paid to liquidator.
-     * Use together with minKeeperFee() and maxKeeperFee() to calculate the actual fee paid.
-     */
-    function liquidationFeeRatio() external view returns (uint) {
-        return _liquidationFeeRatio();
-    }
-
-    /*
-     * Liquidation price buffer in basis points to prevent negative margin on liquidation.
-     */
-    function liquidationBufferRatio() external view returns (uint) {
-        return _liquidationBufferRatio();
-    }
-
-    /*
-     * The minimum margin required to open a position.
-     * This quantity must be no less than `minKeeperFee`.
-     */
-    function minInitialMargin() external view returns (uint) {
-        return _minInitialMargin();
-    }
-
-    /* ========== MUTATIVE FUNCTIONS ========== */
-
-    /* ---------- Setters --------- */
-
-    function _setParameter(
-        bytes32 _marketKey,
-        bytes32 key,
-        uint value
-    ) internal {
-        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, keccak256(abi.encodePacked(_marketKey, key)), value);
-        emit ParameterUpdated(_marketKey, key, value);
-    }
-
-    function setTakerFee(bytes32 _marketKey, uint _takerFee) public onlyOwner {
-        require(_takerFee <= 1e18, "taker fee greater than 1");
-        _setParameter(_marketKey, PARAMETER_TAKER_FEE, _takerFee);
-    }
-
-    function setMakerFee(bytes32 _marketKey, uint _makerFee) public onlyOwner {
-        require(_makerFee <= 1e18, "maker fee greater than 1");
-        _setParameter(_marketKey, PARAMETER_MAKER_FEE, _makerFee);
-    }
-
-    function setOverrideCommitFee(bytes32 _marketKey, uint _overrideCommitFee) public onlyOwner {
-        _setParameter(_marketKey, PARAMETER_OVERRIDE_COMMIT_FEE, _overrideCommitFee);
-    }
-
-    function setTakerFeeDelayedOrder(bytes32 _marketKey, uint _takerFeeDelayedOrder) public onlyOwner {
-        require(_takerFeeDelayedOrder <= 1e18, "taker fee greater than 1");
-        _setParameter(_marketKey, PARAMETER_TAKER_FEE_DELAYED_ORDER, _takerFeeDelayedOrder);
-    }
-
-    function setMakerFeeDelayedOrder(bytes32 _marketKey, uint _makerFeeDelayedOrder) public onlyOwner {
-        require(_makerFeeDelayedOrder <= 1e18, "maker fee greater than 1");
-        _setParameter(_marketKey, PARAMETER_MAKER_FEE_DELAYED_ORDER, _makerFeeDelayedOrder);
-    }
-
-    function setTakerFeeOffchainDelayedOrder(bytes32 _marketKey, uint _takerFeeOffchainDelayedOrder) public onlyOwner {
-        require(_takerFeeOffchainDelayedOrder <= 1e18, "taker fee greater than 1");
-        _setParameter(_marketKey, PARAMETER_TAKER_FEE_OFFCHAIN_DELAYED_ORDER, _takerFeeOffchainDelayedOrder);
-    }
-
-    function setMakerFeeOffchainDelayedOrder(bytes32 _marketKey, uint _makerFeeOffchainDelayedOrder) public onlyOwner {
-        require(_makerFeeOffchainDelayedOrder <= 1e18, "maker fee greater than 1");
-        _setParameter(_marketKey, PARAMETER_MAKER_FEE_OFFCHAIN_DELAYED_ORDER, _makerFeeOffchainDelayedOrder);
-    }
-
-    function setNextPriceConfirmWindow(bytes32 _marketKey, uint _nextPriceConfirmWindow) public onlyOwner {
-        _setParameter(_marketKey, PARAMETER_NEXT_PRICE_CONFIRM_WINDOW, _nextPriceConfirmWindow);
-    }
-
-    function setDelayedOrderConfirmWindow(bytes32 _marketKey, uint _delayedOrderConfirmWindow) public onlyOwner {
-        _setParameter(_marketKey, PARAMETER_DELAYED_ORDER_CONFIRM_WINDOW, _delayedOrderConfirmWindow);
-    }
-
-    function setOffchainDelayedOrderMinAge(bytes32 _marketKey, uint _offchainDelayedOrderMinAge) public onlyOwner {
-        _setParameter(_marketKey, PARAMETER_OFFCHAIN_DELAYED_ORDER_MIN_AGE, _offchainDelayedOrderMinAge);
-    }
-
-    function setOffchainDelayedOrderMaxAge(bytes32 _marketKey, uint _offchainDelayedOrderMaxAge) public onlyOwner {
-        _setParameter(_marketKey, PARAMETER_OFFCHAIN_DELAYED_ORDER_MAX_AGE, _offchainDelayedOrderMaxAge);
-    }
-
-    function setMaxLeverage(bytes32 _marketKey, uint _maxLeverage) public onlyOwner {
-        _setParameter(_marketKey, PARAMETER_MAX_LEVERAGE, _maxLeverage);
-    }
-
-    function setMaxMarketValue(bytes32 _marketKey, uint _maxMarketValue) public onlyOwner {
-        _setParameter(_marketKey, PARAMETER_MAX_MARKET_VALUE, _maxMarketValue);
-    }
-
-    // Before altering parameters relevant to funding rates, outstanding funding on the underlying market
-    // must be recomputed, otherwise already-accrued but unrealised funding in the market can change.
-
-    function _recomputeFunding(bytes32 _marketKey) internal {
-        address marketAddress = _futuresMarketManager().marketForKey(_marketKey);
-
-        IPerpsV2MarketViews marketView = IPerpsV2MarketViews(marketAddress);
-        if (marketView.marketSize() > 0) {
-            IPerpsV2Market market = IPerpsV2Market(marketAddress);
-            // only recompute funding when market has positions, this check is important for initial setup
-            market.recomputeFunding();
-        }
-    }
-
-    function setMaxFundingVelocity(bytes32 _marketKey, uint _maxFundingVelocity) public onlyOwner {
-        _recomputeFunding(_marketKey);
-        _setParameter(_marketKey, PARAMETER_MAX_FUNDING_VELOCITY, _maxFundingVelocity);
-    }
-
-    function setSkewScale(bytes32 _marketKey, uint _skewScale) public onlyOwner {
-        require(_skewScale > 0, "cannot set skew scale 0");
-        _recomputeFunding(_marketKey);
-        _setParameter(_marketKey, PARAMETER_MIN_SKEW_SCALE, _skewScale);
-    }
-
-    function setMinDelayTimeDelta(bytes32 _marketKey, uint _minDelayTimeDelta) public onlyOwner {
-        _setParameter(_marketKey, PARAMETER_MIN_DELAY_TIME_DELTA, _minDelayTimeDelta);
-    }
-
-    function setMaxDelayTimeDelta(bytes32 _marketKey, uint _maxDelayTimeDelta) public onlyOwner {
-        _setParameter(_marketKey, PARAMETER_MAX_DELAY_TIME_DELTA, _maxDelayTimeDelta);
-    }
-
-    function setOffchainMarketKey(bytes32 _marketKey, bytes32 _offchainMarketKey) public onlyOwner {
-        _flexibleStorage().setBytes32Value(
+        _flexibleStorage().getBytes32Value(
             SETTING_CONTRACT_NAME,
-            keccak256(abi.encodePacked(_marketKey, PARAMETER_OFFCHAIN_MARKET_KEY)),
-            _offchainMarketKey
+            keccak256(abi.encodePacked(_marketKey, PARAMETER_OFFCHAIN_MARKET_KEY))
         );
-        emit ParameterUpdatedBytes32(_marketKey, PARAMETER_OFFCHAIN_MARKET_KEY, _offchainMarketKey);
     }
 
-    /*
-     * The max divergence between onchain and offchain prices for an offchain delayed order execution.
-     */
-    function setOffchainPriceDivergence(bytes32 _marketKey, uint _offchainPriceDivergence) public onlyOwner {
-        _setParameter(_marketKey, PARAMETER_OFFCHAIN_PRICE_DIVERGENCE, _offchainPriceDivergence);
+    function _offchainPriceDivergence(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_OFFCHAIN_PRICE_DIVERGENCE);
     }
 
-    function setLiquidationPremiumMultiplier(bytes32 _marketKey, uint _liquidationPremiumMultiplier) public onlyOwner {
-        require(_liquidationPremiumMultiplier > 0, "cannot set liquidation premium multiplier 0");
-        _setParameter(_marketKey, PARAMETER_LIQUIDATION_PREMIUM_MULTIPLIER, _liquidationPremiumMultiplier);
+    function _liquidationPremiumMultiplier(bytes32 _marketKey) internal view returns (uint) {
+        return _parameter(_marketKey, PARAMETER_LIQUIDATION_PREMIUM_MULTIPLIER);
     }
 
-    function setParameters(bytes32 _marketKey, Parameters calldata _parameters) external onlyOwner {
-        _recomputeFunding(_marketKey);
-        setTakerFee(_marketKey, _parameters.takerFee);
-        setMakerFee(_marketKey, _parameters.makerFee);
-        setOverrideCommitFee(_marketKey, _parameters.overrideCommitFee);
-        setMaxLeverage(_marketKey, _parameters.maxLeverage);
-        setMaxMarketValue(_marketKey, _parameters.maxMarketValue);
-        setMaxFundingVelocity(_marketKey, _parameters.maxFundingVelocity);
-        setSkewScale(_marketKey, _parameters.skewScale);
-        setTakerFeeDelayedOrder(_marketKey, _parameters.takerFeeDelayedOrder);
-        setMakerFeeDelayedOrder(_marketKey, _parameters.makerFeeDelayedOrder);
-        setNextPriceConfirmWindow(_marketKey, _parameters.nextPriceConfirmWindow);
-        setDelayedOrderConfirmWindow(_marketKey, _parameters.delayedOrderConfirmWindow);
-        setMinDelayTimeDelta(_marketKey, _parameters.minDelayTimeDelta);
-        setMaxDelayTimeDelta(_marketKey, _parameters.maxDelayTimeDelta);
-        setTakerFeeOffchainDelayedOrder(_marketKey, _parameters.takerFeeOffchainDelayedOrder);
-        setMakerFeeOffchainDelayedOrder(_marketKey, _parameters.makerFeeOffchainDelayedOrder);
-        setOffchainDelayedOrderMinAge(_marketKey, _parameters.offchainDelayedOrderMinAge);
-        setOffchainDelayedOrderMaxAge(_marketKey, _parameters.offchainDelayedOrderMaxAge);
-        setOffchainMarketKey(_marketKey, _parameters.offchainMarketKey);
-        setOffchainPriceDivergence(_marketKey, _parameters.offchainPriceDivergence);
-        setLiquidationPremiumMultiplier(_marketKey, _parameters.liquidationPremiumMultiplier);
+    function _minKeeperFee() internal view returns (uint) {
+        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_KEEPER_FEE);
     }
 
-    function setMinKeeperFee(uint _sUSD) external onlyOwner {
-        require(_sUSD <= _minInitialMargin(), "min margin < liquidation fee");
-        if (_maxKeeperFee() > 0) {
-            // only check if already set
-            require(_sUSD <= _maxKeeperFee(), "max fee < min fee");
-        }
-        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_KEEPER_FEE, _sUSD);
-        emit MinKeeperFeeUpdated(_sUSD);
+    function _maxKeeperFee() internal view returns (uint) {
+        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_MAX_KEEPER_FEE);
     }
 
-    function setMaxKeeperFee(uint _sUSD) external onlyOwner {
-        require(_sUSD >= _minKeeperFee(), "max fee < min fee");
-        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_MAX_KEEPER_FEE, _sUSD);
-        emit MaxKeeperFeeUpdated(_sUSD);
+    function _liquidationFeeRatio() internal view returns (uint) {
+        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_FEE_RATIO);
     }
 
-    function setLiquidationFeeRatio(uint _ratio) external onlyOwner {
-        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_FEE_RATIO, _ratio);
-        emit LiquidationFeeRatioUpdated(_ratio);
+    function _liquidationBufferRatio() internal view returns (uint) {
+        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_BUFFER_RATIO);
     }
 
-    function setLiquidationBufferRatio(uint _ratio) external onlyOwner {
-        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_LIQUIDATION_BUFFER_RATIO, _ratio);
-        emit LiquidationBufferRatioUpdated(_ratio);
+    function _minInitialMargin() internal view returns (uint) {
+        return _flexibleStorage().getUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_INITIAL_MARGIN);
     }
-
-    function setMinInitialMargin(uint _minMargin) external onlyOwner {
-        require(_minKeeperFee() <= _minMargin, "min margin < liquidation fee");
-        _flexibleStorage().setUIntValue(SETTING_CONTRACT_NAME, SETTING_MIN_INITIAL_MARGIN, _minMargin);
-        emit MinInitialMarginUpdated(_minMargin);
-    }
-
-    /* ========== EVENTS ========== */
-
-    event ParameterUpdated(bytes32 indexed marketKey, bytes32 indexed parameter, uint value);
-    event ParameterUpdatedBytes32(bytes32 indexed marketKey, bytes32 indexed parameter, bytes32 value);
-    event MinKeeperFeeUpdated(uint sUSD);
-    event MaxKeeperFeeUpdated(uint sUSD);
-    event LiquidationFeeRatioUpdated(uint bps);
-    event LiquidationBufferRatioUpdated(uint bps);
-    event MinInitialMarginUpdated(uint minMargin);
 }

--- a/contracts/frozen/FrozenPerpsV2MarketBase.sol
+++ b/contracts/frozen/FrozenPerpsV2MarketBase.sol
@@ -4,7 +4,7 @@ pragma experimental ABIEncoderV2;
 import "./../Owned.sol";
 
 // Inheritance
-import "./../MixinPerpsV2MarketSettings.sol";
+import "./FrozenMixinPerpsV2MarketSettings.sol";
 import "./../interfaces/IPerpsV2MarketBaseTypes.sol";
 
 // Libraries
@@ -32,7 +32,7 @@ interface IFuturesMarketManagerInternal {
 }
 
 // https://docs.synthetix.io/contracts/source/contracts/PerpsV2MarketBase
-contract FrozenPerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketBaseTypes {
+contract FrozenPerpsV2MarketBase is Owned, FrozenMixinPerpsV2MarketSettings, IPerpsV2MarketBaseTypes {
     /* ========== LIBRARIES ========== */
 
     using SafeMath for uint;
@@ -82,7 +82,7 @@ contract FrozenPerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2M
         address _marketState,
         address _owner,
         address _resolver
-    ) public MixinPerpsV2MarketSettings(_resolver) Owned(_owner) {
+    ) public FrozenMixinPerpsV2MarketSettings(_resolver) Owned(_owner) {
         marketState = IPerpsV2MarketState(_marketState);
 
         // Set up the mapping between error codes and their revert messages.
@@ -104,7 +104,7 @@ contract FrozenPerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2M
     /* ---------- External Contracts ---------- */
 
     function resolverAddressesRequired() public view returns (bytes32[] memory addresses) {
-        bytes32[] memory existingAddresses = MixinPerpsV2MarketSettings.resolverAddressesRequired();
+        bytes32[] memory existingAddresses = FrozenMixinPerpsV2MarketSettings.resolverAddressesRequired();
         bytes32[] memory newAddresses = new bytes32[](6);
         newAddresses[0] = CONTRACT_EXCHANGER;
         newAddresses[1] = CONTRACT_EXRATES;

--- a/contracts/interfaces/IPerpsV2MarketSettings.sol
+++ b/contracts/interfaces/IPerpsV2MarketSettings.sol
@@ -5,7 +5,6 @@ interface IPerpsV2MarketSettings {
     struct Parameters {
         uint takerFee;
         uint makerFee;
-        uint overrideCommitFee;
         uint takerFeeDelayedOrder;
         uint makerFeeDelayedOrder;
         uint takerFeeOffchainDelayedOrder;
@@ -64,8 +63,6 @@ interface IPerpsV2MarketSettings {
     function offchainPriceDivergence(bytes32 _marketKey) external view returns (uint);
 
     function liquidationPremiumMultiplier(bytes32 _marketKey) external view returns (uint);
-
-    function overrideCommitFee(bytes32 _marketKey) external view returns (uint);
 
     function maxPD(bytes32 _marketKey) external view returns (uint);
 

--- a/test/contracts/PerpsV2Market.delayedOrder.js
+++ b/test/contracts/PerpsV2Market.delayedOrder.js
@@ -21,8 +21,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 		circuitBreaker,
 		sUSD,
 		systemSettings,
-		systemStatus,
-		feePool;
+		systemStatus;
 
 	const owner = accounts[1];
 	const trader = accounts[2];
@@ -73,7 +72,6 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 			ExchangeRates: exchangeRates,
 			CircuitBreaker: circuitBreaker,
 			SynthsUSD: sUSD,
-			FeePool: feePool,
 			SystemSettings: systemSettings,
 			SystemStatus: systemStatus,
 		} = await setupAllContracts({
@@ -116,7 +114,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 
 	addSnapshotBeforeRestoreAfterEach();
 
-	let margin, size, price, fillPrice, desiredTimeDelta, minDelayTimeDelta;
+	let margin, size, price, fillPrice, desiredTimeDelta, minDelayTimeDelta, confirmTimeWindow;
 
 	beforeEach(async () => {
 		// prepare basic order parameters
@@ -126,6 +124,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 		price = toUnit('200');
 		desiredTimeDelta = 60;
 		minDelayTimeDelta = 60;
+		confirmTimeWindow = 30;
 		await setPrice(baseAsset, price);
 		fillPrice = (await perpsV2MarketHelper.fillPriceWithBasePrice(size, 0))[0];
 	});
@@ -134,7 +133,6 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 		it('submitting an order results in correct views and events', async () => {
 			// setup
 			const roundId = await exchangeRates.getCurrentRoundId(baseAsset);
-			const orderFee = (await perpsV2Market.orderFee(size, orderType))[0];
 			const keeperFee = await perpsV2MarketSettings.minKeeperFee();
 			const tx = await perpsV2Market.submitDelayedOrder(size, priceImpactDelta, desiredTimeDelta, {
 				from: trader,
@@ -144,13 +142,13 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 			const order = await perpsV2MarketState.delayedOrders(trader);
 			assert.bnEqual(order.sizeDelta, size);
 			assert.bnEqual(order.targetRoundId, roundId.add(toBN(1)));
-			assert.bnEqual(order.commitDeposit, orderFee);
+			assert.bnEqual(order.commitDeposit, 0);
 			assert.bnEqual(order.keeperDeposit, keeperFee);
 			assert.bnEqual(order.executableAtTime, txBlock.timestamp + desiredTimeDelta);
 
 			// check margin
 			const position = await perpsV2Market.positions(trader);
-			const expectedMargin = margin.sub(orderFee.add(keeperFee));
+			const expectedMargin = margin.sub(keeperFee);
 			assert.bnEqual(position.margin, expectedMargin);
 
 			// The relevant events are properly emitted
@@ -176,7 +174,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 					roundId.add(toBN(1)),
 					txBlock.timestamp,
 					order.executableAtTime,
-					orderFee,
+					0,
 					keeperFee,
 				],
 				log: decodedLogs[2],
@@ -418,7 +416,6 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 		it('submitting an order results in correct views and events', async () => {
 			// setup
 			const roundId = await exchangeRates.getCurrentRoundId(baseAsset);
-			const orderFee = (await perpsV2Market.orderFee(size, orderType))[0];
 			const keeperFee = await perpsV2MarketSettings.minKeeperFee();
 
 			const tx = await perpsV2Market.submitDelayedOrderWithTracking(
@@ -436,7 +433,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 			const order = await perpsV2MarketState.delayedOrders(trader);
 			assert.bnEqual(order.sizeDelta, size);
 			assert.bnEqual(order.targetRoundId, roundId.add(toBN(1)));
-			assert.bnEqual(order.commitDeposit, orderFee);
+			assert.bnEqual(order.commitDeposit, 0);
 			assert.bnEqual(order.keeperDeposit, keeperFee);
 			assert.bnEqual(order.executableAtTime, txBlock.timestamp + desiredTimeDelta);
 			assert.bnEqual(order.trackingCode, trackingCode);
@@ -457,7 +454,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 					roundId.add(toBN(1)),
 					txBlock.timestamp,
 					order.executableAtTime,
-					orderFee,
+					0,
 					keeperFee,
 					trackingCode,
 				],
@@ -601,7 +598,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 		});
 
 		describe('when an order exists', () => {
-			let roundId, orderFee, keeperFee;
+			let roundId, keeperFee;
 
 			// helper function to check cancellation tx effects
 			async function checkCancellation(from) {
@@ -621,12 +618,15 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 					hash: tx.tx,
 					contracts: [sUSD, perpsV2Market, perpsV2MarketDelayedIntent],
 				});
+				const decodedLogNames = decodedLogs.map(({ name }) => name);
 
 				if (from === trader) {
+					assert.deepEqual(decodedLogNames, [
+						'FundingRecomputed',
+						'PositionModified',
+						'DelayedOrderRemoved',
+					]);
 					// trader gets refunded
-					assert.equal(decodedLogs.length, 4);
-					// keeper fee was refunded
-					// PositionModified
 					decodedEventEqual({
 						event: 'PositionModified',
 						emittedFrom: perpsV2Market.address,
@@ -635,7 +635,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 					});
 				} else {
 					// keeper gets paid
-					assert.equal(decodedLogs.length, 3);
+					assert.deepEqual(decodedLogNames, ['Issued', 'DelayedOrderRemoved']);
 					decodedEventEqual({
 						event: 'Issued',
 						emittedFrom: sUSD.address,
@@ -644,17 +644,10 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 					});
 				}
 
-				// commitFee (equal to orderFee) paid to fee pool
-				decodedEventEqual({
-					event: 'Issued',
-					emittedFrom: sUSD.address,
-					args: [await feePool.FEE_ADDRESS(), orderFee],
-					log: decodedLogs.slice(-2, -1)[0], // [-2]
-				});
 				decodedEventEqual({
 					event: 'DelayedOrderRemoved',
 					emittedFrom: perpsV2Market.address,
-					args: [trader, false, roundId, size, roundId.add(toBN(1)), orderFee, keeperFee],
+					args: [trader, false, roundId, size, roundId.add(toBN(1)), 0, keeperFee],
 					log: decodedLogs.slice(-1)[0],
 				});
 
@@ -670,7 +663,6 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 
 			beforeEach(async () => {
 				roundId = await exchangeRates.getCurrentRoundId(baseAsset);
-				orderFee = (await perpsV2Market.orderFee(size, orderType))[0];
 				keeperFee = await perpsV2MarketSettings.minKeeperFee();
 				await perpsV2Market.submitDelayedOrder(size, priceImpactDelta, desiredTimeDelta, {
 					from: trader,
@@ -678,7 +670,10 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 			});
 
 			it('cannot cancel if perps markets are suspended', async () => {
+				// Fast-forward to allow for cancelling but revert because suspended.
 				await systemStatus.suspendFutures(toUnit(0), { from: owner });
+				await fastForward(minDelayTimeDelta + confirmTimeWindow + 1); // ff min + confirm + 1s buffer.
+
 				await assert.revert(
 					perpsV2Market.cancelDelayedOrder(trader, { from: trader }),
 					'Futures markets are suspended'
@@ -686,24 +681,36 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 			});
 
 			it('cannot cancel if market is suspended', async () => {
+				// Fast-forward to allow for cancelling but revert because suspended.
 				await systemStatus.suspendFuturesMarket(marketKey, toUnit(0), { from: owner });
+				await fastForward(minDelayTimeDelta + confirmTimeWindow + 1); // ff min + confirm + 1s buffer.
+
 				await assert.revert(
 					perpsV2Market.cancelDelayedOrder(trader, { from: trader }),
 					'Market suspended'
 				);
 			});
 
-			describe('account owner can cancel', () => {
+			describe('account owner cannot cancel', () => {
 				it('in same round', async () => {
-					await checkCancellation(trader);
+					await assert.revert(
+						perpsV2Market.cancelDelayedOrder(trader, { from: trader }),
+						'cannot be cancelled by keeper yet'
+					);
 				});
 
 				it('in target round', async () => {
 					await setPrice(baseAsset, price);
-					await checkCancellation(trader);
+					await assert.revert(
+						perpsV2Market.cancelDelayedOrder(trader, { from: trader }),
+						'cannot be cancelled by keeper yet'
+					);
 				});
+			});
 
+			describe('account owner can cancel', () => {
 				it('after confirmation window', async () => {
+					await setPrice(baseAsset, price);
 					await setPrice(baseAsset, price);
 					await setPrice(baseAsset, price);
 					await setPrice(baseAsset, price);
@@ -725,10 +732,16 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 				});
 
 				it('by account owner', async () => {
+					await setPrice(baseAsset, price);
+					await setPrice(baseAsset, price);
+					await setPrice(baseAsset, price);
+					await setPrice(baseAsset, price);
+					// can only be cancellable after confirmation window
 					await checkCancellation(trader);
 				});
 
 				it('by non-account owner, after confirmation window', async () => {
+					await setPrice(baseAsset, price);
 					await setPrice(baseAsset, price);
 					await setPrice(baseAsset, price);
 					await setPrice(baseAsset, price);
@@ -791,7 +804,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 
 					// time has moved forward (no change to round) but not enough.
 					const order = await perpsV2MarketState.delayedOrders(trader);
-					const exectuableAtTimeDelta = order.executableAtTime.sub(toBN(timestamp)).toNumber();
+					const executableAtTimeDelta = order.executableAtTime.sub(toBN(timestamp)).toNumber();
 					await fastForward(ffDelta); // fast-forward by 5 seconds
 					await assert.revert(
 						perpsV2Market.cancelDelayedOrder(trader, { from: trader2 }),
@@ -799,7 +812,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 					);
 
 					// time has moved forward, order is executable but cancellable
-					await fastForward(exectuableAtTimeDelta - ffDelta + 1);
+					await fastForward(executableAtTimeDelta - ffDelta + 1);
 					await assert.revert(
 						perpsV2Market.cancelDelayedOrder(trader, { from: trader2 }),
 						'cannot be cancelled by keeper yet'
@@ -828,7 +841,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 		});
 
 		describe('when an order exists', () => {
-			let roundId, orderFee, keeperFee;
+			let roundId, keeperFee;
 
 			beforeEach(async () => {
 				// the beginning of each test, `trader` submits a delayed order with `size`.
@@ -839,8 +852,6 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 				roundId = await exchangeRates.getCurrentRoundId(baseAsset);
 				// keeperFee is the minimum keeperFee for the system
 				keeperFee = await perpsV2MarketSettings.minKeeperFee();
-				// commitFee is the fee that would be charged for a trade when order is submitted
-				orderFee = (await perpsV2Market.orderFee(size, orderType))[0];
 
 				await perpsV2Market.submitDelayedOrder(size, priceImpactDelta, desiredTimeDelta, {
 					from: trader,
@@ -947,13 +958,22 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 					contracts: [sUSD, perpsV2Market, perpsV2MarketDelayedIntent],
 				});
 
-				let expectedRefund = orderFee; // at least the commitFee is refunded
+				let expectedRefund = toUnit('0'); // $0 refund because we don't take a commitFee.
 				if (from === trader) {
 					// trader gets refunded keeperFee
 					expectedRefund = expectedRefund.add(keeperFee);
 					// no event for keeper payment
 					assert.equal(decodedLogs.length, 5);
-					// funding, position(refund), issued (exchange fee), position(trade), order removed
+					assert.deepEqual(
+						decodedLogs.map(({ name }) => name),
+						[
+							'FundingRecomputed',
+							'PositionModified',
+							'Issued',
+							'PositionModified',
+							'DelayedOrderRemoved',
+						]
+					);
 				} else {
 					// keeper gets paid
 					assert.equal(decodedLogs.length, 6);
@@ -995,7 +1015,7 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 				decodedEventEqual({
 					event: 'DelayedOrderRemoved',
 					emittedFrom: perpsV2Market.address,
-					args: [trader, false, roundId, size, roundId.add(toBN(1)), orderFee, keeperFee],
+					args: [trader, false, roundId, size, roundId.add(toBN(1)), toUnit('0'), keeperFee],
 					log: decodedLogs.slice(-1)[0],
 				});
 
@@ -1209,12 +1229,16 @@ contract('PerpsV2Market PerpsV2MarketDelayedOrders', accounts => {
 				await setPrice(baseAsset, spikedPrice);
 			});
 
-			it('canceling an order works', async () => {
-				await perpsV2Market.cancelDelayedOrder(trader, { from: trader });
+			it('cannot cancel an order', async () => {
+				await assert.revert(
+					perpsV2Market.cancelDelayedOrder(trader, { from: trader }),
+					'cannot be cancelled by keeper yet'
+				);
 			});
 
 			it('submitting an order reverts', async () => {
 				// cancel existing
+				await fastForward(minDelayTimeDelta + confirmTimeWindow + 1); // ff min + confirm + 1s buffer.
 				await perpsV2Market.cancelDelayedOrder(trader, { from: trader });
 
 				await assert.revert(

--- a/test/contracts/PerpsV2Market.js
+++ b/test/contracts/PerpsV2Market.js
@@ -6255,7 +6255,7 @@ contract('PerpsV2Market PerpsV2MarketAtomic', accounts => {
 				await assert.revert(
 					perpsV2MarketSettings.setParameters(
 						marketKey,
-						[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, toBytes32(''), 0, 1, 0, 0],
+						[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, toBytes32(''), 0, 1, 0, 0],
 						{
 							from: owner,
 						}
@@ -6329,7 +6329,7 @@ contract('PerpsV2Market PerpsV2MarketAtomic', accounts => {
 				await perpsV2MarketSettings.setSkewScale(marketKey, toUnit('100'), { from: owner });
 				await perpsV2MarketSettings.setParameters(
 					marketKey,
-					[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, toBytes32(''), 0, 1, 0, 0],
+					[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, toBytes32(''), 0, 1, 0, 0],
 					{
 						from: owner,
 					}
@@ -6341,7 +6341,7 @@ contract('PerpsV2Market PerpsV2MarketAtomic', accounts => {
 				await assert.revert(
 					perpsV2MarketSettings.setParameters(
 						marketKey,
-						[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, toBytes32(''), 0, 1, 0, 0],
+						[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, toBytes32(''), 0, 1, 0, 0],
 						{
 							from: owner,
 						}
@@ -6498,7 +6498,7 @@ contract('PerpsV2Market PerpsV2MarketAtomic', accounts => {
 				await perpsV2MarketSettings.setSkewScale(marketKey, toUnit('100'), { from: owner });
 				await perpsV2MarketSettings.setParameters(
 					marketKey,
-					[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, toBytes32(''), 0, 1, 0, 0],
+					[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, toBytes32(''), 0, 1, 0, 0],
 					{
 						from: owner,
 					}
@@ -6577,7 +6577,7 @@ contract('PerpsV2Market PerpsV2MarketAtomic', accounts => {
 				await perpsV2MarketSettings.setSkewScale(marketKey, toUnit('100'), { from: owner });
 				await perpsV2MarketSettings.setParameters(
 					marketKey,
-					[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, toBytes32(''), 0, 1, 0, 0],
+					[0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, toBytes32(''), 0, 1, 0, 0],
 					{
 						from: owner,
 					}

--- a/test/contracts/PerpsV2Market.offchainDelayedOrder.js
+++ b/test/contracts/PerpsV2Market.offchainDelayedOrder.js
@@ -721,7 +721,6 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			beforeEach(async () => {
 				// keeperFee is the minimum keeperFee for the system
 				keeperFee = await perpsV2MarketSettings.minKeeperFee();
-				// commitFee is the fee that would be charged for a trade when order is submitted
 			});
 
 			async function submitOffchainOrderAndDelay(delay, feedTimeOffset = 0) {
@@ -958,12 +957,9 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				describe('if off-chain virtual market is paused', () => {
 					beforeEach('submitOrder and prepare updateFeedData', async () => {
 						const ocMarketKet = await perpsV2MarketSettings.offchainMarketKey(marketKey);
-						// commitFee is the fee that would be charged for a trade when order is submitted
-						// keeperFee is the minimum keeperFee for the system
 						keeperFee = await perpsV2MarketSettings.minKeeperFee();
 
 						await setOnchainPrice(baseAsset, price);
-
 						await submitOffchainOrderAndDelay(offchainDelayedOrderMinAge + 1);
 
 						updateFeedData = await getFeedUpdateData({

--- a/test/contracts/PerpsV2Market.offchainDelayedOrder.js
+++ b/test/contracts/PerpsV2Market.offchainDelayedOrder.js
@@ -716,13 +716,12 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 		});
 
 		describe('when an order exists', () => {
-			let commitFee, keeperFee, updateFeedData;
+			let keeperFee, updateFeedData;
 
 			beforeEach(async () => {
 				// keeperFee is the minimum keeperFee for the system
 				keeperFee = await perpsV2MarketSettings.minKeeperFee();
 				// commitFee is the fee that would be charged for a trade when order is submitted
-				commitFee = (await perpsV2Market.orderFee(size, orderType))[0];
 			});
 
 			async function submitOffchainOrderAndDelay(delay, feedTimeOffset = 0) {
@@ -748,8 +747,6 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			describe('execution reverts', () => {
 				describe('if min age was not reached', () => {
 					beforeEach('submitOrder and prepare updateFeedData', async () => {
-						// commitFee is the fee that would be charged for a trade when order is submitted
-						commitFee = (await perpsV2Market.orderFee(size, orderType))[0];
 						// keeperFee is the minimum keeperFee for the system
 						keeperFee = await perpsV2MarketSettings.minKeeperFee();
 
@@ -776,8 +773,6 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 
 				describe('if max age was exceeded for order', () => {
 					beforeEach('submitOrder and prepare updateFeedData', async () => {
-						// commitFee is the fee that would be charged for a trade when order is submitted
-						commitFee = (await perpsV2Market.orderFee(size, orderType))[0];
 						// keeperFee is the minimum keeperFee for the system
 						keeperFee = await perpsV2MarketSettings.minKeeperFee();
 
@@ -804,8 +799,6 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 
 				describe('if max age was exceeded for price', () => {
 					beforeEach('submitOrder and prepare updateFeedData', async () => {
-						// commitFee is the fee that would be charged for a trade when order is submitted
-						commitFee = (await perpsV2Market.orderFee(size, orderType))[0];
 						// keeperFee is the minimum keeperFee for the system
 						keeperFee = await perpsV2MarketSettings.minKeeperFee();
 
@@ -839,8 +832,6 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 
 				describe('orders on time', () => {
 					beforeEach('submitOrder and prepare updateFeedData', async () => {
-						// commitFee is the fee that would be charged for a trade when order is submitted
-						commitFee = (await perpsV2Market.orderFee(size, orderType))[0];
 						// keeperFee is the minimum keeperFee for the system
 						keeperFee = await perpsV2MarketSettings.minKeeperFee();
 
@@ -891,8 +882,6 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 
 				describe('if off-chain price is zero', () => {
 					beforeEach('submitOrder and prepare updateFeedData', async () => {
-						// commitFee is the fee that would be charged for a trade when order is submitted
-						commitFee = (await perpsV2Market.orderFee(size, orderType))[0];
 						// keeperFee is the minimum keeperFee for the system
 						keeperFee = await perpsV2MarketSettings.minKeeperFee();
 
@@ -918,8 +907,6 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 
 				describe('off-chain is a lot higher than diverts', () => {
 					beforeEach('submitOrder and prepare updateFeedData', async () => {
-						// commitFee is the fee that would be charged for a trade when order is submitted
-						commitFee = (await perpsV2Market.orderFee(size, orderType))[0];
 						// keeperFee is the minimum keeperFee for the system
 						keeperFee = await perpsV2MarketSettings.minKeeperFee();
 
@@ -945,8 +932,6 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 
 				describe('on-chain is a lot higher than diverts', () => {
 					beforeEach('submitOrder and prepare updateFeedData', async () => {
-						// commitFee is the fee that would be charged for a trade when order is submitted
-						commitFee = (await perpsV2Market.orderFee(size, orderType))[0];
 						// keeperFee is the minimum keeperFee for the system
 						keeperFee = await perpsV2MarketSettings.minKeeperFee();
 
@@ -974,7 +959,6 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 					beforeEach('submitOrder and prepare updateFeedData', async () => {
 						const ocMarketKet = await perpsV2MarketSettings.offchainMarketKey(marketKey);
 						// commitFee is the fee that would be charged for a trade when order is submitted
-						commitFee = (await perpsV2Market.orderFee(size, orderType))[0];
 						// keeperFee is the minimum keeperFee for the system
 						keeperFee = await perpsV2MarketSettings.minKeeperFee();
 

--- a/test/contracts/PerpsV2Market.offchainDelayedOrder.js
+++ b/test/contracts/PerpsV2Market.offchainDelayedOrder.js
@@ -24,7 +24,6 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 		sUSD,
 		systemSettings,
 		systemStatus,
-		feePool,
 		debtCache;
 
 	const owner = accounts[1];
@@ -113,7 +112,6 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			ExchangeRates: exchangeRates,
 			CircuitBreaker: circuitBreaker,
 			SynthsUSD: sUSD,
-			FeePool: feePool,
 			SystemSettings: systemSettings,
 			SystemStatus: systemStatus,
 			DebtCache: debtCache,
@@ -212,7 +210,6 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 		it('submitting an order results in correct views and events', async () => {
 			// setup
 			const roundId = await exchangeRates.getCurrentRoundId(baseAsset);
-			const orderFee = (await perpsV2Market.orderFee(size, orderType))[0];
 			const keeperFee = await perpsV2MarketSettings.minKeeperFee();
 
 			const fillPrice = (await perpsV2MarketHelper.fillPriceWithBasePrice(size, 0))[0];
@@ -225,13 +222,13 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			const order = await perpsV2MarketState.delayedOrders(trader);
 			assert.bnEqual(order.sizeDelta, size);
 			assert.bnEqual(order.targetRoundId, 0);
-			assert.bnEqual(order.commitDeposit, orderFee);
+			assert.bnEqual(order.commitDeposit, 0);
 			assert.bnEqual(order.keeperDeposit, keeperFee);
 			assert.bnEqual(order.executableAtTime, 0);
 
 			// check margin
 			const position = await perpsV2Market.positions(trader);
-			const expectedMargin = margin.sub(orderFee.add(keeperFee));
+			const expectedMargin = margin.sub(keeperFee);
 			assert.bnEqual(position.margin, expectedMargin);
 
 			// The relevant events are properly emitted
@@ -249,7 +246,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			decodedEventEqual({
 				event: 'DelayedOrderSubmitted',
 				emittedFrom: perpsV2Market.address,
-				args: [trader, true, size, roundId.add(toBN(1)), txBlock.timestamp, 0, orderFee, keeperFee],
+				args: [trader, true, size, roundId.add(toBN(1)), txBlock.timestamp, 0, 0, keeperFee],
 				log: decodedLogs[2],
 			});
 		});
@@ -321,7 +318,6 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 		it('submitting an order results in correct views and events', async () => {
 			// setup
 			const roundId = await exchangeRates.getCurrentRoundId(baseAsset);
-			const orderFee = (await perpsV2Market.orderFee(size, orderType))[0];
 			const keeperFee = await perpsV2MarketSettings.minKeeperFee();
 
 			const tx = await perpsV2Market.submitOffchainDelayedOrderWithTracking(
@@ -338,7 +334,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 			const order = await perpsV2MarketState.delayedOrders(trader);
 			assert.bnEqual(order.sizeDelta, size);
 			assert.bnEqual(order.targetRoundId, 0);
-			assert.bnEqual(order.commitDeposit, orderFee);
+			assert.bnEqual(order.commitDeposit, 0);
 			assert.bnEqual(order.keeperDeposit, keeperFee);
 			assert.bnEqual(order.executableAtTime, 0);
 			assert.bnEqual(order.trackingCode, trackingCode);
@@ -359,7 +355,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 					roundId.add(toBN(1)),
 					txBlock.timestamp,
 					0,
-					orderFee,
+					0,
 					keeperFee,
 					trackingCode,
 				],
@@ -483,7 +479,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 		});
 
 		describe('when an order exists', () => {
-			let roundId, orderFee, keeperFee;
+			let roundId, keeperFee;
 
 			// helper function to check cancellation tx effects
 			async function checkCancellation(from) {
@@ -508,12 +504,15 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 						perpsV2MarketDelayedIntent,
 					],
 				});
+				const decodedLogNames = decodedLogs.map(({ name }) => name);
 
 				if (from === trader) {
+					assert.deepEqual(decodedLogNames, [
+						'FundingRecomputed',
+						'PositionModified',
+						'DelayedOrderRemoved',
+					]);
 					// trader gets refunded
-					assert.equal(decodedLogs.length, 4);
-					// keeper fee was refunded
-					// PositionModified
 					decodedEventEqual({
 						event: 'PositionModified',
 						emittedFrom: perpsV2Market.address,
@@ -522,7 +521,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 					});
 				} else {
 					// keeper gets paid
-					assert.equal(decodedLogs.length, 3);
+					assert.deepEqual(decodedLogNames, ['Issued', 'DelayedOrderRemoved']);
 					decodedEventEqual({
 						event: 'Issued',
 						emittedFrom: sUSD.address,
@@ -531,18 +530,10 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 					});
 				}
 
-				// commitFee (equal to orderFee) paid to fee pool
-				decodedEventEqual({
-					event: 'Issued',
-					emittedFrom: sUSD.address,
-					args: [await feePool.FEE_ADDRESS(), orderFee],
-					log: decodedLogs.slice(-2, -1)[0], // [-2]
-				});
-
 				decodedEventEqual({
 					event: 'DelayedOrderRemoved',
 					emittedFrom: perpsV2Market.address,
-					args: [trader, true, roundId, size, roundId.add(toBN(1)), orderFee, keeperFee],
+					args: [trader, true, roundId, size, roundId.add(toBN(1)), 0, keeperFee],
 					log: decodedLogs.slice(-1)[0],
 				});
 
@@ -556,7 +547,6 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 
 			beforeEach(async () => {
 				roundId = await exchangeRates.getCurrentRoundId(baseAsset);
-				orderFee = (await perpsV2Market.orderFee(size, orderType))[0];
 				keeperFee = await perpsV2MarketSettings.minKeeperFee();
 				await perpsV2Market.submitOffchainDelayedOrder(size, priceImpactDelta, { from: trader });
 			});
@@ -1053,7 +1043,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 					],
 				});
 
-				let expectedRefund = commitFee; // at least the commitFee is refunded
+				let expectedRefund = toUnit('0');
 				if (from === trader) {
 					// trader gets refunded keeperFee
 					expectedRefund = expectedRefund.add(keeperFee);
@@ -1101,7 +1091,7 @@ contract('PerpsV2Market PerpsV2MarketOffchainOrders', accounts => {
 				decodedEventEqual({
 					event: 'DelayedOrderRemoved',
 					emittedFrom: perpsV2Market.address,
-					args: [trader, true, roundId, size, roundId.add(toBN(1)), commitFee, keeperFee],
+					args: [trader, true, roundId, size, roundId.add(toBN(1)), toUnit('0'), keeperFee],
 					log: decodedLogs.slice(-1)[0],
 				});
 

--- a/test/contracts/PerpsV2MarketData.js
+++ b/test/contracts/PerpsV2MarketData.js
@@ -206,7 +206,6 @@ contract('PerpsV2MarketData', accounts => {
 				[
 					toUnit('0.005'), // 0.5% taker fee
 					toUnit('0.001'), // 0.1% maker fee
-					toUnit('0'), // 0% override commit fee for delayed/offchain order
 					toUnit('0.0005'), // 0.05% taker fee delayed order
 					toUnit('0'), // 0% maker fee delayed order
 					toUnit('0.00005'), // 0.005% taker fee offchain delayed order
@@ -305,7 +304,6 @@ contract('PerpsV2MarketData', accounts => {
 			assert.equal(details.baseAsset, baseAsset);
 			assert.bnEqual(details.feeRates.takerFee, params.takerFee);
 			assert.bnEqual(details.feeRates.makerFee, params.makerFee);
-			assert.bnEqual(details.feeRates.overrideCommitFee, params.overrideCommitFee);
 			assert.bnEqual(details.feeRates.takerFeeDelayedOrder, params.takerFeeDelayedOrder);
 			assert.bnEqual(details.feeRates.makerFeeDelayedOrder, params.makerFeeDelayedOrder);
 			assert.bnEqual(

--- a/test/contracts/PerpsV2MarketManager.js
+++ b/test/contracts/PerpsV2MarketManager.js
@@ -1029,7 +1029,6 @@ contract('FuturesMarketManager (PerpsV2)', accounts => {
 					[
 						toUnit('0.005'), // 0.5% taker fee
 						toUnit('0.001'), // 0.1% maker fee
-						toUnit('0'), // 0% override commit fee for delayed/offchain order
 						toUnit('0.0005'), // 0.05% taker fee delayed order
 						toUnit('0'), // 0% maker fee delayed order
 						toUnit('0.00005'), // 0.005% taker fee offchain delayed order

--- a/test/contracts/PerpsV2MarketSettings.js
+++ b/test/contracts/PerpsV2MarketSettings.js
@@ -34,7 +34,6 @@ contract('PerpsV2MarketSettings', accounts => {
 	const makerFeeDelayedOrder = toUnit('0.0001');
 	const takerFeeOffchainDelayedOrder = toUnit('0.00005');
 	const makerFeeOffchainDelayedOrder = toUnit('0.00001');
-	const overrideCommitFee = toUnit('0');
 
 	const nextPriceConfirmWindow = toBN('2');
 
@@ -158,7 +157,6 @@ contract('PerpsV2MarketSettings', accounts => {
 				'setDelayedOrderConfirmWindow',
 				'setOffchainDelayedOrderMinAge',
 				'setOffchainDelayedOrderMaxAge',
-				'setOverrideCommitFee',
 				'setMaxLeverage',
 				'setMaxMarketValue',
 				'setMaxFundingVelocity',
@@ -182,7 +180,6 @@ contract('PerpsV2MarketSettings', accounts => {
 			params = Object.entries({
 				takerFee,
 				makerFee,
-				overrideCommitFee,
 				takerFeeDelayedOrder,
 				makerFeeDelayedOrder,
 				takerFeeOffchainDelayedOrder,

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -2007,8 +2007,8 @@ const setupAllContracts = async ({
 							60, // 60s minimum delay time in seconds
 							120, // 120s maximum delay time in seconds
 
-							15, // 20s offchain min delay window
-							60, // 20s offchain max delay window
+							15, // 15s offchain min delay window
+							60, // 60s offchain max delay window
 
 							offchainMarketKey, // offchain market key
 							toUnit('0.06'), // offchain price divergence 6%

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -1991,7 +1991,6 @@ const setupAllContracts = async ({
 						[
 							toWei('0.003'), // 0.3% taker fee
 							toWei('0.001'), // 0.1% maker fee
-							toWei('0'), // 0 override commit fee
 							toWei('0.0005'), // 0.05% taker fee delayed order
 							toWei('0.0001'), // 0.01% maker fee delayed order
 							toWei('0.00005'), // 0.005% taker fee offchain delayed order


### PR DESCRIPTION
This PR implements the SIP defined here: https://github.com/Synthetixio/SIPs/pull/1452 (https://sips.synthetix.io/sips/sip-2004/)

In summary, it removes the commitment fee charged upon submission and removes the ability to cancel an order during the confirmation window. This change also updates a variety of tests to reflect the new change and removes the overrideCommitFee SCCP param as it's now redundant.