### PR TITLE
[DRAFT] Split up migrated escrow amount over one year

### DIFF
--- a/contracts/DebtMigratorOnEthereum.sol
+++ b/contracts/DebtMigratorOnEthereum.sol
@@ -25,7 +25,6 @@ contract DebtMigratorOnEthereum is BaseDebtMigrator {
     }
 
     bool public initiationActive;
-    uint public minimumEscrowDuration = 26 weeks;
 
     /* ========== CONSTRUCTOR ========== */
 
@@ -126,15 +125,6 @@ contract DebtMigratorOnEthereum is BaseDebtMigrator {
         bytes memory _debtPayload =
             abi.encodeWithSelector(issuer.modifyDebtSharesForMigration.selector, _account, totalDebtShares);
 
-        IRewardEscrowV2 rewardEscrow;
-        bytes memory _escrowPayload =
-            abi.encodeWithSelector(
-                rewardEscrow.createEscrowEntry.selector,
-                _account,
-                totalEscrowRevoked,
-                minimumEscrowDuration
-            );
-
         // Send a message with the debt & escrow payloads to L2 to finalize the migration
         IDebtMigrator debtMigratorOnOptimism;
         bytes memory messageData =
@@ -144,8 +134,7 @@ contract DebtMigratorOnEthereum is BaseDebtMigrator {
                 totalDebtShares,
                 totalEscrowRevoked,
                 totalLiquidBalance,
-                _debtPayload,
-                _escrowPayload
+                _debtPayload
             );
         _messenger().sendMessage(_debtMigratorOnOptimism(), messageData, _getCrossDomainGasLimit(0)); // passing zero will use the system setting default
 
@@ -153,12 +142,6 @@ contract DebtMigratorOnEthereum is BaseDebtMigrator {
     }
 
     /* ========= RESTRICTED ========= */
-
-    function setMinimumEscrowDuration(uint _duration) public onlyOwner {
-        require(_duration > 0, "Must be greater than zero");
-        minimumEscrowDuration = _duration;
-        emit MinimumEscrowDurationUpdated(minimumEscrowDuration);
-    }
 
     function suspendInitiation() external onlyOwner {
         require(initiationActive, "Initiation suspended");
@@ -180,8 +163,6 @@ contract DebtMigratorOnEthereum is BaseDebtMigrator {
     }
 
     /* ========== EVENTS ========== */
-
-    event MinimumEscrowDurationUpdated(uint duration);
 
     event InitiationSuspended();
 

--- a/contracts/interfaces/IDebtMigrator.sol
+++ b/contracts/interfaces/IDebtMigrator.sol
@@ -7,7 +7,6 @@ interface IDebtMigrator {
         uint debtSharesMigrated,
         uint escrowMigrated,
         uint liquidSnxMigrated,
-        bytes calldata debtPayload,
-        bytes calldata escrowPayload
+        bytes calldata debtPayload
     ) external;
 }

--- a/test/contracts/DebtMigratorOnEthereum.js
+++ b/test/contracts/DebtMigratorOnEthereum.js
@@ -6,8 +6,6 @@ const { toUnit } = require('../utils')();
 const { toBytes32 } = require('../..');
 
 contract('DebtMigratorOnEthereum', accounts => {
-	const oneWeek = 60 * 60 * 24 * 7;
-	const MINIMUM_ESCROW_DURATION = oneWeek * 26;
 	const [sUSD] = ['sUSD'].map(toBytes32);
 	const owner = accounts[1];
 	const user = accounts[2];
@@ -44,12 +42,7 @@ contract('DebtMigratorOnEthereum', accounts => {
 		ensureOnlyExpectedMutativeFunctions({
 			abi: debtMigratorOnEthereum.abi,
 			ignoreParents: ['Owned', 'MixinResolver'],
-			expected: [
-				'migrateDebt',
-				'setMinimumEscrowDuration',
-				'resumeInitiation',
-				'suspendInitiation',
-			],
+			expected: ['migrateDebt', 'resumeInitiation', 'suspendInitiation'],
 		});
 	});
 
@@ -66,36 +59,6 @@ contract('DebtMigratorOnEthereum', accounts => {
 
 		it('initiation is not active by default', async () => {
 			assert.equal(await debtMigratorOnEthereum.initiationActive(), false);
-		});
-
-		it('minimum escrow duration is set to its default', async () => {
-			const minimumEscrowDuration = await debtMigratorOnEthereum.minimumEscrowDuration();
-			assert.bnEqual(minimumEscrowDuration, MINIMUM_ESCROW_DURATION);
-		});
-	});
-
-	describe('setMinimumEscrowDuration', async () => {
-		describe('revert condtions', async () => {
-			it('should fail if not called by the owner', async () => {
-				await assert.revert(
-					debtMigratorOnEthereum.setMinimumEscrowDuration(toUnit(1), { from: user }),
-					'Only the contract owner may perform this action'
-				);
-			});
-			it('should fail if the minimum is 0', async () => {
-				await assert.revert(
-					debtMigratorOnEthereum.setMinimumEscrowDuration(toUnit(0), { from: owner }),
-					'Must be greater than zero'
-				);
-			});
-		});
-		describe('when it succeeds', async () => {
-			beforeEach(async () => {
-				await debtMigratorOnEthereum.setMinimumEscrowDuration(toUnit(2), { from: owner });
-			});
-			it('should update the minimum escrow duration', async () => {
-				assert.bnEqual(await debtMigratorOnEthereum.minimumEscrowDuration(), toUnit(2));
-			});
 		});
 	});
 

--- a/test/contracts/DebtMigratorOnOptimism.js
+++ b/test/contracts/DebtMigratorOnOptimism.js
@@ -3,7 +3,7 @@ const { ensureOnlyExpectedMutativeFunctions } = require('./helpers');
 const { assert } = require('./common');
 const { setupAllContracts } = require('./setup');
 const { toBytes32 } = require('../..');
-const { toUnit } = require('../utils')();
+const { divideDecimal, toUnit } = require('../utils')();
 const { smock } = require('@defi-wonderland/smock');
 
 contract('DebtMigratorOnOptimism', accounts => {
@@ -12,7 +12,6 @@ contract('DebtMigratorOnOptimism', accounts => {
 	const mockMessenger = accounts[3];
 	const mockL1Migrator = accounts[4];
 	const mockedPayloadData = '0xdeadbeef';
-	const oneWeek = 604800;
 
 	let debtMigratorOnOptimism,
 		flexibleStorage,
@@ -97,7 +96,6 @@ contract('DebtMigratorOnOptimism', accounts => {
 						0,
 						0,
 						mockedPayloadData, // Any data
-						mockedPayloadData, // Any data
 						{ from: owner }
 					),
 					'Sender is not the messenger'
@@ -114,7 +112,6 @@ contract('DebtMigratorOnOptimism', accounts => {
 						1,
 						1,
 						mockedPayloadData, // Any data
-						mockedPayloadData, // Any data
 						{ from: mockMessenger }
 					),
 					'L1 sender is not the debt migrator'
@@ -125,7 +122,7 @@ contract('DebtMigratorOnOptimism', accounts => {
 
 	describe('when invoked by the L1 Migrator', () => {
 		let migrationFinalizedTx;
-		let expectedDebtData, expectedEscrowData;
+		let expectedDebtData;
 		let liquidSNXBalanceBefore, escrowedSNXBalanceBefore, debtShareBalanceBefore;
 		const liquidSNXAmount = toUnit('500');
 		const debtShareAmount = toUnit('100');
@@ -148,12 +145,6 @@ contract('DebtMigratorOnOptimism', accounts => {
 				fnc: 'modifyDebtSharesForMigration',
 				args: [user, debtShareAmount],
 			});
-
-			expectedEscrowData = getDataOfEncodedFncCall({
-				c: 'RewardEscrowV2',
-				fnc: 'createEscrowEntry',
-				args: [user, escrowAmount, oneWeek],
-			});
 		});
 
 		before('record balances', async () => {
@@ -169,7 +160,6 @@ contract('DebtMigratorOnOptimism', accounts => {
 				escrowAmount,
 				liquidSNXAmount,
 				expectedDebtData,
-				expectedEscrowData,
 				{ from: mockMessenger }
 			);
 		});
@@ -190,21 +180,31 @@ contract('DebtMigratorOnOptimism', accounts => {
 		});
 
 		it('updates the L2 state', async () => {
+			const variance = toUnit('100'); // account for variance in the decimal precision
+
 			// updates balances
 			const liquidSNXBalanceAfter = await synthetix.balanceOf(user);
 			const escrowedSNXBalanceAfter = await rewardEscrowV2.balanceOf(user);
 			const debtShareBalanceAfter = await synthetixDebtShare.balanceOf(user);
 			assert.bnEqual(liquidSNXBalanceAfter, liquidSNXBalanceBefore.add(liquidSNXAmount));
-			assert.bnEqual(escrowedSNXBalanceAfter, escrowedSNXBalanceBefore.add(escrowAmount));
 			assert.bnEqual(debtShareBalanceAfter, debtShareBalanceBefore.add(debtShareAmount));
+			assert.bnClose(escrowedSNXBalanceAfter, escrowedSNXBalanceBefore.add(escrowAmount), variance);
 
-			// creates a single escrow entry with the total escrow amount
-			assert.bnEqual(await rewardEscrowV2.numVestingEntries(user), 1);
+			// creates twelve escrow entries whose sum equals the total migrated escrow amount
+			assert.bnEqual(await rewardEscrowV2.numVestingEntries(user), 12);
 			assert.bnEqual(
-				(await rewardEscrowV2.getVestingSchedules(user, 0, 1))[0].escrowAmount,
-				escrowAmount
+				(await rewardEscrowV2.getVestingSchedules(user, 0, 1))[0].escrowAmount, // first entry
+				divideDecimal(escrowAmount, toUnit(12))
 			);
-			assert.bnEqual(await rewardEscrowV2.totalEscrowedAccountBalance(user), escrowAmount);
+			assert.bnEqual(
+				(await rewardEscrowV2.getVestingSchedules(user, 11, 1))[0].escrowAmount, // last (twelfth) entry
+				divideDecimal(escrowAmount, toUnit(12))
+			);
+			assert.bnClose(
+				await rewardEscrowV2.totalEscrowedAccountBalance(user),
+				escrowAmount,
+				variance
+			);
 		});
 	});
 });

--- a/test/integration/dual/debtMigration.integration.js
+++ b/test/integration/dual/debtMigration.integration.js
@@ -54,9 +54,6 @@ describe('migrateDebt() integration tests (L1, L2)', () => {
 			[DebtMigratorOnOptimism.address]
 		);
 		await tx.wait();
-
-		tx = await DebtMigratorOnEthereum.connect(owner).rebuildCache();
-		await tx.wait();
 	});
 
 	before('ensure the migrator is connected on L2', async () => {
@@ -67,6 +64,11 @@ describe('migrateDebt() integration tests (L1, L2)', () => {
 			[toBytes32('base:DebtMigratorOnEthereum')],
 			[DebtMigratorOnEthereum.address]
 		);
+		await tx.wait();
+	});
+
+	before('rebuild migrator caches', async () => {
+		tx = await DebtMigratorOnEthereum.connect(owner).rebuildCache();
 		await tx.wait();
 
 		tx = await DebtMigratorOnOptimism.connect(ctx.l2.users.owner).rebuildCache();
@@ -189,7 +191,7 @@ describe('migrateDebt() integration tests (L1, L2)', () => {
 					postParametersL2.escrowedBalance,
 					initialParametersL2.escrowedBalance.add(escrowEntriesData.totalEscrowed)
 				);
-				assert.bnEqual(postParametersL2.userNumVestingEntries, 1); // creates one entry on L2 with total escrow amount
+				assert.bnEqual(postParametersL2.userNumVestingEntries, 12); // creates twelve entries on L2 totaling the full escrow amount
 				assert.bnEqual(
 					postParametersL2.userEscrowedBalance,
 					initialParametersL2.userEscrowedBalance.add(escrowEntriesData.totalEscrowed)


### PR DESCRIPTION
RE: [SIP-237: Debt Migration](https://sips.synthetix.io/sips/sip-237/) 

For the migrated escrow amount, create twelve distinct escrow entries on L2 that vest over a year instead of packing it all into a single entry.