### PR TITLE
Fix test deploy job and dual int tests

### DIFF
--- a/test/integration/behaviors/stake.behavior.js
+++ b/test/integration/behaviors/stake.behavior.js
@@ -10,6 +10,7 @@ function itCanStake({ ctx }) {
 		const SNXAmount = ethers.utils.parseEther('1000');
 		const amountToIssueAndBurnsUSD = ethers.utils.parseEther('1');
 
+		let tx;
 		let user, owner;
 		let AddressResolver, Synthetix, SynthetixDebtShare, SynthsUSD, Issuer;
 		let balancesUSD, debtsUSD;
@@ -25,17 +26,23 @@ function itCanStake({ ctx }) {
 			const MockAggregatorFactory = await createMockAggregatorFactory(owner);
 			const aggregator = (await MockAggregatorFactory.deploy()).connect(owner);
 
-			await aggregator.setDecimals(27);
+			tx = await aggregator.setDecimals(27);
+			await tx.wait();
+
 			const { timestamp } = await ctx.provider.getBlock();
 			// debt share ratio of 0.5
-			await aggregator.setLatestAnswer(ethers.utils.parseUnits('0.5', 27), timestamp);
+			tx = await aggregator.setLatestAnswer(ethers.utils.parseUnits('0.5', 27), timestamp);
+			await tx.wait();
 
 			AddressResolver = AddressResolver.connect(owner);
-			await AddressResolver.importAddresses(
+			tx = await AddressResolver.importAddresses(
 				[toBytes32('ext:AggregatorDebtRatio')],
 				[aggregator.address]
 			);
-			await Issuer.connect(owner).rebuildCache();
+			await tx.wait();
+
+			tx = await Issuer.connect(owner).rebuildCache();
+			await tx.wait();
 		});
 
 		before('ensure the user has enough SNX', async () => {

--- a/test/integration/behaviors/stake.behavior.js
+++ b/test/integration/behaviors/stake.behavior.js
@@ -1,6 +1,6 @@
 const ethers = require('ethers');
 const { toBytes32 } = require('../../../index');
-const { assert } = require('../../contracts/common');
+const { assert, addSnapshotBeforeRestoreAfter } = require('../../contracts/common');
 const { ensureBalance } = require('../utils/balances');
 const { skipMinimumStakeTime } = require('../utils/skip');
 const { createMockAggregatorFactory } = require('../../utils/index')();
@@ -14,6 +14,8 @@ function itCanStake({ ctx }) {
 		let user, owner;
 		let AddressResolver, Synthetix, SynthetixDebtShare, SynthsUSD, Issuer;
 		let balancesUSD, debtsUSD;
+
+		addSnapshotBeforeRestoreAfter();
 
 		before('target contracts and users', () => {
 			({ AddressResolver, Synthetix, SynthetixDebtShare, SynthsUSD, Issuer } = ctx.contracts);

--- a/test/integration/dual/debtMigration.integration.js
+++ b/test/integration/dual/debtMigration.integration.js
@@ -43,23 +43,31 @@ describe('migrateDebt() integration tests (L1, L2)', () => {
 	});
 
 	before('ensure the migrators are connected', async () => {
+		let tx;
+
 		// Configure L1.
 		({ AddressResolver } = ctx.l1.contracts);
 		AddressResolver = AddressResolver.connect(owner);
-		await AddressResolver.importAddresses(
+		tx = await AddressResolver.importAddresses(
 			[toBytes32('ovm:DebtMigratorOnOptimism')],
 			[DebtMigratorOnOptimism.address]
 		);
-		await DebtMigratorOnEthereum.connect(owner).rebuildCache();
+		await tx.wait();
+
+		tx = await DebtMigratorOnEthereum.connect(owner).rebuildCache();
+		await tx.wait();
 
 		// Configure L2.
 		({ AddressResolver } = ctx.l2.contracts);
 		AddressResolver = AddressResolver.connect(ctx.l2.users.owner);
-		await AddressResolver.importAddresses(
+		tx = await AddressResolver.importAddresses(
 			[toBytes32('base:DebtMigratorOnEthereum')],
 			[DebtMigratorOnEthereum.address]
 		);
-		await DebtMigratorOnOptimism.connect(ctx.l2.users.owner).rebuildCache();
+		await tx.wait();
+
+		tx = await DebtMigratorOnOptimism.connect(ctx.l2.users.owner).rebuildCache();
+		await tx.wait();
 	});
 
 	before('ensure the user has enough SNX', async () => {

--- a/test/integration/dual/debtMigration.integration.js
+++ b/test/integration/dual/debtMigration.integration.js
@@ -2,7 +2,7 @@ const ethers = require('ethers');
 const { toBytes32 } = require('../../../index');
 const { appendEscrows, retrieveEscrowParameters } = require('../utils/escrow');
 const { approveIfNeeded } = require('../utils/approve');
-const { assert } = require('../../contracts/common');
+const { assert, addSnapshotBeforeRestoreAfter } = require('../../contracts/common');
 const { bootstrapDual } = require('../utils/bootstrap');
 const { ensureBalance } = require('../utils/balances');
 const { finalizationOnL2 } = require('../utils/optimism');
@@ -11,6 +11,7 @@ describe('migrateDebt() integration tests (L1, L2)', () => {
 	const ctx = this;
 	bootstrapDual({ ctx });
 
+	let tx;
 	let owner, user;
 	let AddressResolver,
 		DebtMigratorOnEthereum,
@@ -35,6 +36,8 @@ describe('migrateDebt() integration tests (L1, L2)', () => {
 	const SNXAmount = ethers.utils.parseEther('1000');
 	const amountToIssue = ethers.utils.parseEther('100');
 
+	addSnapshotBeforeRestoreAfter();
+
 	before('target contracts and users', () => {
 		({ DebtMigratorOnEthereum, RewardEscrowV2, Synthetix, SynthetixDebtShare } = ctx.l1.contracts);
 		({ DebtMigratorOnOptimism } = ctx.l2.contracts);
@@ -42,9 +45,7 @@ describe('migrateDebt() integration tests (L1, L2)', () => {
 		owner = ctx.l1.users.owner;
 	});
 
-	before('ensure the migrators are connected', async () => {
-		let tx;
-
+	before('ensure the migrator is connected on L1', async () => {
 		// Configure L1.
 		({ AddressResolver } = ctx.l1.contracts);
 		AddressResolver = AddressResolver.connect(owner);
@@ -56,7 +57,9 @@ describe('migrateDebt() integration tests (L1, L2)', () => {
 
 		tx = await DebtMigratorOnEthereum.connect(owner).rebuildCache();
 		await tx.wait();
+	});
 
+	before('ensure the migrator is connected on L2', async () => {
 		// Configure L2.
 		({ AddressResolver } = ctx.l2.contracts);
 		AddressResolver = AddressResolver.connect(ctx.l2.users.owner);

--- a/test/publish/.gitignore
+++ b/test/publish/.gitignore
@@ -1,1 +1,0 @@
-test.log


### PR DESCRIPTION
*~~Bumped `foundry_locked_commit` to `1d9a34e` to fix anvil timeout~~
* Added empty `test.log` file to test/publish to fix file not found error in job-test-deploy
  * `tail: cannot open 'test/publish/test.log' for reading: No such file or directory`
* Fix flaky `NOUNCE_EXPIRED` ethersjs errors in dual integration tests by adding snapshot before / restore after
  * (https://github.com/ethers-io/ethers.js/issues/435)