### PR TITLE
SIP-2036 fix reward distributor to bubble failures

### DIFF
--- a/contracts/RewardsDistribution.sol
+++ b/contracts/RewardsDistribution.sol
@@ -166,10 +166,11 @@ contract RewardsDistribution is Owned, IRewardsDistribution {
                 bytes memory payload = abi.encodeWithSignature("notifyRewardAmount(uint256)", distributions[i].amount);
 
                 // solhint-disable avoid-low-level-calls
-                (bool success, bytes result) = distributions[i].destination.call(payload);
+                (bool success, bytes memory result) = distributions[i].destination.call(payload);
 
                 if (!success) {
                     // if the error was emitted by the destination contract, bubble
+                    uint len = result.length;
                     assembly {
                         revert(add(result, 0x20), len)
                     }

--- a/contracts/RewardsDistribution.sol
+++ b/contracts/RewardsDistribution.sol
@@ -156,7 +156,7 @@ contract RewardsDistribution is Owned, IRewardsDistribution {
 
         // Iterate the array of distributions sending the configured amounts
         for (uint i = 0; i < distributions.length; i++) {
-            if (distributions[i].destination != address(0) || distributions[i].amount != 0) {
+            if (distributions[i].destination != address(0) && distributions[i].amount != 0) {
                 remainder = remainder.sub(distributions[i].amount);
 
                 // Transfer the SNX

--- a/contracts/RewardsDistribution.sol
+++ b/contracts/RewardsDistribution.sol
@@ -166,10 +166,13 @@ contract RewardsDistribution is Owned, IRewardsDistribution {
                 bytes memory payload = abi.encodeWithSignature("notifyRewardAmount(uint256)", distributions[i].amount);
 
                 // solhint-disable avoid-low-level-calls
-                (bool success, ) = distributions[i].destination.call(payload);
+                (bool success, bytes result) = distributions[i].destination.call(payload);
 
                 if (!success) {
-                    // Note: we're ignoring the return value as it will fail for contracts that do not implement RewardsDistributionRecipient.sol
+                    // if the error was emitted by the destination contract, bubble
+                    assembly {
+                        revert(add(result, 0x20), len)
+                    }
                 }
             }
         }

--- a/contracts/TradingRewards.sol
+++ b/contracts/TradingRewards.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.5.16;
 import "./Pausable.sol";
 import "./MixinResolver.sol";
 import "./Owned.sol";
+import "./RewardsDistributionRecipient.sol";
 
 // External dependencies.
 import "openzeppelin-solidity-2.3.0/contracts/token/ERC20/SafeERC20.sol";
@@ -17,7 +18,7 @@ import "./interfaces/ITradingRewards.sol";
 import "./interfaces/IExchanger.sol";
 
 // https://docs.synthetix.io/contracts/source/contracts/tradingrewards
-contract TradingRewards is ITradingRewards, ReentrancyGuard, Owned, Pausable, MixinResolver {
+contract TradingRewards is ITradingRewards, ReentrancyGuard, Owned, Pausable, MixinResolver, RewardsDistributionRecipient {
     using SafeMath for uint;
     using SafeDecimalMath for uint;
     using SafeERC20 for IERC20;
@@ -255,6 +256,8 @@ contract TradingRewards is ITradingRewards, ReentrancyGuard, Owned, Pausable, Mi
 
         emit AssignedRewardTokensRecovered(recoverAddress, amount, periodID);
     }
+
+    function notifyRewardAmount(uint256 reward) external {}
 
     function _validateRecoverAddress(address recoverAddress) internal view {
         if (recoverAddress == address(0) || recoverAddress == address(this)) {


### PR DESCRIPTION
in the simplest possible way, fix a bug which prevents reward distribution from getting sent to L2 due to internal OOG gas logic in optimism contract (normally if you are OOG then the remaining code in RewardsDistribution would also fail, but optimism deliberately consumes an excessive amount of gas in a way that causes only the internal call to fail)

in accordance with [SIP-2036](https://sips.synthetix.io/sips/sip-2036/)

note: if you are wondering why I didnt just call the rewards distribution receiver contract normally and continue to be using hte low level call, the reason is im trying to keep changes to a minimal and this change basically ended up being a 1 line changes.