### PR TITLE
Naos v2.84.4 post release sources update

### DIFF
--- a/publish/releases.json
+++ b/publish/releases.json
@@ -656,8 +656,8 @@
 			"sip": 237,
 			"layer": "both",
 			"sources": {
-				"base": ["Issuer", "Synthetix"],
-				"ovm": ["Issuer", "Synthetix"]
+				"base": ["Issuer", "Synthetix", "DebtMigratorOnEthereum"],
+				"ovm": ["Issuer", "Synthetix", "DebtMigratorOnOptimism"]
 			},
 			"released": "both"
 		},


### PR DESCRIPTION
* Adds missing debt migrator sources to the 237 entry in `releases.json`