### PR TITLE
Add route information in migration contract

### DIFF
--- a/publish/src/command-utils/perps-v2-utils.js
+++ b/publish/src/command-utils/perps-v2-utils.js
@@ -13,7 +13,7 @@ const excludedFunctions = [
 	'resolver',
 	'resolverAddressesRequired',
 	'rebuildCache',
-	'isResolvedCache',
+	'isResolverCached',
 	// ProxyPerpsV2
 	'addRoute',
 	'removeRoute',
@@ -21,6 +21,11 @@ const excludedFunctions = [
 	'getRoutesLength',
 	'getRoutesPage',
 	'getAllTargets',
+	// Proxyable
+	'messageSender',
+	'setMessageSender',
+	'proxy',
+	'setProxy',
 	// PerpsV2MarketBase
 	'marketState',
 ];

--- a/publish/src/command-utils/perps-v2-utils.js
+++ b/publish/src/command-utils/perps-v2-utils.js
@@ -48,10 +48,11 @@ const implementationConfigurations = [
 	},
 ];
 
-const getFunctionSignatures = (instance, excludedFunctions) => {
+const getFunctionSignatures = (instance, excludedFunctions, contractName = '') => {
 	const contractInterface = instance.abi
 		? new ethers.utils.Interface(instance.abi)
 		: instance.interface;
+
 	const signatures = [];
 	const funcNames = Object.keys(contractInterface.functions);
 	for (const funcName of funcNames) {
@@ -61,6 +62,7 @@ const getFunctionSignatures = (instance, excludedFunctions) => {
 			stateMutability: contractInterface.functions[funcName].stateMutability,
 			isView: contractInterface.functions[funcName].stateMutability === 'view',
 			contractAddress: instance.address,
+			contractName,
 		};
 		signatures.push(signature);
 	}
@@ -223,7 +225,7 @@ const deployMarketImplementations = async ({
 			updateState: !implementation.isView,
 			useExchangeRate: implementation.useExchangeRate,
 			updated: !isSameContract,
-			functionSignatures: getFunctionSignatures(newContract, excludedFunctions),
+			functionSignatures: getFunctionSignatures(newContract, excludedFunctions, name),
 		});
 	}
 
@@ -375,6 +377,7 @@ const linkToProxy = async ({ runStep, perpsV2MarketProxy, implementations }) => 
 				readResult.isView === f.isView,
 			write: 'addRoute',
 			writeArg: [f.signature, f.contractAddress, f.isView],
+			comment: `Add route to ${f.contractName}.${f.functionName}`,
 		});
 	}
 };

--- a/test/contracts/setup.js
+++ b/test/contracts/setup.js
@@ -133,7 +133,7 @@ const excludedFunctions = [
 	'resolver',
 	'resolverAddressesRequired',
 	'rebuildCache',
-	'isResolvedCache',
+	'isResolverCached',
 	// ProxyPerpsV2
 	'addRoute',
 	'removeRoute',
@@ -141,6 +141,11 @@ const excludedFunctions = [
 	'getRoutesLength',
 	'getRoutesPage',
 	'getAllTargets',
+	// Proxyable
+	'messageSender',
+	'setMessageSender',
+	'proxy',
+	'setProxy',
 	// PerpsV2MarketBase
 	'marketState',
 ];


### PR DESCRIPTION
Improve PerpsV2 deployment script by adding a comment in the migration contract with target information (`Add route contract.function`)

i.e.
```
        // Add route to PerpsV2MarketBNBPERP.closePosition;
        perpsv2proxybnbperp_i.addRoute(0xa126d601, 0xc7dCC0929881530d3386de51D9ffdD35B8009c6E, false);
        // Add route to PerpsV2MarketBNBPERP.closePositionWithTracking;
        perpsv2proxybnbperp_i.addRoute(0x5c8011c3, 0xc7dCC0929881530d3386de51D9ffdD35B8009c6E, false);
```