### PR TITLE
SCCP-2032 / SIP-2030 Update

### DIFF
--- a/publish/deployed/goerli-ovm/perpsv2-markets.json
+++ b/publish/deployed/goerli-ovm/perpsv2-markets.json
@@ -1416,7 +1416,7 @@
 		"offchainDelayedOrderMaxAge": "60",
 		"maxLeverage": "27.5",
 		"maxMarketValue": "650000",
-		"maxFundingVelocity": "27",
+		"maxFundingVelocity": "36",
 		"skewScale": "13000000",
 		"offchainPriceDivergence": "0.10",
 		"liquidationPremiumMultiplier": "3",
@@ -1452,7 +1452,7 @@
 		"liquidationBufferRatio": "0.0075",
 		"maxPD": "0.00030",
 		"maxLiquidationDelta": "0.00015",
-		"paused": true,
-		"offchainPaused": true
+		"paused": false,
+		"offchainPaused": false
 	}
 ]

--- a/publish/deployed/mainnet-ovm/perpsv2-markets.json
+++ b/publish/deployed/mainnet-ovm/perpsv2-markets.json
@@ -1416,7 +1416,7 @@
 		"offchainDelayedOrderMaxAge": "60",
 		"maxLeverage": "27.5",
 		"maxMarketValue": "650000",
-		"maxFundingVelocity": "27",
+		"maxFundingVelocity": "36",
 		"skewScale": "13000000",
 		"offchainPriceDivergence": "0.10",
 		"liquidationPremiumMultiplier": "3",
@@ -1452,7 +1452,7 @@
 		"liquidationBufferRatio": "0.0075",
 		"maxPD": "0.00030",
 		"maxLiquidationDelta": "0.00015",
-		"paused": true,
-		"offchainPaused": true
+		"paused": false,
+		"offchainPaused": false
 	}
 ]


### PR DESCRIPTION
- As per SCCP-2032 WLD should have a maxFundingVelocity of 36
- As per SIP-2030 USDT should be unpaused