### PR TITLE
Fix CI-tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
             if [ -z "$NEW_CONTRACTS" ]; then
               npx hardhat test:integration:l2 --use-fork
             else
-              npx hardhat test:integration:l2 --deploy --use-sips --use-fork
+              npx hardhat test:integration:l2 --deploy --use-sips --use-fork --ignore-safety-checks
             fi;
       - store_test_results:
           path: /tmp/junit/

--- a/.circleci/src/jobs/job-fork-tests-ovm.yml
+++ b/.circleci/src/jobs/job-fork-tests-ovm.yml
@@ -18,7 +18,7 @@ steps:
         if [ -z "$NEW_CONTRACTS" ]; then
           npx hardhat test:integration:l2 --use-fork
         else
-          npx hardhat test:integration:l2 --deploy --use-sips --use-fork
+          npx hardhat test:integration:l2 --deploy --use-sips --use-fork --ignore-safety-checks
         fi;
   - store_test_results:
       path: /tmp/junit/

--- a/contracts/PerpsV2MarketBase.sol
+++ b/contracts/PerpsV2MarketBase.sol
@@ -63,6 +63,7 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
     bytes32 internal constant CONTRACT_FUTURESMARKETMANAGER = "FuturesMarketManager";
     bytes32 internal constant CONTRACT_PERPSV2MARKETSETTINGS = "PerpsV2MarketSettings";
     bytes32 internal constant CONTRACT_PERPSV2EXCHANGERATE = "PerpsV2ExchangeRate";
+    bytes32 internal constant CONTRACT_FLEXIBLESTORAGE = "FlexibleStorage";
 
     // Holds the revert message for each type of error.
     mapping(uint8 => string) internal _errorMessages;
@@ -109,20 +110,16 @@ contract PerpsV2MarketBase is Owned, MixinPerpsV2MarketSettings, IPerpsV2MarketB
 
     function resolverAddressesRequired() public view returns (bytes32[] memory addresses) {
         bytes32[] memory existingAddresses = MixinPerpsV2MarketSettings.resolverAddressesRequired();
-        bytes32[] memory newAddresses = new bytes32[](6);
+        bytes32[] memory newAddresses = new bytes32[](7);
         newAddresses[0] = CONTRACT_EXCHANGER;
         newAddresses[1] = CONTRACT_EXRATES;
         newAddresses[2] = CONTRACT_SYSTEMSTATUS;
         newAddresses[3] = CONTRACT_FUTURESMARKETMANAGER;
         newAddresses[4] = CONTRACT_PERPSV2MARKETSETTINGS;
         newAddresses[5] = CONTRACT_PERPSV2EXCHANGERATE;
-        // newAddresses[1] = CONTRACT_CIRCUIT_BREAKER;
+        newAddresses[6] = CONTRACT_FLEXIBLESTORAGE;
         addresses = combineArrays(existingAddresses, newAddresses);
     }
-
-    // function _exchangeCircuitBreaker() internal view returns (IExchangeCircuitBreaker) {
-    //     return IExchangeCircuitBreaker(requireAndGetAddress(CONTRACT_CIRCUIT_BREAKER));
-    // }
 
     function _exchangeRates() internal view returns (IExchangeRates) {
         return IExchangeRates(requireAndGetAddress(CONTRACT_EXRATES));

--- a/hardhat/tasks/task-test-integration.js
+++ b/hardhat/tasks/task-test-integration.js
@@ -19,6 +19,10 @@ task('test:integration:l1', 'run isolated layer 1 production tests')
 	.addFlag('deploy', 'Deploy an l1 instance before running the tests')
 	.addFlag('useSips', 'Use sources from SIPs directly, instead of releases')
 	.addFlag('useFork', 'Run the tests against a fork of mainnet')
+	.addFlag(
+		'ignoreSafetyChecks',
+		'Ignores some validations regarding paths, compiler versions, etc.'
+	)
 	.addOptionalParam(
 		'providerPort',
 		'The target port for the running local chain to test on',
@@ -59,6 +63,7 @@ task('test:integration:l1', 'run isolated layer 1 production tests')
 					providerUrl,
 					useFork: true,
 					useOvm,
+					ignoreSafetyChecks: taskArguments.ignoreSafetyChecks,
 				});
 			} else {
 				await deployInstance({
@@ -81,6 +86,10 @@ task('test:integration:l2', 'run isolated layer 2 production tests')
 	.addFlag('deploy', 'Deploy an l2 instance before running the tests')
 	.addFlag('useSips', 'Use sources from SIPs directly, instead of releases')
 	.addFlag('useFork', 'Run the tests against a fork of mainnet')
+	.addFlag(
+		'ignoreSafetyChecks',
+		'Ignores some validations regarding paths, compiler versions, etc.'
+	)
 	.addOptionalParam(
 		'providerPort',
 		'The target port for the running local chain to test on',
@@ -114,6 +123,7 @@ task('test:integration:l2', 'run isolated layer 2 production tests')
 					useOvm,
 					useSips: taskArguments.useSips,
 				});
+				console.log('ignoreSafetyChecks', taskArguments.ignoreSafetyChecks);
 				await deployInstance({
 					addNewSynths: true,
 					buildPath,
@@ -123,6 +133,7 @@ task('test:integration:l2', 'run isolated layer 2 production tests')
 					providerUrl,
 					useFork: true,
 					useOvm,
+					ignoreSafetyChecks: taskArguments.ignoreSafetyChecks,
 				});
 			} else {
 				await deployInstance({

--- a/hardhat/tasks/task-test-integration.js
+++ b/hardhat/tasks/task-test-integration.js
@@ -123,7 +123,6 @@ task('test:integration:l2', 'run isolated layer 2 production tests')
 					useOvm,
 					useSips: taskArguments.useSips,
 				});
-				console.log('ignoreSafetyChecks', taskArguments.ignoreSafetyChecks);
 				await deployInstance({
 					addNewSynths: true,
 					buildPath,

--- a/publish/src/command-utils/perps-v2-utils.js
+++ b/publish/src/command-utils/perps-v2-utils.js
@@ -118,16 +118,25 @@ const getStateNameAndCurrentAddress = ({ deployer, marketKey }) => {
 		name: marketProxyName,
 	});
 
-	return { name: marketProxyName, address: previousContractAddress };
+	let target;
+	if (previousContractAddress) {
+		target = deployer.getExistingContract({
+			contract: marketProxyName,
+		});
+	}
+
+	return { name: marketProxyName, address: previousContractAddress, target };
 };
 
 const deployMarketState = async ({ deployer, owner, marketKey, baseAsset }) => {
-	const { name: marketStateName, address: previousContractAddress } = getStateNameAndCurrentAddress(
-		{
-			deployer,
-			marketKey,
-		}
-	);
+	const {
+		name: marketStateName,
+		address: previousContractAddress,
+		target: previousContractTarget,
+	} = getStateNameAndCurrentAddress({
+		deployer,
+		marketKey,
+	});
 
 	const baseAssetB32 = toBytes32(baseAsset);
 	const marketKeyB32 = toBytes32(marketKey);
@@ -153,6 +162,7 @@ const deployMarketState = async ({ deployer, owner, marketKey, baseAsset }) => {
 		contract: marketStateName,
 		updated: !isSameContract,
 		previousContractAddress,
+		previousContractTarget,
 	};
 };
 

--- a/publish/src/commands/deploy/deploy-perpsv2.js
+++ b/publish/src/commands/deploy/deploy-perpsv2.js
@@ -271,7 +271,7 @@ const deployPerpsV2Markets = async ({
 			});
 
 			// if updated, enable in legacy state
-			if (deployedMarketState.updated) {
+			if (deployedMarketState.updated && deployedMarketState.previousContractTarget) {
 				await runStep({
 					contract: deployedMarketState.contract,
 					target: deployedMarketState.previousContractTarget,

--- a/publish/src/commands/deploy/deploy-perpsv2.js
+++ b/publish/src/commands/deploy/deploy-perpsv2.js
@@ -42,9 +42,12 @@ const deployPerpsV2Generics = async ({
 	console.log(gray(`\n------ DEPLOY PERPS V2 GENERICS  ------\n`));
 
 	// Get previous added markets
-	const prevFuturesMarketManager = deployer.getExistingContract({
-		contract: 'FuturesMarketManager',
-	});
+	let prevFuturesMarketManager;
+	try {
+		prevFuturesMarketManager = deployer.getExistingContract({
+			contract: 'FuturesMarketManager',
+		});
+	} catch (e) {}
 	const prevFuturesMarketManagerConfig = {};
 	if (useOvm && prevFuturesMarketManager) {
 		const proxiedMarkets = await prevFuturesMarketManager['allMarkets(bool)'](true);

--- a/publish/src/commands/deploy/deploy-perpsv2.js
+++ b/publish/src/commands/deploy/deploy-perpsv2.js
@@ -269,6 +269,16 @@ const deployPerpsV2Markets = async ({
 				write: 'linkOrInitializeState',
 				writeArg: [],
 			});
+
+			// if updated, enable in legacy state
+			if (deployedMarketState.updated) {
+				await runStep({
+					contract: deployedMarketState.contract,
+					target: deployedMarketState.previousContractTarget,
+					write: 'addAssociatedContracts',
+					writeArg: [[deployedMarketState.target.address]],
+				});
+			}
 		}
 
 		// Link/configure contracts relationships

--- a/publish/src/commands/deploy/index.js
+++ b/publish/src/commands/deploy/index.js
@@ -318,6 +318,7 @@ const deploy = async ({
 		account,
 		addressOf,
 		deployer,
+		runStep,
 		useOvm,
 	});
 

--- a/publish/src/commands/deploy/index.js
+++ b/publish/src/commands/deploy/index.js
@@ -320,6 +320,7 @@ const deploy = async ({
 		deployer,
 		runStep,
 		useOvm,
+		limitPromise,
 	});
 
 	if (includeFutures) {

--- a/test/integration/behaviors/perpsV2.behavior.js
+++ b/test/integration/behaviors/perpsV2.behavior.js
@@ -133,7 +133,7 @@ function itCanTrade({ ctx }) {
 			}
 		});
 
-		before('ensure users have sUSD', async () => {
+		before('ensure users have sUSD ', async () => {
 			await ensureBalance({ ctx, symbol: 'sUSD', user: someUser, balance: sUSDAmount });
 		});
 

--- a/test/integration/behaviors/perpsV2.behavior.js
+++ b/test/integration/behaviors/perpsV2.behavior.js
@@ -72,6 +72,8 @@ function itCanTrade({ ctx }) {
 				SynthsUSD,
 			} = ctx.contracts);
 
+			// TODO: Remove the log once not needed
+			console.log('LOG_PPPPPPP_ PerpsV2MarketHelper', PerpsV2MarketHelper);
 			owner = ctx.users.owner;
 			someUser = ctx.users.someUser;
 			otherUser = ctx.users.otherUser;

--- a/test/integration/behaviors/perpsV2.behavior.js
+++ b/test/integration/behaviors/perpsV2.behavior.js
@@ -1,6 +1,11 @@
 const ethers = require('ethers');
+const path = require('path');
+const fs = require('fs');
 const chalk = require('chalk');
 const { assert } = require('../../contracts/common');
+const {
+	constants: { COMPILED_FOLDER, BUILD_FOLDER },
+} = require('../../../');
 
 const { addAggregatorAndSetRate } = require('../utils/rates');
 const { ensureBalance } = require('../utils/balances');
@@ -14,6 +19,28 @@ const multiplyDecimal = (a, b) => a.mul(b).div(unit);
 
 const proxiedContract = (proxy, abi, user) => {
 	return new ethers.Contract(proxy.address, abi, user);
+};
+
+const deployHelper = async ({ AddressResolver, owner, args }) => {
+	const buildPath = path.join(__dirname, '..', '..', '..', BUILD_FOLDER, COMPILED_FOLDER);
+
+	const builtArtifact = JSON.parse(
+		fs.readFileSync(path.resolve(buildPath, 'TestablePerpsV2Market.json'), 'utf8')
+	);
+
+	const factory = new ethers.ContractFactory(builtArtifact.abi, builtArtifact.evm.bytecode, owner);
+
+	const deployedContract = await factory.deploy(
+		args.proxy,
+		args.marketState,
+		args.owner,
+		args.resolver
+	);
+	await deployedContract.deployTransaction.wait();
+
+	await AddressResolver.connect(owner).rebuildCaches([deployedContract.address]);
+
+	return deployedContract;
 };
 
 const unifyAbis = implementations => {
@@ -46,15 +73,17 @@ function itCanTrade({ ctx }) {
 			PerpsV2MarketETH,
 			PerpsV2MarketImplETHPERP,
 			PerpsV2MarketLiquidateETHPERP,
-			PerpsV2MarketDelayedIntentETHPERP,
-			PerpsV2MarketDelayedExecutionETHPERP,
+			PerpsV2DelayedIntentETHPERP,
+			PerpsV2DelayedExecutionETHPERP,
 			PerpsV2MarketViewsETHPERP,
+			PerpsV2MarketStateETHPERP,
 			PerpsV2ProxyETHPERP,
 			FuturesMarketBTC,
 			ExchangeRates,
+			AddressResolver,
 			SynthsUSD;
 
-		before('target contracts and users', () => {
+		before('target contracts and users', async () => {
 			({
 				FuturesMarketManager,
 				FuturesMarketSettings,
@@ -63,27 +92,41 @@ function itCanTrade({ ctx }) {
 				TestablePerpsV2MarketETH: PerpsV2MarketHelper,
 				PerpsV2MarketETHPERP: PerpsV2MarketImplETHPERP,
 				PerpsV2MarketLiquidateETHPERP,
-				PerpsV2MarketDelayedIntentETHPERP,
-				PerpsV2MarketDelayedExecutionETHPERP,
+				PerpsV2DelayedIntentETHPERP,
+				PerpsV2DelayedExecutionETHPERP,
 				PerpsV2MarketViewsETHPERP,
+				PerpsV2MarketStateETHPERP,
 				PerpsV2ProxyETHPERP,
 				FuturesMarketBTC,
 				ExchangeRates,
+				AddressResolver,
 				SynthsUSD,
 			} = ctx.contracts);
 
-			// TODO: Remove the log once not needed
-			console.log('LOG_PPPPPPP_ PerpsV2MarketHelper', PerpsV2MarketHelper);
 			owner = ctx.users.owner;
 			someUser = ctx.users.someUser;
 			otherUser = ctx.users.otherUser;
+
+			if (!PerpsV2MarketHelper) {
+				// Deploy it
+				PerpsV2MarketHelper = await deployHelper({
+					AddressResolver,
+					owner,
+					args: {
+						proxy: PerpsV2ProxyETHPERP.address,
+						marketState: PerpsV2MarketStateETHPERP.address,
+						owner: owner.address,
+						resolver: AddressResolver.address,
+					},
+				});
+			}
 
 			const unifiedAbis = unifyAbis([
 				PerpsV2MarketImplETHPERP,
 				PerpsV2MarketViewsETHPERP,
 				PerpsV2MarketLiquidateETHPERP,
-				PerpsV2MarketDelayedIntentETHPERP,
-				PerpsV2MarketDelayedExecutionETHPERP,
+				PerpsV2DelayedIntentETHPERP,
+				PerpsV2DelayedExecutionETHPERP,
 			]);
 			if (unifiedAbis && PerpsV2ProxyETHPERP) {
 				PerpsV2MarketETH = proxiedContract(PerpsV2ProxyETHPERP, unifiedAbis, someUser);
@@ -192,7 +235,7 @@ function itCanTrade({ ctx }) {
 					if (skipTest) {
 						return;
 					}
-					const size = multiplyDecimal(posSize1x, toUnit('-5'));
+					const size = multiplyDecimal(posSize1x, toUnit('-2'));
 
 					const desiredFillPrice1 = (
 						await PerpsV2MarketHelper.fillPriceWithMeta(size, priceImpactDelta, 0)

--- a/test/integration/behaviors/perpsV2.behavior.js
+++ b/test/integration/behaviors/perpsV2.behavior.js
@@ -246,7 +246,11 @@ function itCanTrade({ ctx }) {
 
 					// close
 					const desiredFillPrice2 = (
-						await PerpsV2MarketHelper.fillPriceWithMeta(size, priceImpactDelta, 0)
+						await PerpsV2MarketHelper.fillPriceWithMeta(
+							multiplyDecimal(size, toUnit('-1')),
+							priceImpactDelta,
+							0
+						)
 					)[1];
 					await market.closePosition(desiredFillPrice2);
 				});

--- a/test/integration/utils/deploy.js
+++ b/test/integration/utils/deploy.js
@@ -36,6 +36,7 @@ async function deployInstance({
 	skipFeedChecks = true,
 	useFork = false,
 	useOvm,
+	ignoreSafetyChecks = false,
 }) {
 	const privateKey = network === 'local' ? getLocalPrivateKey({ index: 0 }) : undefined;
 
@@ -56,6 +57,8 @@ async function deployInstance({
 		yes: true,
 		includeFutures: true,
 		includePerpsV2: true,
+		runPerpsV2Cleanup: true,
+		ignoreSafetyChecks,
 	});
 }
 


### PR DESCRIPTION
This PR fixes some CI tests. In order to do that it:
- propagates the `ignoreSafetyChecks` flag required by this deployment to the tests
- adds a missing address requirement (.sol minor change)
- rebuild caches for generic perpsV2 contracts once they are deployed 
- re-adds previous markets when `FuturesMarketManager` is updated (since the markets will be replaced asynchronous) (deployment fix on the fly)
- links the new state to the previous one by authorizing the new one as `associatedContract` 
