### PR TITLE
typo fix Depot.sol

### DIFF
--- a/contracts/Depot.sol
+++ b/contracts/Depot.sol
@@ -443,7 +443,7 @@ contract Depot is Owned, Pausable, ReentrancyGuard, MixinResolver, IDepot {
         // gas for fullfilling multiple small synth deposits
         if (amount < minimumDepositAmount) {
             // We cant fail/revert the transaction or send the synths back in a reentrant call.
-            // So we will keep your synths balance seperate from the FIFO queue so you can withdraw them
+            // So we will keep your synths balance separate from the FIFO queue so you can withdraw them
             smallDeposits[msg.sender] = smallDeposits[msg.sender].add(amount);
 
             emit SynthDepositNotAccepted(msg.sender, amount, minimumDepositAmount);


### PR DESCRIPTION
## Typo Fix in `Depot.sol`

This pull request fixes a typo in the `Depot.sol` contract. The word **"seperate"** has been corrected to **"separate"**.

### Changes:
- Fixed the typo **"seperate"** to **"separate"** in the `Depot.sol` contract.

### Checklist:
- [x] Corrected the typo.
- [x] Changes have been reviewed and tested.
